### PR TITLE
chore(flake/home-manager): `5d48f3de` -> `72526a5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744812667,
-        "narHash": "sha256-2AJZwXMO82YGw6B/RRCPz8Wz2zSRCZIdjhdFuiw7Ymg=",
+        "lastModified": 1744919155,
+        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d48f3ded3b55ef32d5853c9022fb4df29b3fc45",
+        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`72526a5f`](https://github.com/nix-community/home-manager/commit/72526a5f7cde2ef9075637802a1e2a8d2d658f70) | `` tests/firefox: fix test commands (#6840) ``                     |
| [`e72178b8`](https://github.com/nix-community/home-manager/commit/e72178b84e440703e17ff5d393ba060784bed099) | `` tests/atuin: add theme test ``                                  |
| [`88e61873`](https://github.com/nix-community/home-manager/commit/88e61873646616ed80605e14b75332de22934481) | `` atuin: add support for themes ``                                |
| [`2c71aae6`](https://github.com/nix-community/home-manager/commit/2c71aae678c03a39c2542e136b87bd040ae1b3cb) | `` tests/firefox: validate folder linking ``                       |
| [`baa2a0b3`](https://github.com/nix-community/home-manager/commit/baa2a0b3bd23de23ba23f50508e44e9d77819ec2) | `` tests/firefox: consolidate userChrome.css test files ``         |
| [`c3c91dd8`](https://github.com/nix-community/home-manager/commit/c3c91dd8b4974ce221748b997e644c4838e3ebbc) | `` mkFirefoxModule: fix userChrome with leading comment (#6836) `` |
| [`c6b75d69`](https://github.com/nix-community/home-manager/commit/c6b75d69b6994ba68ec281bd36faebcc56097800) | `` tests/firefox: add userchrome test cases ``                     |
| [`1827e843`](https://github.com/nix-community/home-manager/commit/1827e84344ff7cb814e3e4dfad51a45856ea50f6) | `` mkFirefoxModule: fix userChrome ``                              |
| [`cb65c814`](https://github.com/nix-community/home-manager/commit/cb65c81403f61f49483858730b087ff6699c61c1) | `` chawan: init module (#6768) ``                                  |
| [`b35bccc3`](https://github.com/nix-community/home-manager/commit/b35bccc32d3fc49f6fcc4e08ccfd6025c9eefa20) | `` home-manager-auto-expire: fix spelling error (#6829) ``         |
| [`7ede02c3`](https://github.com/nix-community/home-manager/commit/7ede02c32a729db0d6340bdb41d10e73ec511ca0) | `` progs: firefox: *.userChrome may be path or drv (#6761) ``      |
| [`d8263c0b`](https://github.com/nix-community/home-manager/commit/d8263c0b845cec48869dc6b2ba80125fa002ff03) | `` labwc: Add module for Labwc (#6807) ``                          |