### PR TITLE
chore(flake/stylix): `039e938b` -> `1db9218e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -180,11 +180,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1743774811,
-        "narHash": "sha256-oiHLDHXq7ymsMVYSg92dD1OLnKLQoU/Gf2F1GoONLCE=",
+        "lastModified": 1744642301,
+        "narHash": "sha256-5A6LL7T0lttn1vrKsNOKUk9V0ittdW0VEqh6AtefxJ4=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "df53a7a31872faf5ca53dd0730038a62ec63ca9e",
+        "rev": "59e3de00f01e5adb851d824cf7911bd90c31083a",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1743884191,
-        "narHash": "sha256-foVcginhVvjg8ZnTzY5wwMeZ4wjJ8yX66PW5kgyivPE=",
+        "lastModified": 1745459908,
+        "narHash": "sha256-bWqgohVf/py9EW3bLS/dYbenD2p9N2/Qsw1+CJk1S04=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fde90f5f52e13eed110a0e53a2818a2b09e4d37c",
+        "rev": "dbc4ba3233b2bf951521177bf0ee0a7679959035",
         "type": "github"
       },
       "original": {
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745197327,
-        "narHash": "sha256-67BDvZBfS+IGM/onh7FgjSo1B+oeh6tewDCFvwrDzvs=",
+        "lastModified": 1745466324,
+        "narHash": "sha256-bKnHFiW/24Up/DWuO8ntzBOUu179mfx96COUeUCKSAQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "039e938b29ce870ba326be1d60ae6d7c0a58f84e",
+        "rev": "1db9218e9770c4fc2aaae64222820fabb213be7a",
         "type": "github"
       },
       "original": {
@@ -833,11 +833,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1742851696,
-        "narHash": "sha256-sR4K+OVFKeUOvNIqcCr5Br7NLxOBEwoAgsIyjsZmb8s=",
+        "lastModified": 1744974599,
+        "narHash": "sha256-Fg+rdGs5FAgfkYNCs74lnl8vkQmiZVdBsziyPhVqrlY=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "c37771c4ae8ff1667e27ddcf24991ebeb94a4e77",
+        "rev": "28c26a621123ad4ebd5bbfb34ab39421c0144bdd",
         "type": "github"
       },
       "original": {
@@ -865,11 +865,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1743296873,
-        "narHash": "sha256-8IQulrb1OBSxMwdKijO9fB70ON//V32dpK9Uioy7FzY=",
+        "lastModified": 1745111349,
+        "narHash": "sha256-udV+nHdpqgkJI9D0mtvvAzbqubt9jdifS/KhTTbJ45w=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "af5152c8d7546dfb4ff6df94080bf5ff54f64e3a",
+        "rev": "e009f18a01182b63559fb28f1c786eb027c3dee9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`1db9218e`](https://github.com/danth/stylix/commit/1db9218e9770c4fc2aaae64222820fabb213be7a) | `` stylix: update all flake inputs ``                                      |
| [`7ddc94f9`](https://github.com/danth/stylix/commit/7ddc94f9dc9b1fc39fb1b2eaf8d773a3132966c9) | `` treewide: add missing `.`s to extensions (#1165) ``                     |
| [`9738ceb9`](https://github.com/danth/stylix/commit/9738ceb9012fee460f3c545d0c1efe7246549912) | `` ci: fix update flake pr title condition (#1169) ``                      |
| [`a49bff74`](https://github.com/danth/stylix/commit/a49bff748c63a67f4d3be3bb975002fcad6dbb07) | `` stylix: use awwpotato's base16.nix fork (#1164) ``                      |
| [`a97dca14`](https://github.com/danth/stylix/commit/a97dca14afd598384253b0377ac9139be9c59291) | `` ci: fix update-flake pr-title syntax (#1166) ``                         |
| [`f46d58be`](https://github.com/danth/stylix/commit/f46d58be39a7822a88f29b1650ec14c961c81414) | `` gtk: invert extraCss warning (#1159) ``                                 |
| [`b37f3052`](https://github.com/danth/stylix/commit/b37f305238354eee2701bf790921834e14614141) | `` doc: display GitHub handles in maintainer sections (#1140) ``           |
| [`375b1de2`](https://github.com/danth/stylix/commit/375b1de2424aac1338ee6e8b4ef15976b64b0462) | `` gtk: warn about non-functional gtk.gtk{3,4}.extraCss options (#1153) `` |
| [`a7a0682b`](https://github.com/danth/stylix/commit/a7a0682b3e5e61601c7372102d891aed981292cb) | `` gitui: fix config.lib.stylix.colors.withHashtag typo (#1154) ``         |
| [`45aa31f5`](https://github.com/danth/stylix/commit/45aa31f5a4975e6f28596fa3c49997b8a35c78a1) | `` stylix: apply standardized message convention (#1155) ``                |
| [`ae74f20c`](https://github.com/danth/stylix/commit/ae74f20cc25a24b9440b2ef9b95e6eb71a79186d) | `` zed: use themes option (#1151) ``                                       |