### PR TITLE
chore(flake/stylix): `ce45f19e` -> `042db377`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744270948,
-        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
+        "lastModified": 1744572782,
+        "narHash": "sha256-CFNluxLqxmDPQYxi37nBd4wrpB0lI4Os8nRA7UWAJK0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
+        "rev": "042db377bccc99b1a724b076c89ba803e411d889",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`042db377`](https://github.com/danth/stylix/commit/042db377bccc99b1a724b076c89ba803e411d889) | `` fcitx5: enable theme, refactor (#1131) ``                |
| [`379ba613`](https://github.com/danth/stylix/commit/379ba613a68fafdd756db370f0ef878a0d3a7308) | `` ci: explicit permissions for github app token (#1132) `` |
| [`2ce9f0ec`](https://github.com/danth/stylix/commit/2ce9f0ec13a12682856fac549de1ac86dc4aa51a) | `` emacs: add panchoh as maintainer (#1068) ``              |
| [`49d8cb14`](https://github.com/danth/stylix/commit/49d8cb14bc9caa0362cc23f05c9a0d3a391cc1c3) | `` bemenu: add noodlez1232 as maintainer (#1075) ``         |
| [`27c1d217`](https://github.com/danth/stylix/commit/27c1d217040f3d22fa10485aad34474d77f5b7ba) | `` stylix: remove empty line in maintainers list (#1056) `` |
| [`75291f7b`](https://github.com/danth/stylix/commit/75291f7b18b1d90dcabe0651d9a1e2e7356b503d) | `` treewide: add _0x5a4 as maintainer (#1044) ``            |
| [`0fb3bc5f`](https://github.com/danth/stylix/commit/0fb3bc5f8cbe1c74825bfe90996e19b686e082fb) | `` treewide: add mateusauler as maintainer (#1043) ``       |
| [`65433f9f`](https://github.com/danth/stylix/commit/65433f9fc7aefa8fb91601093d3429183aad0173) | `` kubecolor: add ajgon as maintainer (#1027) ``            |
| [`bf4cc681`](https://github.com/danth/stylix/commit/bf4cc681f6428e9181182dfef34e4a99bf4ab2c6) | `` swaync: add themaxmur as maintainer (#1032) ``           |
| [`09207f8b`](https://github.com/danth/stylix/commit/09207f8bbd331c8481122369457c7486ffa3e2e3) | `` nvf: add butzist as maintainer (#1031) ``                |
| [`6421b5c2`](https://github.com/danth/stylix/commit/6421b5c2d26882a22e85a318bff57b82edb587ea) | `` hyprland: add skoove as maintainer (#1030) ``            |
| [`4286d581`](https://github.com/danth/stylix/commit/4286d5819c7a3efb3193f90194175fd892256812) | `` fcitx5: add make-42 as maintainer (#1028) ``             |
| [`292ac3a9`](https://github.com/danth/stylix/commit/292ac3a93084c99ad59bc1bacfed66498df3ec53) | `` treewide: add awwpotato as maintainer (#1021) ``         |
| [`85b081e3`](https://github.com/danth/stylix/commit/85b081e369f7215a2823f0fc0556b15b68b8c9ac) | `` glance: add louis-thevenet as maintainer (#1022) ``      |
| [`1ac1b0d9`](https://github.com/danth/stylix/commit/1ac1b0d95147fff51dad0249da95f5eb5b7d92a2) | `` treewide: add danth as maintainer (#1011) ``             |
| [`a29a420b`](https://github.com/danth/stylix/commit/a29a420bb230548316f85fae70a5352e06675e4a) | `` treewide: add naho as maintainer (#1007) ``              |