### PR TITLE
chore(flake/home-manager): `b74b22bb` -> `cfa196c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744400600,
-        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
+        "lastModified": 1744570807,
+        "narHash": "sha256-g07PYyZCIHVDLzRo8fllZRES7Nf9R8+xZwNJ7t0gt5s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
+        "rev": "cfa196c705a896372319249d757085876ab62448",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`cfa196c7`](https://github.com/nix-community/home-manager/commit/cfa196c705a896372319249d757085876ab62448) | `` flake.lock: Update (#6812) ``                               |
| [`4f898f37`](https://github.com/nix-community/home-manager/commit/4f898f373d8b0bfdac635b036396c90b0ad17be8) | `` helix: add support for path and string themes (#6814) ``    |
| [`db56335c`](https://github.com/nix-community/home-manager/commit/db56335ca8942d86f2200664acdbd5b9212b26ad) | `` way-displays: fix failing use of `lib.mkDefault` (#6809) `` |