### PR TITLE
chore(flake/home-manager): `496fa9c0` -> `3fbe9a2b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745190356,
-        "narHash": "sha256-2tOi3l1E1qwG3P5dzTN4yJ52SSENNXAWZMyPwcPx9gw=",
+        "lastModified": 1745205007,
+        "narHash": "sha256-k67bEcLkSo13TIBfs0CGYkJjG12aaikabMtxWbSeqr0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "496fa9c054d3a212c8bcb3ac80ab310841eed361",
+        "rev": "3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`3fbe9a2b`](https://github.com/nix-community/home-manager/commit/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c) | `` tests/ranger: null package ``       |
| [`63bfbf55`](https://github.com/nix-community/home-manager/commit/63bfbf55b6e561f5c517a29f9bf9157ff9dd8c87) | `` ranger: nullable package support `` |
| [`14eda3db`](https://github.com/nix-community/home-manager/commit/14eda3db4e0347bb03f0d2e32f28f4467744abe1) | `` clock-rs: add module ``             |
| [`ac21ae37`](https://github.com/nix-community/home-manager/commit/ac21ae37168f339cccfd7002039314aeb3829bf6) | `` maintainers: add Oughie ``          |
| [`b0cc0924`](https://github.com/nix-community/home-manager/commit/b0cc092405da805da6fa964f5a178343658ceaf0) | `` shikane: init module (#4096) ``     |