### PR TITLE
chore(flake/home-manager): `908e055e` -> `2d057cd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742825959,
-        "narHash": "sha256-wgnQZMrLLQJlZ+htTXzoQtoz9EzL15Z2crH3+OnRmMk=",
+        "lastModified": 1742842119,
+        "narHash": "sha256-YnJ1MHMLMDcWW4sRQya7IfXdJQAqW5y+lkL/WIvefc8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "908e055e157a0b35466faf4125d7e7410ff56160",
+        "rev": "2d057cd9d4f767737498e0aae75b07353c75bdee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`2d057cd9`](https://github.com/nix-community/home-manager/commit/2d057cd9d4f767737498e0aae75b07353c75bdee) | `` zellij: use mkPackageOption ``                                |
| [`a9042b53`](https://github.com/nix-community/home-manager/commit/a9042b53c2be62487c33ec296a27623989320e2a) | `` zellij: default integration disabled again ``                 |
| [`82a32114`](https://github.com/nix-community/home-manager/commit/82a32114771cb3d7f392c48d679a7f66c064dd46) | `` zellij: add khaneliman maintainer ``                          |
| [`10dca990`](https://github.com/nix-community/home-manager/commit/10dca990ae02aaf41ff12c5b18dd3dcf258c0d04) | `` zellij: remove with lib ``                                    |
| [`6d4148df`](https://github.com/nix-community/home-manager/commit/6d4148df8e531b264c87ad86a151a4ea3047a1b5) | `` zellij: refactor implementation ``                            |
| [`0394c71f`](https://github.com/nix-community/home-manager/commit/0394c71f2bc00be1e8e76d2931549721c710904c) | `` zellij: Add additional options for integrating with shells `` |