### PR TITLE
chore(flake/stylix): `1a2f1af9` -> `581fa67c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743442833,
-        "narHash": "sha256-v6PrGSxY/Rgu3JzHyFSzGUv5USLxPTUMPr/8i4zbOKs=",
+        "lastModified": 1743775855,
+        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1a2f1af9f999b23c44a0b15a8841a7a297576a9c",
+        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`581fa67c`](https://github.com/danth/stylix/commit/581fa67c818aaf91a1533149fb737d3e8c0949b8) | `` stylix: guard entire overlay declarations (#1088) ``                 |
| [`a214b330`](https://github.com/danth/stylix/commit/a214b330e5d8940b05ccd951eb5c6ac0f13d125f) | `` mpv: unset subtitle font size (#1090) ``                             |
| [`9ef80628`](https://github.com/danth/stylix/commit/9ef806283b87f99dfa574b6642165cf052a1d49e) | `` discord: fix template for  new ui redesign (#1063) ``                |
| [`ac8dd8b1`](https://github.com/danth/stylix/commit/ac8dd8b1a6bc2d367f7ec8e39e0032f03ae9a458) | `` ci: bump actions/create-github-app-token from 1 to 2 ``              |
| [`f32b1c08`](https://github.com/danth/stylix/commit/f32b1c0875ee573ecf5967a76e125317e1f202a2) | `` wayfire: fix broken wallpaper option (#1087) ``                      |
| [`194a91d0`](https://github.com/danth/stylix/commit/194a91d0018daaf5bcfcea4702e6800426a82445) | `` doc: collapse flake.lock in GitHub bug template (#1059) ``           |
| [`aee4df6d`](https://github.com/danth/stylix/commit/aee4df6dc1509fc38fb868c06bc58351446a5871) | `` doc: add link to CommonMark Spec (#1081) ``                          |
| [`1832ffa9`](https://github.com/danth/stylix/commit/1832ffa9a27037388277591612af7437d1bd2bad) | `` stylix: prevent partially declared cursor (#1080) ``                 |
| [`54721996`](https://github.com/danth/stylix/commit/54721996d6590267d095f63297d9051e9342a33d) | `` doc: add links between NVF, Neovim, Nixvim, and Vim pages (#1040) `` |
| [`711bd28a`](https://github.com/danth/stylix/commit/711bd28ac96dec8c9187f8db4a297677eef2e654) | `` stylix: add missing parentheses around mkMerge (#1078) ``            |
| [`b45eb498`](https://github.com/danth/stylix/commit/b45eb498944ffeae47aba8d1e42b8449fd07ca08) | `` docs: add trick about lib.mkAfter (#1055) ``                         |