### PR TITLE
chore(flake/nixpkgs): `2c8d3f48` -> `42a1c966`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743583204,
-        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
+        "lastModified": 1743827369,
+        "narHash": "sha256-rpqepOZ8Eo1zg+KJeWoq1HAOgoMCDloqv5r2EAa9TSA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
+        "rev": "42a1c966be226125b48c384171c44c651c236c22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`a9e9363a`](https://github.com/NixOS/nixpkgs/commit/a9e9363a1101283aa5f7059eb322e3076a96ea91) | `` geant4: 11.3.0 -> 11.3.1 ``                                                          |
| [`8e79d173`](https://github.com/NixOS/nixpkgs/commit/8e79d17301e3abea13093fea64f0b0a573ad9439) | `` erlang_language_platform: rename to erlang-language-platform ``                      |
| [`f9f91492`](https://github.com/NixOS/nixpkgs/commit/f9f91492042402e41a4894d0e356da6c0b62c524) | `` hyprprop: 0.1-unstable-2025-03-17 -> 0.1-unstable-2025-03-31 (#395882) ``            |
| [`f5af8076`](https://github.com/NixOS/nixpkgs/commit/f5af80763364a4b5613da6fda0c302c01155e4bb) | `` tower-pixel-dungeon: 0.3.2 -> 0.5.4 ``                                               |
| [`f3a10f31`](https://github.com/NixOS/nixpkgs/commit/f3a10f311dd2914c083f914bc87a5960abae5d95) | `` drawpile: 2.2.1 -> 2.2.2 ``                                                          |
| [`08e64d47`](https://github.com/NixOS/nixpkgs/commit/08e64d47792410ae1115219b1cee55e3cd047e93) | `` zrc: init at 2.1 ``                                                                  |
| [`33879210`](https://github.com/NixOS/nixpkgs/commit/338792101e893ac2b92e2671bed35d7f3e9a009b) | `` ungoogled-chromium: 134.0.6998.165-1 -> 135.0.7049.52-1 ``                           |
| [`e2e57593`](https://github.com/NixOS/nixpkgs/commit/e2e5759330fc247b93d6fc627f5b74863a345d8d) | `` zigbee2mqtt_2: 2.2.0 -> 2.2.1 ``                                                     |
| [`5f62a3f0`](https://github.com/NixOS/nixpkgs/commit/5f62a3f0a711c81264fc09d27a4d19555105cc25) | `` python312Packages.langgraph-checkpoint-duckdb: removed ``                            |
| [`8fbb4370`](https://github.com/NixOS/nixpkgs/commit/8fbb437033d8c44c2075b340bc2af9aa35453170) | `` nixosTests.homepage-dashboard: migrate to runTest ``                                 |
| [`492cc1d8`](https://github.com/NixOS/nixpkgs/commit/492cc1d81eff6673aae527493e7d6da35f20e81d) | `` opencascade-occt: Build with rapidjson to enable glTF export in FreeCAD ``           |
| [`8717786c`](https://github.com/NixOS/nixpkgs/commit/8717786cc3f3cf2721e7860e11a5a9f826553a60) | `` vale: 3.11.0 -> 3.11.1 ``                                                            |
| [`33f2784b`](https://github.com/NixOS/nixpkgs/commit/33f2784b7c7feb227c67b2d90b7de312a60b7b57) | `` nixosTests.cgit: migrate to runTest ``                                               |
| [`8504b83d`](https://github.com/NixOS/nixpkgs/commit/8504b83df5cb799c49088529be63a64446dccd72) | `` python312Packages.langgraph: rm langgraph-checkpoint-duckdb ``                       |
| [`5b5017d5`](https://github.com/NixOS/nixpkgs/commit/5b5017d5cef8b5ccfc3d9c7760b03fe7c05f4da5) | `` lighttpd: 1.4.78 -> 1.4.79 ``                                                        |
| [`10de31a0`](https://github.com/NixOS/nixpkgs/commit/10de31a04d457bcc78663d3fa2891cd4ea189718) | `` nixosTests.bind: migrate to runTest ``                                               |
| [`92d438ce`](https://github.com/NixOS/nixpkgs/commit/92d438cec90b6fab400335306ab38b72780a76f5) | `` nixosTests.moodle: migrate to runTest ``                                             |
| [`0d2a3fe1`](https://github.com/NixOS/nixpkgs/commit/0d2a3fe1b3f910322e283ab3a56932712d4dc64c) | `` svd2rust: 0.36.0 -> 0.36.1 ``                                                        |
| [`43023159`](https://github.com/NixOS/nixpkgs/commit/43023159f699aa8e9787d78300030eeadf04be76) | `` trdl-client: 0.8.7 -> 0.9.0 ``                                                       |
| [`1ae8dc30`](https://github.com/NixOS/nixpkgs/commit/1ae8dc30ed63051529618f5c055eb8f64f81923d) | `` vscode-extensions.mongodb.mongodb-vscode: 1.12.1 -> 1.13.0 ``                        |
| [`d395872e`](https://github.com/NixOS/nixpkgs/commit/d395872e2b8904e8061f1e7d675a4f76c9f20463) | `` fangfrisch 1.9.0 -> 1.9.2 ``                                                         |
| [`e6ee7d8b`](https://github.com/NixOS/nixpkgs/commit/e6ee7d8b116d3e0ebe8bcc9cb93bad88f39e2e86) | `` vscode-extensions.ms-python.isort: 2023.13.13171013 -> 2025.0.0 ``                   |
| [`a44e3553`](https://github.com/NixOS/nixpkgs/commit/a44e3553f776154baba862e12c22e64c7303d2d7) | `` bashunit: init at 0.19.0 ``                                                          |
| [`20d81559`](https://github.com/NixOS/nixpkgs/commit/20d81559e36235edd3324a4455baa9c59e98b62f) | `` rssguard: move package to by-name scheme ``                                          |
| [`249b8edc`](https://github.com/NixOS/nixpkgs/commit/249b8edca06f58cd5ac3a16950bb6d6c724f35ca) | `` copilot-language-server: add fhs version (#393260) ``                                |
| [`fdcba6e9`](https://github.com/NixOS/nixpkgs/commit/fdcba6e9d5358959436f4ced8c362d5f96533a5c) | `` ytui-music: replace youtube-dl with yt-dlp ``                                        |
| [`edb3bdd2`](https://github.com/NixOS/nixpkgs/commit/edb3bdd29947dd590fdba9aa4abd26d4fa00a955) | `` python313Packages.boto3-stubs: 1.37.26 -> 1.37.27 ``                                 |
| [`b0871fb1`](https://github.com/NixOS/nixpkgs/commit/b0871fb1ed4ef24ebeeb4e3016ce202a770ee1f4) | `` python313Packages.botocore-stubs: 1.37.26 -> 1.37.27 ``                              |
| [`a38c7fd8`](https://github.com/NixOS/nixpkgs/commit/a38c7fd8bef26c21973a84bceb844dc9e7f7a85e) | `` python312Packages.mypy-boto3-transcribe: 1.37.5 -> 1.37.27 ``                        |
| [`efa192cc`](https://github.com/NixOS/nixpkgs/commit/efa192cc9b97f60919e7ae50d459be98ec15c050) | `` python312Packages.mypy-boto3-sesv2: 1.37.24 -> 1.37.27 ``                            |
| [`8266265f`](https://github.com/NixOS/nixpkgs/commit/8266265f6960c54101c73ada862afba988883385) | `` python312Packages.mypy-boto3-sagemaker: 1.37.25 -> 1.37.27 ``                        |
| [`81ee1f14`](https://github.com/NixOS/nixpkgs/commit/81ee1f148c22de39cb0c9b47e38d47fcdf9a1ade) | `` python312Packages.mypy-boto3-route53: 1.37.15 -> 1.37.27 ``                          |
| [`ff43a052`](https://github.com/NixOS/nixpkgs/commit/ff43a052bc34d339405a7d08d033eb0c7168b967) | `` python312Packages.mypy-boto3-opensearch: 1.37.0 -> 1.37.27 ``                        |
| [`40bd63a4`](https://github.com/NixOS/nixpkgs/commit/40bd63a475c362475ef10d4ff3a3dcce4d166fe8) | `` home-assistant: pin jellyfin-apiclient-python to version 1.10.0 ``                   |
| [`895df12b`](https://github.com/NixOS/nixpkgs/commit/895df12b3fcbc96ed756ad9577813344a1c87afb) | `` python312Packages.mypy-boto3-chime-sdk-voice: 1.37.0 -> 1.37.27 ``                   |
| [`7afa349e`](https://github.com/NixOS/nixpkgs/commit/7afa349ea8b05e500c37e72e5e70f15e35a242eb) | `` nixos/paperless: mirror upstream admin user creation more closely ``                 |
| [`f7f726bc`](https://github.com/NixOS/nixpkgs/commit/f7f726bc891ed71c5cd9be7d46c4572697c31249) | `` all-the-package-names: 2.0.2117 -> 2.0.2128 ``                                       |
| [`fd4d38d9`](https://github.com/NixOS/nixpkgs/commit/fd4d38d9315327da30f7a3cd81ad4fa3eeb0305d) | `` bluespec: Add a simple `installCheckPhase` ``                                        |
| [`4bbc09a1`](https://github.com/NixOS/nixpkgs/commit/4bbc09a1d0a044f2e894a4b42e5d5c485aefa36b) | `` beam26Packages.erlfmt: 1.6.0 -> 1.6.1 ``                                             |
| [`c4500a94`](https://github.com/NixOS/nixpkgs/commit/c4500a94e4676ae4520af302430da88a84ad2169) | `` python312Packages.posthog: 3.18.1 -> 3.23.0 ``                                       |
| [`366a2470`](https://github.com/NixOS/nixpkgs/commit/366a24706ebccb15b1d7c4eaae528bddc3da2864) | `` bluespec: Conditionalize `withDocs` deps ``                                          |
| [`e6629c35`](https://github.com/NixOS/nixpkgs/commit/e6629c356440121a45d6c7d5b3effb1acda8b215) | `` bluespec: Fix wrong executable name for `bsc` ``                                     |
| [`991ddfeb`](https://github.com/NixOS/nixpkgs/commit/991ddfebd8539981f77c2567ac99b394935a2f4a) | `` nix-update: simplify expression ``                                                   |
| [`b4948783`](https://github.com/NixOS/nixpkgs/commit/b494878375c609b59ec0d09855e775f5ced90a01) | `` nix-update: 1.10.0 -> 1.11.0 ``                                                      |
| [`428cee5a`](https://github.com/NixOS/nixpkgs/commit/428cee5acf1970b3aa0f5710de38d3ef5af492b8) | `` erlang_27: 27.3.1 -> 27.3.2 ``                                                       |
| [`57ddd566`](https://github.com/NixOS/nixpkgs/commit/57ddd56634b85ea00171bc58b2c59d1c9b3c47cd) | `` grafana-loki: 3.4.2 -> 3.4.3 ``                                                      |
| [`9fbc4bf2`](https://github.com/NixOS/nixpkgs/commit/9fbc4bf2d3c2f8c8339e536c1abd69c7c89617fe) | `` linux-doc: fix build (#395281) ``                                                    |
| [`2789c83e`](https://github.com/NixOS/nixpkgs/commit/2789c83e9c0d696bc44516c80c599c87c8279316) | `` gosec: 2.22.2 -> 2.22.3 ``                                                           |
| [`0f8342b5`](https://github.com/NixOS/nixpkgs/commit/0f8342b5f490334c96e2f2984c089a6d21b01032) | `` mkosi: rename python3 -> python ``                                                   |
| [`2c525864`](https://github.com/NixOS/nixpkgs/commit/2c525864bcd332763cd839457b6aaf28998df46d) | `` libmt32emu: 2.7.1 -> 2.7.2 ``                                                        |
| [`3c6b1cf6`](https://github.com/NixOS/nixpkgs/commit/3c6b1cf6f60dd2e786c6ed11a22eab790863d41b) | `` paretosecurity: 0.0.96 -> 0.1.3 ``                                                   |
| [`d86c274b`](https://github.com/NixOS/nixpkgs/commit/d86c274b99b9c40ac54e0423cc99e9ab44105497) | `` nixosTests.starship: migrate to runTest ``                                           |
| [`8f0d4225`](https://github.com/NixOS/nixpkgs/commit/8f0d4225d4aca60386844933164e92b6660d00b3) | `` nixosTests.lighttpd: migrate to runTest ``                                           |
| [`e6067eee`](https://github.com/NixOS/nixpkgs/commit/e6067eeed96dd759fa6e49701e9b4dd77b96e549) | `` nixfmt-rfc-style: 2025-03-03 -> 2025-04-04 ``                                        |
| [`470a936f`](https://github.com/NixOS/nixpkgs/commit/470a936f46fed1e6dd699fd286757592b3b5f95d) | `` nixosTests.tuxguitar: migrate to runTest ``                                          |
| [`8807f45d`](https://github.com/NixOS/nixpkgs/commit/8807f45da070cec9c6b5bb10da865a128cfde570) | `` nixosTests.librenms: migrate to runTest ``                                           |
| [`6e164676`](https://github.com/NixOS/nixpkgs/commit/6e164676985976249f8befa6415646c7b3c4f997) | `` lswt: add patch fixing JSON formatting of identifier string ``                       |
| [`ed7eae38`](https://github.com/NixOS/nixpkgs/commit/ed7eae38b4598bd4787aaf198e7c5b89773fdd7e) | `` gojq: install zsh completion ``                                                      |
| [`bc073b4c`](https://github.com/NixOS/nixpkgs/commit/bc073b4c29e4fb4f5757144e04096e0c16c81932) | `` lokalise2-cli: 3.1.1 -> 3.1.2 ``                                                     |
| [`5c8db99f`](https://github.com/NixOS/nixpkgs/commit/5c8db99f60db399957f579bd23442283371d6050) | `` ma: init at version 11 ``                                                            |
| [`7f100c8e`](https://github.com/NixOS/nixpkgs/commit/7f100c8ea89b35db7c24da0a88c298ee150c6f93) | `` nimble: add changelog ``                                                             |
| [`5345e43b`](https://github.com/NixOS/nixpkgs/commit/5345e43b4944f1207d8b2a7424614f3400ca022d) | `` nimble: add daylinmorgan as maintainer ``                                            |
| [`edc90eb0`](https://github.com/NixOS/nixpkgs/commit/edc90eb00a1b886807fcc863c620ca9ae7c07373) | `` nimble: 0.16.0 -> 0.18.0 ``                                                          |
| [`439fee9f`](https://github.com/NixOS/nixpkgs/commit/439fee9f72c3d8173249e2186b23d7371a681567) | `` maintainers: update usertam email and keys ``                                        |
| [`2c4d04f7`](https://github.com/NixOS/nixpkgs/commit/2c4d04f74a1bb9165402bac494d83f226b1cb95e) | `` profanity: 0.14.0 -> 0.15.0 ``                                                       |
| [`3cf5c2fa`](https://github.com/NixOS/nixpkgs/commit/3cf5c2fa15ce4b8c9325d695301789fa9f0d60d2) | `` coreboot-utils: 24.12 -> 25.03 ``                                                    |
| [`37521544`](https://github.com/NixOS/nixpkgs/commit/375215442b6865df1d2efdf17b3b71be837d622b) | `` coreboot-toolchain: 24.12 -> 25.03 ``                                                |
| [`81758d39`](https://github.com/NixOS/nixpkgs/commit/81758d399f9bc7e3c666464dfd4e24734be78cec) | `` moosefs: 4.57.5 -> 4.57.6 ``                                                         |
| [`64abab71`](https://github.com/NixOS/nixpkgs/commit/64abab71e51268536d8a5b368170bdfb5c65d5e6) | `` vencord: 1.11.7 -> 1.11.8 ``                                                         |
| [`7361e6d6`](https://github.com/NixOS/nixpkgs/commit/7361e6d6b1f44410c79d431f95b7b48addbe669f) | `` bird3: 3.0.1 -> 3.1.0 (#395932) ``                                                   |
| [`e1964791`](https://github.com/NixOS/nixpkgs/commit/e1964791d66993a8aa5b9f19c1c6dd5827851355) | `` dxx-rebirth: 0.60.0-beta2-unstable-2025-03-01 -> 0.60.0-beta2-unstable-2025-03-29 `` |
| [`edef4448`](https://github.com/NixOS/nixpkgs/commit/edef4448e8c89b8a8acfc0b91cb5304b77363006) | `` tippecanoe: 2.75.1 -> 2.77.0 ``                                                      |
| [`b038877f`](https://github.com/NixOS/nixpkgs/commit/b038877f0203013915bfb6dd49908cf86c333620) | `` mosdepth: 0.3.10 -> 0.3.11 ``                                                        |
| [`ccbc5c12`](https://github.com/NixOS/nixpkgs/commit/ccbc5c1282e114d123e9cf06cf96a9a5fd6735dc) | `` gpupad: init at 2.4.0 ``                                                             |
| [`36be2e2a`](https://github.com/NixOS/nixpkgs/commit/36be2e2a525ac379085673ad47901299f1bca402) | `` rain: 1.21.0 -> 1.22.0 ``                                                            |
| [`915d7021`](https://github.com/NixOS/nixpkgs/commit/915d70217de01d00d365369abf64c5be6fa2139d) | `` aider-chat: 0.80.0 -> 0.81.0, enable update script ``                                |
| [`7256f291`](https://github.com/NixOS/nixpkgs/commit/7256f29179189f6ee5bc2b36eec9d2825137ecec) | `` splash: 3.11.1 -> 3.11.2 ``                                                          |
| [`dbb3bdb4`](https://github.com/NixOS/nixpkgs/commit/dbb3bdb4d4d981692cefe88436eb36f3a59f9d96) | `` onlyoffice-documentserver: fail loudly when HASH_POSTFIX would change ``             |
| [`ed26b7b0`](https://github.com/NixOS/nixpkgs/commit/ed26b7b0c374e946dbd774e00d7f0aa1b8fde87f) | `` nixos/onlyoffice: misc cleanup ``                                                    |
| [`d3780887`](https://github.com/NixOS/nixpkgs/commit/d3780887fa0c2d81bd73ba5d055ecc41f5765085) | `` python312Packages.qcodes-contrib-drivers: 0.22.0 -> 0.23.0 ``                        |
| [`2728be7c`](https://github.com/NixOS/nixpkgs/commit/2728be7c3150573a0e45c7cd77c03000520541f9) | `` nixos/glance: fix broken server stats ``                                             |
| [`43d45777`](https://github.com/NixOS/nixpkgs/commit/43d457772b6b5e7e58dd8bdca6ed3335c682361e) | `` python312Packages.qcodes: 0.51.0 -> 0.52.0 ``                                        |
| [`7236ac70`](https://github.com/NixOS/nixpkgs/commit/7236ac70cbc0b3ff08c18dce12ae1f7315581b60) | `` tagparser: 12.4.0 -> 12.5.0 ``                                                       |
| [`46b20f3f`](https://github.com/NixOS/nixpkgs/commit/46b20f3f17369d3a02ec2b504ff1d831bc6b8e57) | `` python3Packages.django-phonenumber-field: build locale files ``                      |
| [`c57db497`](https://github.com/NixOS/nixpkgs/commit/c57db49783197cf983b6d6cd19079e34636c9896) | `` kdePackages.qtutilities: 6.14.6 -> 6.15.0 ``                                         |
| [`d6c28d90`](https://github.com/NixOS/nixpkgs/commit/d6c28d909f1e3ba09f7dfae63fbdc70d772f52f2) | `` dprint-plugins: update ``                                                            |
| [`72857eab`](https://github.com/NixOS/nixpkgs/commit/72857eab9f577157ca606015cec5861ba104b63f) | `` prometheus-tibber-exporter: init tibber nixos module integration ``                  |
| [`979caf8f`](https://github.com/NixOS/nixpkgs/commit/979caf8f05c7cfe8196f60059b972f9ecb14d6b8) | `` prometheus-ecoflow-exporter: init ecoflow nixos module integration ``                |
| [`69872616`](https://github.com/NixOS/nixpkgs/commit/698726164206845f48bfd024efb31ccde858c33b) | `` hyprlandPlugins.hyprsplit: 0.48.0 -> 0.48.1 ``                                       |
| [`4a9e0387`](https://github.com/NixOS/nixpkgs/commit/4a9e0387dda2318814eb13b6d3db04fae978d522) | `` go-judge: 1.9.2 -> 1.9.3 ``                                                          |
| [`31e51f5d`](https://github.com/NixOS/nixpkgs/commit/31e51f5d444cf30111a85511d05bdf50425262cc) | `` giza: 1.4.4 -> 1.5.0 ``                                                              |
| [`bcfd895b`](https://github.com/NixOS/nixpkgs/commit/bcfd895b66b0ccd400b579d4302c856a368b916f) | `` eask-cli: 0.10.3 -> 0.11.0 ``                                                        |
| [`aed60364`](https://github.com/NixOS/nixpkgs/commit/aed60364918c223ef0e1fc8788374c6e96af8d10) | `` cpp-utilities: 5.27.3 -> 5.28.0 ``                                                   |
| [`fbfba47c`](https://github.com/NixOS/nixpkgs/commit/fbfba47cab9f9c0780b1d7f9b24858431a190530) | `` claude-code: 0.2.59 -> 0.2.62 ``                                                     |
| [`aff6004b`](https://github.com/NixOS/nixpkgs/commit/aff6004b25f94a5935ce84accffd2c4e8f9a01dc) | `` tailwindcss_4: 4.1.1 -> 4.1.2 ``                                                     |
| [`cb60a011`](https://github.com/NixOS/nixpkgs/commit/cb60a01188fe3579abb1b97a0e51b21bac90087d) | `` nixos/rke2: make tests work in test driver sandbox (#395775) ``                      |
| [`1af9e80c`](https://github.com/NixOS/nixpkgs/commit/1af9e80c8614f6ec38798f01010587a17d382289) | `` python312Packages.ihm: 2.3 -> 2.4 ``                                                 |
| [`af2ef85a`](https://github.com/NixOS/nixpkgs/commit/af2ef85a8049794e1a79fda30a0d26e1a4dfafde) | `` python312Packages.xiaomi-ble: 0.35.0 -> 0.36.0 ``                                    |
| [`0c02d1f7`](https://github.com/NixOS/nixpkgs/commit/0c02d1f7c81dc43510c698289af20e41ed70b07a) | `` cobalt: 0.19.8 -> 0.19.9 ``                                                          |
| [`ce0c3c76`](https://github.com/NixOS/nixpkgs/commit/ce0c3c7649eb88d3f61551c924000e76720ea38a) | `` python312Packages.mkdocs-awesome-nav: 3.0.0 -> 3.1.0 ``                              |
| [`1aff6add`](https://github.com/NixOS/nixpkgs/commit/1aff6add433419109b367b9c4ac0851047e82d36) | `` ocamlPackages.ocamlformat-mlx: 0.26.2.0 → 0.27.0.0 ``                                |
| [`c14c3347`](https://github.com/NixOS/nixpkgs/commit/c14c3347ad9a05cae767e06ed6647c72cc736153) | `` vscode-extensions.saoudrizwan.claude-dev: 3.8.4 -> 3.8.6 ``                          |
| [`d1c6a15d`](https://github.com/NixOS/nixpkgs/commit/d1c6a15d9b2b82fbff3b8564ff249c732e7857ef) | `` candy-icons: 0-unstable-2025-03-19 -> 0-unstable-2025-04-02 ``                       |
| [`b559c1b2`](https://github.com/NixOS/nixpkgs/commit/b559c1b2bf6c8b59329765998f4a2b61dd3d8c74) | `` python312Packages.pure-protobuf: 3.1.3 -> 3.1.4 ``                                   |
| [`91d57181`](https://github.com/NixOS/nixpkgs/commit/91d5718182027588069d0018aa458a357e628958) | `` Revert "python313Packages.bring-api: 1.0.2 -> 1.1.0" ``                              |
| [`a2e88642`](https://github.com/NixOS/nixpkgs/commit/a2e886428b4a52bd908a3eccd5c4a6f48993dccf) | `` firefox: copy *.dylibs on darwin ``                                                  |
| [`30736fc4`](https://github.com/NixOS/nixpkgs/commit/30736fc47b42d5834e0752ba37923d45be32b2cb) | `` nixos/amdvlk: enable 32 bit drivers properly ``                                      |