### PR TITLE
chore(flake/home-manager): `db7738e6` -> `5d48f3de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744735751,
-        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
+        "lastModified": 1744812667,
+        "narHash": "sha256-2AJZwXMO82YGw6B/RRCPz8Wz2zSRCZIdjhdFuiw7Ymg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
+        "rev": "5d48f3ded3b55ef32d5853c9022fb4df29b3fc45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`5d48f3de`](https://github.com/nix-community/home-manager/commit/5d48f3ded3b55ef32d5853c9022fb4df29b3fc45) | `` mcfly: Fix mcfly-fzf initialization crash for fish and zsh (#6827) `` |
| [`401e7b54`](https://github.com/nix-community/home-manager/commit/401e7b544e7c8e8a59f4ec7f1745f7619bbfbde3) | `` Translate using Weblate (Dutch) (#6828) ``                            |