### PR TITLE
chore(flake/lovesegfault-vim-config): `60b47d7e` -> `ad582692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742688495,
-        "narHash": "sha256-m8+2pXiWzealVcUlCxfftDcz7bqEk5mGVQxA1h0UdA4=",
+        "lastModified": 1742774955,
+        "narHash": "sha256-TKEgJIBxTJVPfE8ipmmevXfgIFsj6aMzqq1fxc2zXQw=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "60b47d7eeb7109ca2fd2ee33fe42866490cb72d0",
+        "rev": "ad5826921d2f6adc4efd714331c51a9c426282ca",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742645604,
-        "narHash": "sha256-4LB/Gx1p/ml79xZfgTvOYvMXXnj5vrFfDYcWIndgXP0=",
+        "lastModified": 1742732006,
+        "narHash": "sha256-ZIBMfPNb/hfoFf79MRnhDXGKl0yGhjlYEpy3+/jbxFI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3d84c137eab329ec1a6d4c4b0a067bfa8eea0bb5",
+        "rev": "7776e37b67e7875c3cd56d9d20fd050798071706",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ad582692`](https://github.com/lovesegfault/vim-config/commit/ad5826921d2f6adc4efd714331c51a9c426282ca) | `` chore(flake/nixpkgs): a84ebe20 -> 1e5b653d `` |
| [`d1f1076a`](https://github.com/lovesegfault/vim-config/commit/d1f1076ad1ac3d3800a3124a099c2af61d7410e7) | `` chore(flake/nixvim): 3d84c137 -> 7776e37b ``  |