### PR TITLE
chore(flake/tinted-schemes): `c37771c4` -> `6db1e653`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -849,11 +849,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1742851696,
-        "narHash": "sha256-sR4K+OVFKeUOvNIqcCr5Br7NLxOBEwoAgsIyjsZmb8s=",
+        "lastModified": 1744626413,
+        "narHash": "sha256-QHb1sns7cVOoDH9azcioIY9GCM+ZWXz1OZlv5n/HjwI=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "c37771c4ae8ff1667e27ddcf24991ebeb94a4e77",
+        "rev": "6db1e6536a81339ff06bfe8aaaaf35f5a9032d5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                               |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`6db1e653`](https://github.com/tinted-theming/schemes/commit/6db1e6536a81339ff06bfe8aaaaf35f5a9032d5f) | `` Add and update github schemes to reflect the Tinted Theming styling spec (#52) ``  |
| [`0f18375c`](https://github.com/tinted-theming/schemes/commit/0f18375cac261b94e7fafa12ac1fd0d29c07349a) | `` Ensure relevant scheme-system exists in yaml file (#51) ``                         |
| [`5dc50019`](https://github.com/tinted-theming/schemes/commit/5dc50019e932e772f4f8e2d8af8ca9ca202b9bdd) | `` Added Embarcadero & Mission Brogue Schemes (#42) ``                                |
| [`c4672071`](https://github.com/tinted-theming/schemes/commit/c4672071e58a947fee17a548a682e443449ac27c) | `` Fix bug where system is incorrectly named (#50) ``                                 |
| [`5c481ad9`](https://github.com/tinted-theming/schemes/commit/5c481ad9e963540fb4260ef8ee51f8ce35c7d7d7) | `` Added Digital Rain theme (#49) ``                                                  |
| [`186585a5`](https://github.com/tinted-theming/schemes/commit/186585a5aac077916489ac8af2937cadc95ba7dd) | `` Add Kanagawa Dragon scheme (#48) ``                                                |
| [`7b0b2dd9`](https://github.com/tinted-theming/schemes/commit/7b0b2dd90e0fdf84a69972e4e8e0affdea677413) | `` Set gruvbox scheme colors according to https://github.com/morhetz/gruvbox (#46) `` |