### PR TITLE
chore(flake/home-manager): `22b326b4` -> `6899001a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745256380,
-        "narHash": "sha256-hJH1S5Xy0K2J6eT22AMDIcQ07E8XYC1t7DnXUr2llEM=",
+        "lastModified": 1745350245,
+        "narHash": "sha256-KK0LZX8O73DVIcI5qnxuDeSh3b4RrkDfC6lvIjzEyzc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22b326b42bf42973d5e4fe1044591fb459e6aeac",
+        "rev": "6899001a762b0e089ad7b8ec7637d0a678640b8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`6899001a`](https://github.com/nix-community/home-manager/commit/6899001a762b0e089ad7b8ec7637d0a678640b8e) | `` fcitx5: add `themes` and `classicUiConfig` options (#6876) `` |
| [`c9433ae6`](https://github.com/nix-community/home-manager/commit/c9433ae62fbb4bd09609e242569edc3b551e21a9) | `` keepassxc: register as native messaging host (#6879) ``       |
| [`b925865c`](https://github.com/nix-community/home-manager/commit/b925865c74a783c2fd42f0f340f18f2276baa316) | `` ci: label msmtp changes with "mail" (#6881) ``                |
| [`342b3e3e`](https://github.com/nix-community/home-manager/commit/342b3e3e6df239dc972372e6a641acf052ff74aa) | `` msmtp: rename environment variables (#6839) ``                |
| [`cf0c5e01`](https://github.com/nix-community/home-manager/commit/cf0c5e0105c5920f203473b571bbdc051c46995a) | `` xdg-autostart: fix runCommandNoCCLocal deprecation (#6880) `` |
| [`ce8dc1f7`](https://github.com/nix-community/home-manager/commit/ce8dc1f77ada561f4deee2c76f7cd6f6c7b8feec) | `` xsettingsd: Remove erroneous `lib.` insertion (#6877) ``      |
| [`81541ea3`](https://github.com/nix-community/home-manager/commit/81541ea36d1fead4be7797e826ee325d4c19308b) | `` lorri: fix missing makeSearchPath (#6875) ``                  |
| [`42d90297`](https://github.com/nix-community/home-manager/commit/42d90297b38424a62235550a191fca875913e2f7) | `` git: support maintenance on darwin (#6868) ``                 |