### PR TITLE
chore(flake/lovesegfault-vim-config): `baa21ff1` -> `1d33ebcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743552519,
-        "narHash": "sha256-OWR2g3ZIeBaPdnKUSj4OvfwSm6JR0p8pEg2XVC5eopQ=",
+        "lastModified": 1743638902,
+        "narHash": "sha256-nxqtoe3WDrLIGOQ5hhx6T6RvmDG97KMR7ojyWOy38jI=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "baa21ff13e8cc5ad19053bcb6cd5c8245f8c5468",
+        "rev": "1d33ebcc7f00a6ddd2862c521af2ea5e9023cbd4",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743536158,
-        "narHash": "sha256-/jlBU7EGIfaa5VKwvVyrSspuuNmgKYOjAuTd2ywyevg=",
+        "lastModified": 1743598191,
+        "narHash": "sha256-30aI8rWjX64E9vIlE4iqgQguTjItvTnQLTqHtFppF/w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "754b8df7e37be04b7438decee5a5aa18af72cbe1",
+        "rev": "a183298bf67307bdb7a25a2a3c565e76029f1b9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`1d33ebcc`](https://github.com/lovesegfault/vim-config/commit/1d33ebcc7f00a6ddd2862c521af2ea5e9023cbd4) | `` chore(flake/treefmt-nix): 29a3d7b7 -> 18bed671 `` |
| [`61131268`](https://github.com/lovesegfault/vim-config/commit/61131268ac5e595201ac6a2e52abe384edc63579) | `` chore(flake/nixvim): 754b8df7 -> a183298b ``      |