### PR TITLE
chore(flake/treefmt-nix): `61c88349` -> `29a3d7b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742982148,
-        "narHash": "sha256-aRA6LSxjlbMI6MmMzi/M5WH/ynd8pK+vACD9za3MKLQ=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "61c88349bf6dff49fa52d7dfc39b21026c2a8881",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`29a3d7b7`](https://github.com/numtide/treefmt-nix/commit/29a3d7b768c70addce17af0869f6e2bd8f5be4b7) | `` Merge pull request #325 from xsteadfastx/adds-sql-formatter `` |