### PR TITLE
chore(flake/stylix): `a2f8840b` -> `ce45f19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744127443,
-        "narHash": "sha256-8E4hqLYI4zJbEVPQBq5zzJDsiHGOU4+0htGKexwXRPw=",
+        "lastModified": 1744270948,
+        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a2f8840bed6daade6b980426c9f72dd672e92329",
+        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ce45f19e`](https://github.com/danth/stylix/commit/ce45f19e8acb43e5f02888d873d451e2f994546b) | `` kde: add run wrapper (#1117) ``                             |
| [`82f67a36`](https://github.com/danth/stylix/commit/82f67a36eba1b111f8d568bf5e5ceb30e4b623d6) | `` doc: align module capitalization (#1115) ``                 |
| [`31fdf606`](https://github.com/danth/stylix/commit/31fdf60634beaa0bb14fa57fc64cd5a67d1bf101) | `` stylix: disallow nixpkgs aliases in testbeds (#1124) ``     |
| [`85220767`](https://github.com/danth/stylix/commit/852207671fd11839e83b67b98efe82f1c7cad1f8) | `` ci: include release branch in update PR title (#1114) ``    |
| [`c8bc1c1d`](https://github.com/danth/stylix/commit/c8bc1c1d9ec5f3c852da40983ae0e9cfe775dbda) | `` treewide: remove use of multiple with statements (#1085) `` |