### PR TITLE
chore(flake/disko): `76c0a6db` -> `1770bf1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744145203,
-        "narHash": "sha256-I2oILRiJ6G+BOSjY+0dGrTPe080L3pbKpc+gCV3Nmyk=",
+        "lastModified": 1745224732,
+        "narHash": "sha256-0OWgbEKhpMLpk3WQi3ugOwxWW4Y6JVpKiQ+o0nuNzus=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "76c0a6dba345490508f36c1aa3c7ba5b6b460989",
+        "rev": "1770bf1ae5da05564f86b969ef21c7228cc1a70b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1770bf1a`](https://github.com/nix-community/disko/commit/1770bf1ae5da05564f86b969ef21c7228cc1a70b) | `` flake.lock: Update ``                                                  |
| [`51d33bbb`](https://github.com/nix-community/disko/commit/51d33bbb7f1e74ba5f9d9a77357735149da99081) | `` UI nit: remove unnecessary newline when prompting user for password `` |