### PR TITLE
chore(flake/home-manager): `0e75a404` -> `ad0614a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742756669,
-        "narHash": "sha256-55QHo/lETkGO4lUfxhJ6TUs5OLOz5Ks7JDNAKDzpt4I=",
+        "lastModified": 1742771635,
+        "narHash": "sha256-HQHzQPrg+g22tb3/K/4tgJjPzM+/5jbaujCZd8s2Mls=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e75a40458d065d1e5c6a10d0b74b9e35b550ae6",
+        "rev": "ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ad0614a1`](https://github.com/nix-community/home-manager/commit/ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818) | `` firefox: don't show migration warning when bookmarks isn't set (#6689) `` |
| [`4f453846`](https://github.com/nix-community/home-manager/commit/4f4538467fd29a8f5037c0939592cd89cd401155) | `` firefox: fix migrate search v7 test for all firefox forks (#6690) ``      |