### PR TITLE
chore(flake/nixos-hardware): `0ed819e7` -> `de6fc555`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1743167577,
-        "narHash": "sha256-I09SrXIO0UdyBFfh0fxDq5WnCDg8XKmZ1HQbaXzMA1k=",
+        "lastModified": 1743420942,
+        "narHash": "sha256-b/exDDQSLmENZZgbAEI3qi9yHkuXAXCPbormD8CSJXo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "0ed819e708af17bfc4bbc63ee080ef308a24aa42",
+        "rev": "de6fc5551121c59c01e2a3d45b277a6d05077bc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`de6fc555`](https://github.com/NixOS/nixos-hardware/commit/de6fc5551121c59c01e2a3d45b277a6d05077bc4) | `` added intel whiskey lake ``                      |
| [`a3f63440`](https://github.com/NixOS/nixos-hardware/commit/a3f63440fcfb280d7c9c5dd83f6cc95051867b17) | `` added lenovo thinkpad p43s ``                    |
| [`be7794e5`](https://github.com/NixOS/nixos-hardware/commit/be7794e5a66c81be581ceccaf741a97189652f95) | `` Added Lenovo Thinkpad P14s Gen 5 Intel config `` |