### PR TITLE
chore(flake/home-manager): `fc09cb7a` -> `9676e8a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745001336,
-        "narHash": "sha256-R4HuzrgYtOYBNmB3lfRxcieHEBO4uSfgHNz4MzWkZ5M=",
+        "lastModified": 1745071558,
+        "narHash": "sha256-bvcatss0xodcdxXm0LUSLPd2jjrhqO3yFSu3stOfQXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc09cb7aaadb70d6c4898654ffc872f0d2415df9",
+        "rev": "9676e8a52a177d80c8a42f66566362a6d74ecf78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9676e8a5`](https://github.com/nix-community/home-manager/commit/9676e8a52a177d80c8a42f66566362a6d74ecf78) | `` inori: init module (#6289) ``                              |
| [`ae84885d`](https://github.com/nix-community/home-manager/commit/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7) | `` workflows/conflicts: init (#6845) ``                       |
| [`307281bf`](https://github.com/nix-community/home-manager/commit/307281bfda7f3e3469234a03a7dd9d0026bf9f36) | `` labeler: expand labels (#6846) ``                          |
| [`991a4804`](https://github.com/nix-community/home-manager/commit/991a4804720669220f7cbba078a2a27e2496eb69) | `` mkFirefoxModule: userchrome support derivations (#6844) `` |
| [`67f60ebc`](https://github.com/nix-community/home-manager/commit/67f60ebce88a89939fb509f304ac554bcdc5bfa6) | `` tests/home-cursor: don't use realPkgs ``                   |
| [`4bc9b08c`](https://github.com/nix-community/home-manager/commit/4bc9b08c330842cb6e0cdafdb3c3b900cdde111a) | `` tests/broot: stub broot ``                                 |
| [`39037b08`](https://github.com/nix-community/home-manager/commit/39037b08f11ed034f4e0649aadbcdd856fab0ced) | `` tests: darwin stub hjson-go ``                             |
| [`412eb166`](https://github.com/nix-community/home-manager/commit/412eb166eb6725549c7e6b317eb48dc2bc648e39) | `` tests/thunderbird: dont use realPkgs ``                    |