### PR TITLE
chore(flake/home-manager): `6d1f834c` -> `abfad3d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745427103,
-        "narHash": "sha256-J4v65MKoXt95nmCYr6a7Cdiyl9QmPp6u3+7aJ71zxbk=",
+        "lastModified": 1745494811,
+        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d1f834ca63700604a96d8c38aa8ac272d95071a",
+        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`abfad3d2`](https://github.com/nix-community/home-manager/commit/abfad3d2958c9e6300a883bd443512c55dfeb1be) | `` treewide: substituteAll -> replaceVars/substitute `` |
| [`d31710fb`](https://github.com/nix-community/home-manager/commit/d31710fb2cd536b1966fee2af74e99a0816a61a8) | `` fcitx5: fix iniFormat usage (#6899) ``               |