### PR TITLE
chore(flake/lovesegfault-vim-config): `6912b7d8` -> `9342605c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744762033,
-        "narHash": "sha256-jto7r+BD91cjY0wD951Yya8R68NzYse31MgXqpRcfS4=",
+        "lastModified": 1744905850,
+        "narHash": "sha256-WnCOrjJ1T0/S4MCSJ/JyIQCLFz+QSp37hn9+UEY9gDE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "6912b7d8a7147f828fd49f8700dc43c33be44ba2",
+        "rev": "9342605cfb46b84b401958f5a39c9b0b3ffb99cc",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744200902,
-        "narHash": "sha256-BqTLjxT1C1XfREDBQSxPrfKI9DBpZHBVLHzfXZs+h8M=",
+        "lastModified": 1744753228,
+        "narHash": "sha256-Re8g2pby4sr4hgzJmQJxeH/9PtgX85nivkWibapRI5s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "51203927e395535c4a427295efed4e1b2ef8349b",
+        "rev": "d4dada282aeac94b5d53dd70e276a2f5f534f783",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                     |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`9342605c`](https://github.com/lovesegfault/vim-config/commit/9342605cfb46b84b401958f5a39c9b0b3ffb99cc) | `` fix: remove treesitter settings moved to dependencies `` |
| [`b5d68019`](https://github.com/lovesegfault/vim-config/commit/b5d68019478877188d2d1f10a4c41d21823b7c12) | `` chore(flake/nixvim): 51203927 -> d4dada28 ``             |
| [`2c481816`](https://github.com/lovesegfault/vim-config/commit/2c481816390af94428ce22cd8ad637a356f85796) | `` chore(flake/nixpkgs): f675531b -> 2631b0b7 ``            |