### PR TITLE
chore(flake/stylix): `c546582b` -> `1a2f1af9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743434236,
-        "narHash": "sha256-KH9Qdnjj9FJuktRHhK5hsQdeSPYsZfGRB7t+Q34In34=",
+        "lastModified": 1743442833,
+        "narHash": "sha256-v6PrGSxY/Rgu3JzHyFSzGUv5USLxPTUMPr/8i4zbOKs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c546582bae1a2c8745295a167b8db779215d780b",
+        "rev": "1a2f1af9f999b23c44a0b15a8841a7a297576a9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                    |
| --------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`1a2f1af9`](https://github.com/danth/stylix/commit/1a2f1af9f999b23c44a0b15a8841a7a297576a9c) | `` discord: add extraCss option (#1058) `` |
| [`eb19696b`](https://github.com/danth/stylix/commit/eb19696b18fd65ddcc6fbec5056b92b75b4f4343) | `` stylix: add overlay module (#1048) ``   |