### PR TITLE
chore(flake/stylix): `1db9218e` -> `4846adbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745466324,
-        "narHash": "sha256-bKnHFiW/24Up/DWuO8ntzBOUu179mfx96COUeUCKSAQ=",
+        "lastModified": 1745541960,
+        "narHash": "sha256-CnkPq3sjuxB2HC93JVSotfMCF3dDrdKo3e4JOImKiLs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1db9218e9770c4fc2aaae64222820fabb213be7a",
+        "rev": "4846adbc2a0334687c024aed0ca77ecd93ccdb0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4846adbc`](https://github.com/danth/stylix/commit/4846adbc2a0334687c024aed0ca77ecd93ccdb0d) | `` vesktop: use upstream options (#1150) ``                          |
| [`21774695`](https://github.com/danth/stylix/commit/21774695205278373f67de5540bd08fea376895c) | `` ci: bump DeterminateSystems/nix-installer-action from 16 to 17 `` |
| [`3194470d`](https://github.com/danth/stylix/commit/3194470d07d2885da178a6baca10a91ea1068e1b) | `` gitui: fix two typos (#1172) ``                                   |