### PR TITLE
chore(flake/nix-fast-build): `93b318c2` -> `1556d8c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1744182287,
-        "narHash": "sha256-o9O4KA7R/evL/KT7UsdKHTT+em+BvnxuGa0vn9U3U60=",
+        "lastModified": 1744547774,
+        "narHash": "sha256-0xMZH1sDCoQxLe385OpVwkIW0xwl4KYGmjM++Y4uTRc=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "93b318c24112dd435a265ecc6bf09401e63ade63",
+        "rev": "1556d8c533d8fee16ee7c46aa7092ef18d8b39ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`1556d8c5`](https://github.com/Mic92/nix-fast-build/commit/1556d8c533d8fee16ee7c46aa7092ef18d8b39ae) | `` chore(deps): update nixpkgs digest to d3dc44f (#123) `` |
| [`3df8aa89`](https://github.com/Mic92/nix-fast-build/commit/3df8aa89f7279746d790c014edc5208eb668c272) | `` chore(deps): update nixpkgs digest to 208645b (#122) `` |
| [`b01f2559`](https://github.com/Mic92/nix-fast-build/commit/b01f2559cdcef1f9c42ce3cac324256bd2b7955d) | `` chore(deps): update nixpkgs digest to a931801 (#121) `` |
| [`cb773b11`](https://github.com/Mic92/nix-fast-build/commit/cb773b118e64a69aa52451e40ada6e16d78ca6c0) | `` chore(deps): update nixpkgs digest to e58dd8c (#120) `` |