### PR TITLE
chore(flake/stylix): `38aff11a` -> `758fe634`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744668092,
-        "narHash": "sha256-XDmpI3ywMkypsHKRF2am6BzZ5OjwpQMulAe8L87Ek8U=",
+        "lastModified": 1745156230,
+        "narHash": "sha256-8Oeww77z62PVy4xmyH6UHFxRoZfKgXkSSyKQpIWMTyQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "38aff11a7097f4da6b95d4c4d2c0438f25a08d52",
+        "rev": "758fe63490093650075ec7587b7a6eb38614a4dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`758fe634`](https://github.com/danth/stylix/commit/758fe63490093650075ec7587b7a6eb38614a4dd) | `` helix: use theme option ``                  |
| [`8b0d9317`](https://github.com/danth/stylix/commit/8b0d9317edd57c5374adcf6957ae4775875c2a9d) | `` btop: use theme option (#1126) ``           |
| [`8d5cd725`](https://github.com/danth/stylix/commit/8d5cd725ad591890c0cd804bf68cc842b8afca51) | `` qt: fix kvantum breaking plasma6 (#1128) `` |