### PR TITLE
chore(flake/darwin): `bb81755a` -> `75f8e4db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742869675,
-        "narHash": "sha256-rgwUZJZVztaNYPTsf6MIqirPL5r2JTMMyHuzk1ezyYk=",
+        "lastModified": 1743125241,
+        "narHash": "sha256-TA/xYqZbBwCCprXf8ABORDsjJy0Idw6OdQNqYQhgKCM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "bb81755a3674951724d79b8cba6bbff01409d44d",
+        "rev": "75f8e4dbc553d3052f917e66ee874f69d49c9981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`ce5a3b9d`](https://github.com/nix-darwin/nix-darwin/commit/ce5a3b9db91ee65f2e969442884baac64b4b41f3) | `` treewide: point to the new GitHub organization `` |
| [`000c40f4`](https://github.com/nix-darwin/nix-darwin/commit/000c40f4fe7009118aac5b02d432dcb9321c3042) | `` readme: update contact information ``             |