### PR TITLE
chore(flake/home-manager): `a802defb` -> `f463902a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743781299,
-        "narHash": "sha256-wLz6pjEVMXAb8EGDbXtyW98GQ8vm9cEyKhZTf/TTu24=",
+        "lastModified": 1744008831,
+        "narHash": "sha256-g3mHJLB8ShKuMaBBZxiGuoftJ22f7Boegiw5xBUnS8E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a802defb16dcdcc7fd0ff5a2d7be913ce2fe79e7",
+        "rev": "f463902a3f03e15af658e48bcc60b39188ddf734",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`f463902a`](https://github.com/nix-community/home-manager/commit/f463902a3f03e15af658e48bcc60b39188ddf734) | `` .git-blame-ignore-revs: init (#6767) ``                        |
| [`c15ab0ce`](https://github.com/nix-community/home-manager/commit/c15ab0ce0dbe64843358a3081b09ed35144dfd65) | `` swayr: systemd.target default to wayland.systemd target ``     |
| [`320e152d`](https://github.com/nix-community/home-manager/commit/320e152d0bade4ca3c1054c1ddee97bb50dfb541) | `` wlsunset: systemdTarget used for all targets ``                |
| [`a90ab0ab`](https://github.com/nix-community/home-manager/commit/a90ab0ab5f00efce68729df4e0ea196f03b2d2c6) | `` wlsunset: systemdTarget default to wayland.systemd target ``   |
| [`8871d0b1`](https://github.com/nix-community/home-manager/commit/8871d0b1ef705554db56982916bbceefd3253e78) | `` cliphist: systemdTargets default to wayland.systemd target ``  |
| [`8c9b5450`](https://github.com/nix-community/home-manager/commit/8c9b54504c89f3aec9c82b262c1f4304407fbad6) | `` swaync: use x-restart-triggers for reload (#6764) ``           |
| [`ef3b2a6b`](https://github.com/nix-community/home-manager/commit/ef3b2a6b602c3f1a80c6897d6de3ee62339a3eb7) | `` flake.lock: Update (#6762) ``                                  |
| [`d094c676`](https://github.com/nix-community/home-manager/commit/d094c6763c6ddb860580e7d3b4201f8f496a6836) | `` news: create an individual file for each news entry (#6747) `` |
| [`b5e29565`](https://github.com/nix-community/home-manager/commit/b5e29565131802cc8adee7dccede794226da8614) | `` redshift/gammastep: add tray tests ``                          |
| [`46f93825`](https://github.com/nix-community/home-manager/commit/46f93825af684a094950ae66ba5ef24a4b10c49f) | `` redshift/gammastep: fix tray.target dependency ``              |
| [`0f5908da`](https://github.com/nix-community/home-manager/commit/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1) | `` home-environment: enable home aliases for nushell (#6754) ``   |
| [`07547d29`](https://github.com/nix-community/home-manager/commit/07547d29e12deeb82dedf893cdc89b127fe7195c) | `` swaync: use lib.getExe (#6755) ``                              |
| [`bb036cb3`](https://github.com/nix-community/home-manager/commit/bb036cb35383982066e01a6ac8d45597132cf5d5) | `` swaync: Add onChange (#6233) ``                                |