### PR TITLE
chore(flake/home-manager): `ddda2b1f` -> `22b326b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745252367,
-        "narHash": "sha256-xmQJPtCzKCQ911kFu5cwhWi8uqY1i57kHxsuB9mmRL8=",
+        "lastModified": 1745256380,
+        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478",
+        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`22b326b4`](https://github.com/nix-community/home-manager/commit/22b326b42bf42973d5e4fe1044591fb459e6aeac) | `` television: add module (#6866) ``                    |
| [`be4e5ec6`](https://github.com/nix-community/home-manager/commit/be4e5ec62ce5703a00e40668f7a1a79d04c2195d) | `` nix-init: add module (#6864) ``                      |
| [`08b85bd0`](https://github.com/nix-community/home-manager/commit/08b85bd0002c7ac500b8d9ac0112467885712b1f) | `` vesktop: add support for multiple themes (#6860) ``  |
| [`ca836711`](https://github.com/nix-community/home-manager/commit/ca8367117a20e11139b6b887aa19cb5d48dc1075) | `` atuin: Fix deprecated string type warning (#6861) `` |