### PR TITLE
chore(flake/treefmt-nix): `29a3d7b7` -> `815e4121`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743081648,
-        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`815e4121`](https://github.com/numtide/treefmt-nix/commit/815e4121d6a5d504c0f96e5be2dd7f871e4fd99d) | `` add oxipng (#331) ``                          |
| [`0a499a6d`](https://github.com/numtide/treefmt-nix/commit/0a499a6de83844a65d7a75e24969b2487ac0badc) | `` Update programs/sql-formatter.nix ``          |
| [`97bd2d28`](https://github.com/numtide/treefmt-nix/commit/97bd2d286702ba82fa10b14e28fc2236dea0aa1c) | `` meson: add option for editorconfig support `` |
| [`a39d06aa`](https://github.com/numtide/treefmt-nix/commit/a39d06aa8cb289f06da3ac0d4eb8656f3d8598be) | `` muon: add option for editorconfig support ``  |
| [`e089e068`](https://github.com/numtide/treefmt-nix/commit/e089e068237edbe4f7c62e5aca4a649afed0ce1d) | `` sql-formatter: fix multi file input ``        |