### PR TITLE
chore(flake/home-manager): `296ddc64` -> `63e77d09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742588233,
-        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
+        "lastModified": 1742670145,
+        "narHash": "sha256-xQ2F9f+ICAGBp/nNv3ddD2U4ZvzuLOci0u/5lyMXPvk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
+        "rev": "63e77d09a133ac641a0c204e7cfb0c97e133706d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`63e77d09`](https://github.com/nix-community/home-manager/commit/63e77d09a133ac641a0c204e7cfb0c97e133706d) | `` jankyborders: add module (#6677) ``                     |
| [`94ea2cb5`](https://github.com/nix-community/home-manager/commit/94ea2cb536fa083665e12d08515d97313e0900f1) | `` treewide: zsh initExtraBeforeCompInit -> initContent `` |
| [`10deb9d0`](https://github.com/nix-community/home-manager/commit/10deb9d043e625d8c6a629f5575718e0768dcfb4) | `` treewide: zsh initExtra -> initContent ``               |