### PR TITLE
chore(flake/home-manager): `4040c577` -> `542efdf2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744172174,
-        "narHash": "sha256-Ud0ClYf8YHhbYmg1piPJx2iuYOh62HQiRzDObD2gzsk=",
+        "lastModified": 1744208565,
+        "narHash": "sha256-vG3JJOar/r8ognz7wuwMtOJ8Knu1MMlOzHB1N6R2MbY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4040c5779ce56d36805bc7a83e072f0f894eae7d",
+        "rev": "542efdf2dfac351498f534eb71671525b9bd45ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`542efdf2`](https://github.com/nix-community/home-manager/commit/542efdf2dfac351498f534eb71671525b9bd45ed) | `` flake.lock: Update (#6785) ``                       |
| [`9864a2f4`](https://github.com/nix-community/home-manager/commit/9864a2f421e859d9784b6c413ec25d1415ddfe08) | `` thunderbird: add accountsOrder option (#6310) ``    |
| [`a1036d4d`](https://github.com/nix-community/home-manager/commit/a1036d4d3e939d740149508aa68b2545c4964d37) | `` tests: stub notmuch darwin (#6788) ``               |
| [`fcb8a2b6`](https://github.com/nix-community/home-manager/commit/fcb8a2b62b30ae054a4eadbf43c913a755f1d14c) | `` swaylock: fix path values in config file (#6786) `` |