### PR TITLE
chore(flake/nix-index-database): `2cfb4e1c` -> `36dc43cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742174123,
-        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
+        "lastModified": 1742701275,
+        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
+        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`36dc43cb`](https://github.com/nix-community/nix-index-database/commit/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6) | `` update generated.nix to release 2025-03-23-032447 `` |
| [`2085ed4d`](https://github.com/nix-community/nix-index-database/commit/2085ed4d8a2268f918aa1b7316912cd92646b7bd) | `` flake.lock: Update ``                                |