### PR TITLE
chore(flake/nixos-hardware): `9a049b4a` -> `8bf8a2a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1744633460,
-        "narHash": "sha256-fbWE4Xpw6eH0Q6in+ymNuDwTkqmFmtxcQEmtRuKDTTk=",
+        "lastModified": 1745392233,
+        "narHash": "sha256-xmqG4MZArM1JNxPJ33s0MtuBzgnaCO9laARoU3AfP8E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9a049b4a421076d27fee3eec664a18b2066824cb",
+        "rev": "8bf8a2a0822365bd8f44fd1a19d7ed0a1d629d64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`04779973`](https://github.com/NixOS/nixos-hardware/commit/047799739c0c04c11075018a23b5ec55e4652b24) | `` lenovo-legion-16arh7h: add integrated GPU only and hybrid configurations `` |
| [`085c9ada`](https://github.com/NixOS/nixos-hardware/commit/085c9ada2dae5b7a67c8d7ab17754362f96ba8dd) | `` intel-comet-lake: use intel-media-driver ``                                 |
| [`af7de84f`](https://github.com/NixOS/nixos-hardware/commit/af7de84f851e61202cb32bc528917416359336e2) | `` E14-intel: import intel comet lake ``                                       |