### PR TITLE
chore(flake/home-manager): `1efd2503` -> `1f679ed2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743136572,
-        "narHash": "sha256-uwaVrKgi6g1TUq56247j6QvvFtYHloCkjCrEpGBvV54=",
+        "lastModified": 1743259333,
+        "narHash": "sha256-2Fi3K++co4IGbeOLGXdRA6VEfbzQzMgcuBaPTyjfj0s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1efd2503172016a6742c87b47b43ca2c8145607d",
+        "rev": "1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1f679ed2`](https://github.com/nix-community/home-manager/commit/1f679ed2a2ebe3894bad9f89fb0bd9f141c28a68) | `` zsh-abbr: Add global abbreviations (#6720) `` |
| [`3527c8c7`](https://github.com/nix-community/home-manager/commit/3527c8c7785d1855ccf9da0e8436a0e769190b18) | `` sesh: add module (#5789) ``                   |