### PR TITLE
chore(flake/home-manager): `6899001a` -> `1d0e1390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745350245,
-        "narHash": "sha256-KK0LZX8O73DVIcI5qnxuDeSh3b4RrkDfC6lvIjzEyzc=",
+        "lastModified": 1745380081,
+        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6899001a762b0e089ad7b8ec7637d0a678640b8e",
+        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`1d0e1390`](https://github.com/nix-community/home-manager/commit/1d0e13904bd8c444ab1595f686ede5eff377e881) | `` i18n.inputMethod: add awwpotato as maintainer ``                       |
| [`585bae4b`](https://github.com/nix-community/home-manager/commit/585bae4bbb48789ece06f4b18cb373651760c4ab) | `` i18n.inputMethod: align enable option with nixos ``                    |
| [`7ef31370`](https://github.com/nix-community/home-manager/commit/7ef3137035deca91854c38c114eeaf611707b005) | `` vesktop: fix config path on darwin (#6889) ``                          |
| [`97a62d8e`](https://github.com/nix-community/home-manager/commit/97a62d8eef74ab06b20152be0b323292dfe03c88) | `` tests/default: add zoxide darwin stub (#6888) ``                       |
| [`68bc080c`](https://github.com/nix-community/home-manager/commit/68bc080cdf00b1ec65f78c1d1e65e9828904cd22) | `` fcitx5: refactor logic (#6886) ``                                      |
| [`f1aabf1d`](https://github.com/nix-community/home-manager/commit/f1aabf1deb6981176b7608cdf67140519a3d442b) | `` zsh: deprecate initLocation options in favor of initContent (#6841) `` |
| [`c42f04c8`](https://github.com/nix-community/home-manager/commit/c42f04c83f866e3ad7d285072b253dffdabad6fe) | `` mkFirefoxModule: revert userChrome changes (#6887) ``                  |
| [`b99e3e46`](https://github.com/nix-community/home-manager/commit/b99e3e46b86aefc01f229e0a29d0c03c1079aaed) | `` ci: fixed redundant rule (#6883) ``                                    |