### PR TITLE
chore(flake/home-manager): `3fbe9a2b` -> `82ee14ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745205007,
-        "narHash": "sha256-k67bEcLkSo13TIBfs0CGYkJjG12aaikabMtxWbSeqr0=",
+        "lastModified": 1745251259,
+        "narHash": "sha256-Hf8WEJMMoP6Fe+k+PYkVJFk5UKory2S0jW7HqRVqQFc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c",
+        "rev": "82ee14ff60611b46588ea852f267aafcc117c8c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`82ee14ff`](https://github.com/nix-community/home-manager/commit/82ee14ff60611b46588ea852f267aafcc117c8c8) | `` treewide: remove with lib (#6871) ``          |
| [`6695b1d4`](https://github.com/nix-community/home-manager/commit/6695b1d477246e30a3f14a7084c82775b30c09c1) | `` kconfig: escape arguments properly (#6867) `` |