### PR TITLE
chore(flake/darwin): `75f8e4db` -> `eaff8219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743125241,
-        "narHash": "sha256-TA/xYqZbBwCCprXf8ABORDsjJy0Idw6OdQNqYQhgKCM=",
+        "lastModified": 1743350051,
+        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "75f8e4dbc553d3052f917e66ee874f69d49c9981",
+        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`e7bd2f8f`](https://github.com/nix-darwin/nix-darwin/commit/e7bd2f8f2f0829149ce99142e2ad1cdce9dff155) | `` nix-tools: re‐add `nixPackage` ``             |
| [`75a7fb88`](https://github.com/nix-darwin/nix-darwin/commit/75a7fb885d0afcaa77e6c930be991aab6a6755ab) | `` website: try to fix redirect ``               |
| [`516590cf`](https://github.com/nix-darwin/nix-darwin/commit/516590cf1299aceb7f987d433e14f406f9089973) | `` website: fix manual path ``                   |
| [`2c77fdbf`](https://github.com/nix-darwin/nix-darwin/commit/2c77fdbfba643fbd201837c1dcff5fcdf340da39) | `` ci: deploy the website from GitHub Actions `` |
| [`a5af2a5b`](https://github.com/nix-darwin/nix-darwin/commit/a5af2a5b22f991987a19cee673ac9f9c09587f1f) | `` readme: use logo from GitHub attachments ``   |