### PR TITLE
chore(flake/disko): `0d8c6ad4` -> `329d3d7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741786315,
-        "narHash": "sha256-VT65AE2syHVj6v/DGB496bqBnu1PXrrzwlw07/Zpllc=",
+        "lastModified": 1743598667,
+        "narHash": "sha256-ViE7NoFWytYO2uJONTAX35eGsvTYXNHjWALeHAg8OQY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "0d8c6ad4a43906d14abd5c60e0ffe7b587b213de",
+        "rev": "329d3d7e8bc63dd30c39e14e6076db590a6eabe6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                   |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`329d3d7e`](https://github.com/nix-community/disko/commit/329d3d7e8bc63dd30c39e14e6076db590a6eabe6) | `` interactive-vm: use disk.imageName instead of .name `` |
| [`f6dbc895`](https://github.com/nix-community/disko/commit/f6dbc8952df9e40afafbe38449751bfad12d64f2) | `` flake.lock: Update ``                                  |
| [`ddbe63d4`](https://github.com/nix-community/disko/commit/ddbe63d43ea595c4af82e48409e2873d4fd32939) | `` chore: small improvements in `interactive-vm.md` ``    |
| [`b36e8760`](https://github.com/nix-community/disko/commit/b36e87600d858f34b8cb90932e87dc61ef0aa28a) | `` zfs: properly disable zfs-based swap ``                |
| [`212ff715`](https://github.com/nix-community/disko/commit/212ff71553a64485899f82c86034ace0ca388cc5) | `` allow to build cli ``                                  |
| [`b2c95fb6`](https://github.com/nix-community/disko/commit/b2c95fb68f58e14136134bb42b982caf70addb23) | `` make devshell usuable on macOS ``                      |