### PR TITLE
chore(flake/lovesegfault-vim-config): `7e7e8c41` -> `bc76df0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743725317,
-        "narHash": "sha256-57GNBcoa8Xobaeh3yRPqzX4vVNiK74fWL2VCb56f0X4=",
+        "lastModified": 1743984512,
+        "narHash": "sha256-YhGJD35EtjCckEsnMJn7GF26HQ2QC+RjsjYVcDofjyo=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "7e7e8c41328c2004c9b5e25b292fff391fb7dd95",
+        "rev": "bc76df0dd799f2b53694cd0f523ba9cce1132fd1",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743723573,
-        "narHash": "sha256-yxONmoimNU0hy0s8pF5lKCSZNqxVmbIHuag3sdk3R30=",
+        "lastModified": 1743964204,
+        "narHash": "sha256-DFktXTeZWVM4kEET+GQHhI0XlrUG0HUAi+hZ7C/MEp0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "9f495dda930ceca1653813ded11859d6b1342803",
+        "rev": "99a2f96cf0f54034201b40d878aa9bb21b72cdf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`bc76df0d`](https://github.com/lovesegfault/vim-config/commit/bc76df0dd799f2b53694cd0f523ba9cce1132fd1) | `` chore(flake/nixpkgs): 2c8d3f48 -> 42a1c966 ``     |
| [`022717a9`](https://github.com/lovesegfault/vim-config/commit/022717a9cd1299ab5e7ca413a25fa25f0c24aa55) | `` chore(flake/nixvim): 7b431133 -> 99a2f96c ``      |
| [`ee19b44f`](https://github.com/lovesegfault/vim-config/commit/ee19b44f44f7ebf69750101dd798837f52c9d2ed) | `` chore(flake/nixvim): 9f495dda -> 7b431133 ``      |
| [`93c174ef`](https://github.com/lovesegfault/vim-config/commit/93c174ef1c1a4ab3116470d0c0d127d9a817dcc6) | `` chore(flake/treefmt-nix): 57dabe2a -> 815e4121 `` |