### PR TITLE
chore(flake/home-manager): `9172a6f9` -> `5ff90f09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742701794,
-        "narHash": "sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw=",
+        "lastModified": 1742744903,
+        "narHash": "sha256-qd2uiGol/kb9Dk0vgOOLBl9VsycG0VfteM78OduFl2Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9172a6f956f7e0f7810861b9b1146f1c43d9abcb",
+        "rev": "5ff90f09d1bd189b722e60798513724cdd3580b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`5ff90f09`](https://github.com/nix-community/home-manager/commit/5ff90f09d1bd189b722e60798513724cdd3580b6) | `` wofi: merge multiple style definitions (#6673) `` |
| [`b61ae3b6`](https://github.com/nix-community/home-manager/commit/b61ae3b677a07c30cf6be5233e772b97a3a8b2fb) | `` flake.lock: Update (#6684) ``                     |
| [`57e9a8a2`](https://github.com/nix-community/home-manager/commit/57e9a8a290cbeeb173b12d6bec1681e177ce6570) | `` davmail: init module (#6674) ``                   |