### PR TITLE
chore(flake/stylix): `61a5f77f` -> `daef51e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742926290,
-        "narHash": "sha256-63joFDrDekkI8papsDPwObKCCYSZ7t/1t94M398BxLY=",
+        "lastModified": 1742997483,
+        "narHash": "sha256-eDN1TAIj57ZTR8jsl63tdOdGebRdL7xE6Om0r0LZd5s=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "61a5f77f2202f3a79797089752713e16b1ab5b10",
+        "rev": "daef51e92086a5b4d6a7756ad495dfd34353b7cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                  |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`daef51e9`](https://github.com/danth/stylix/commit/daef51e92086a5b4d6a7756ad495dfd34353b7cb) | `` doc: format and polish Nix code according to our formatter (#1025) `` |