### PR TITLE
chore(flake/lovesegfault-vim-config): `e6a29342` -> `4e7213fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745280407,
-        "narHash": "sha256-lOSFqM4NJkqZjSFDp4lh9bUALb2wPn54fJguUKNUvxw=",
+        "lastModified": 1745366996,
+        "narHash": "sha256-YsHqMZ4+EGY7r4q0QJr44eSVKL01HnEqKk+hV//uifo=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "e6a293425b6a5750b7c93c22087483071d12acfe",
+        "rev": "4e7213fadd1c268208853ea2e9ad3ca8cf9a0674",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745244491,
-        "narHash": "sha256-UlwXkytxGW/aokB9fZ6cSznYKM9ynDLHqhjcPve0KL4=",
+        "lastModified": 1745324162,
+        "narHash": "sha256-Sjb/LvtWpPtSXacjJCTrLAmWtXNJd0SWxO3PzTvD7Tc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a58109958d14bcece8ec3e2085e41ea3351e387",
+        "rev": "60638182b8d1b0fe13631d02eafaf8903499ee60",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`4e7213fa`](https://github.com/lovesegfault/vim-config/commit/4e7213fadd1c268208853ea2e9ad3ca8cf9a0674) | `` chore(flake/nixpkgs): b024ced1 -> c11863f1 `` |
| [`16417a50`](https://github.com/lovesegfault/vim-config/commit/16417a50990ede10e35842b5d74c0a0fd7c51c14) | `` chore(flake/nixvim): 7a581099 -> 60638182 ``  |