### PR TITLE
chore(flake/home-manager): `b4314965` -> `1d2ed9c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743267068,
-        "narHash": "sha256-G7866vbO5jgqMcYJzgbxej40O6mBGQMGt6gM0himjoA=",
+        "lastModified": 1743346616,
+        "narHash": "sha256-AB/ve2el1TB7k4iyogHGCVlWVkrhp3+4FKKMr1W5iKQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b431496538b0e294fbe44a1441b24ae8195c63f0",
+        "rev": "1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`1d2ed9c5`](https://github.com/nix-community/home-manager/commit/1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41) | `` flake.lock: Update (#6730) ``                                                  |
| [`802653e5`](https://github.com/nix-community/home-manager/commit/802653e5d1f654ac67c045ca6eea8c8cfa8fc052) | `` auto-upgrade: unbreak on unattended, loginctl enable-linger systems (#6719) `` |
| [`8ce84337`](https://github.com/nix-community/home-manager/commit/8ce84337430492b984a7ddd73371773e8d19ad73) | `` granted: Add override for package (#6722) ``                                   |
| [`2760046f`](https://github.com/nix-community/home-manager/commit/2760046f34780cc72f67e06240ccf6a7a3ae3765) | `` docs: correct improper import of home.nix (#6732) ``                           |
| [`71703001`](https://github.com/nix-community/home-manager/commit/717030011980e9eb31eb8ce011261dd532bce92c) | `` podman: fix service name in generated manifest (#6710) ``                      |