### PR TITLE
chore(flake/home-manager): `b14a70c4` -> `1efd2503`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743097780,
-        "narHash": "sha256-5tUbaMBKYbfTe/4aXACxmiXG22TgwPBNcfZ8Kg3rt+g=",
+        "lastModified": 1743136572,
+        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52",
+        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`1efd2503`](https://github.com/nix-community/home-manager/commit/1efd2503172016a6742c87b47b43ca2c8145607d) | `` flake.lock: Update (#6708) ``                                    |
| [`26ccff08`](https://github.com/nix-community/home-manager/commit/26ccff08df360afd888b08633a5dddbb99f04d8f) | `` thunderbird: set additional gmail smtpserver settings (#6713) `` |
| [`13d68e9a`](https://github.com/nix-community/home-manager/commit/13d68e9ac05caccc1f81ce40612a8086421e1706) | `` helix: avoid IFD (#6714) ``                                      |