### PR TITLE
chore(flake/stylix): `2fb8321e` -> `c546582b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743075971,
-        "narHash": "sha256-8fSI6C19ZTcHgvoLK17wfEEVI08tgnZfSLgVe3E/22w=",
+        "lastModified": 1743434236,
+        "narHash": "sha256-KH9Qdnjj9FJuktRHhK5hsQdeSPYsZfGRB7t+Q34In34=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2fb8321ea16c595e0208b22021ddaf1f471c634a",
+        "rev": "c546582bae1a2c8745295a167b8db779215d780b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`c546582b`](https://github.com/danth/stylix/commit/c546582bae1a2c8745295a167b8db779215d780b) | `` bat: add copyright notice (#1070) ``                         |
| [`eede7135`](https://github.com/danth/stylix/commit/eede71351571c60b87dbf9eefb7ddf2b11fb1354) | `` ci: prevent unintentional credential persistence (#1074) ``  |
| [`20117a58`](https://github.com/danth/stylix/commit/20117a58eb73c0ac36d1421ba9dd89392053da9a) | `` ci: run all builds in a single job (#1069) ``                |
| [`8fce9170`](https://github.com/danth/stylix/commit/8fce91704d59dbe5bf0d76b166866ed33f2359c9) | `` doc: add license check to PR template (#1072) ``             |
| [`21b90991`](https://github.com/danth/stylix/commit/21b90991afd366f7bf9d2c7fd51095c7015907eb) | `` doc: improve maintainer subheading in PR template (#1071) `` |
| [`0323253b`](https://github.com/danth/stylix/commit/0323253b3ee48ba132071fe626eddfcb5cbb8b6b) | `` mpv: init mpvScripts.modernz (#1067) ``                      |