### PR TITLE
chore(flake/home-manager): `82ee14ff` -> `ddda2b1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745251259,
-        "narHash": "sha256-Hf8WEJMMoP6Fe+k+PYkVJFk5UKory2S0jW7HqRVqQFc=",
+        "lastModified": 1745252367,
+        "narHash": "sha256-xmQJPtCzKCQ911kFu5cwhWi8uqY1i57kHxsuB9mmRL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "82ee14ff60611b46588ea852f267aafcc117c8c8",
+        "rev": "ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`ddda2b1f`](https://github.com/nix-community/home-manager/commit/ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478) | `` direnv: only set sessionVariable for old version (#6842) `` |