### PR TITLE
chore(flake/nix-fast-build): `0ef0c606` -> `ce8bd0c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1741859942,
-        "narHash": "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=",
+        "lastModified": 1744010047,
+        "narHash": "sha256-VblOQvp2aj7IVMGAqgLdWu/KLocKJf7l5bmONgpfa8I=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8",
+        "rev": "ce8bd0c16597629f567e7ec5dda8fd4a60f0e523",
         "type": "github"
       },
       "original": {
@@ -902,11 +902,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`02db4961`](https://github.com/Mic92/nix-fast-build/commit/02db4961dd394ed26a11defc25d2e73e93a4191e) | `` chore(deps): update nixpkgs digest to da98c5d ``            |
| [`662a0e96`](https://github.com/Mic92/nix-fast-build/commit/662a0e96626a80fcece298f755d680771f6c171e) | `` chore(deps): lock file maintenance (#116) ``                |
| [`e85548d5`](https://github.com/Mic92/nix-fast-build/commit/e85548d51e60ac6121e58d087856ee26f03df27d) | `` chore(deps): update nixpkgs digest to 06f3516 ``            |
| [`2fadd869`](https://github.com/Mic92/nix-fast-build/commit/2fadd8696095bde39531e3815deea894a00b9b4a) | `` chore(deps): update nixpkgs digest to 250b695 (#114) ``     |
| [`65f8b77c`](https://github.com/Mic92/nix-fast-build/commit/65f8b77cb4c212749885bc79bafaec9b9d5c33e6) | `` chore(deps): update nixpkgs digest to 3070507 (#113) ``     |
| [`beba6aa1`](https://github.com/Mic92/nix-fast-build/commit/beba6aa1456d1a61becf8fca3d3044a223894ffb) | `` chore(deps): update nixpkgs digest to a462b94 (#112) ``     |
| [`8a6b59d8`](https://github.com/Mic92/nix-fast-build/commit/8a6b59d8c3854552f3d2b5346e500c1fbab2d45c) | `` chore(deps): update treefmt-nix digest to 815e412 (#111) `` |
| [`84440fb1`](https://github.com/Mic92/nix-fast-build/commit/84440fb14c64dbe0b2a683bd6f89e0c68839e292) | `` chore(deps): update nixpkgs digest to 2bfc080 (#110) ``     |
| [`2098f760`](https://github.com/Mic92/nix-fast-build/commit/2098f7602e271f4dab8a39f5a41e55e36a4b921d) | `` chore(deps): update treefmt-nix digest to 57dabe2 (#109) `` |
| [`14ddba15`](https://github.com/Mic92/nix-fast-build/commit/14ddba15ecd5fcde6b2ca58199fe6c48806582fa) | `` chore(deps): update nixpkgs digest to f90d0a3 (#108) ``     |
| [`ec4be4cf`](https://github.com/Mic92/nix-fast-build/commit/ec4be4cfb202a72926e53afcd6e3400ab54d99d2) | `` chore(deps): update nixpkgs digest to 155d1c0 (#106) ``     |
| [`5d52bf38`](https://github.com/Mic92/nix-fast-build/commit/5d52bf3833e66853147d8eaca445f6039c0b503a) | `` chore(deps): update treefmt-nix digest to 18bed67 (#105) `` |
| [`9818b77e`](https://github.com/Mic92/nix-fast-build/commit/9818b77e8ee5aa23e4467c9aa64f0b0c84ea5d7c) | `` chore(deps): update nixpkgs digest to adae22b (#104) ``     |
| [`9d86462d`](https://github.com/Mic92/nix-fast-build/commit/9d86462d2cbf8f91f99a2c92f2accb6aeff4f7b9) | `` chore(deps): update flake-parts digest to c621e84 (#103) `` |
| [`611e285a`](https://github.com/Mic92/nix-fast-build/commit/611e285a5a218c67e76eabdfc3a5056cb53f402c) | `` chore(deps): update nixpkgs digest to a180027 (#102) ``     |
| [`8b69b58c`](https://github.com/Mic92/nix-fast-build/commit/8b69b58c51fb8f4b405c6c8d765ce7190e6f7f59) | `` drop mergify ``                                             |
| [`dcca80d1`](https://github.com/Mic92/nix-fast-build/commit/dcca80d195610471fcdcb534b11465876f79fa7a) | `` add auto-merge github action ``                             |
| [`8b883a50`](https://github.com/Mic92/nix-fast-build/commit/8b883a50b79aa96200c5fb24c5702a34c6c0070b) | `` drop github action to update lock files ``                  |
| [`ba64b4d8`](https://github.com/Mic92/nix-fast-build/commit/ba64b4d87937be0b33ad46a66dd8c03158372c63) | `` flake.lock: Update ``                                       |
| [`87241a45`](https://github.com/Mic92/nix-fast-build/commit/87241a458ddf7e6ef50b01331df22112b51efeee) | `` Don't report negative durations ``                          |
| [`5aceac97`](https://github.com/Mic92/nix-fast-build/commit/5aceac97475f3fb5de3276561d7202faf8c35a44) | `` List only the really failed attrs as failed ``              |