### PR TITLE
chore(flake/nix-index-database): `b3696bfb` -> `a36f6a71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743306489,
-        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
+        "lastModified": 1743911143,
+        "narHash": "sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
+        "rev": "a36f6a7148aec2c77d78e4466215cceb2f5f4bfb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a36f6a71`](https://github.com/nix-community/nix-index-database/commit/a36f6a7148aec2c77d78e4466215cceb2f5f4bfb) | `` update generated.nix to release 2025-04-06-032615 `` |
| [`63c826e8`](https://github.com/nix-community/nix-index-database/commit/63c826e84ea6df8a77851c7eca7fdb274a54d542) | `` flake.lock: Update ``                                |