### PR TITLE
chore(flake/stylix): `4846adbc` -> `b4d3137c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1745459908,
-        "narHash": "sha256-bWqgohVf/py9EW3bLS/dYbenD2p9N2/Qsw1+CJk1S04=",
+        "lastModified": 1746056780,
+        "narHash": "sha256-/emueQGaoT4vu0QjU9LDOG5roxRSfdY0K2KkxuzazcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbc4ba3233b2bf951521177bf0ee0a7679959035",
+        "rev": "d476cd0972dd6242d76374fcc277e6735715c167",
         "type": "github"
       },
       "original": {
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745541960,
-        "narHash": "sha256-CnkPq3sjuxB2HC93JVSotfMCF3dDrdKo3e4JOImKiLs=",
+        "lastModified": 1746065148,
+        "narHash": "sha256-NR8JCOo9BrK0T7iPmNKR+fa/zS+do+GgAMVg4fwMvYM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4846adbc2a0334687c024aed0ca77ecd93ccdb0d",
+        "rev": "b4d3137c5ce960073a991bd99a333cad1b233101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`b4d3137c`](https://github.com/danth/stylix/commit/b4d3137c5ce960073a991bd99a333cad1b233101) | `` ci: use format for flake update title (#1197) ``                         |
| [`7476be8b`](https://github.com/danth/stylix/commit/7476be8b0bfdd4f6135e8a72678b2b9487069fe3) | `` ci: fix stable pr title for update flake (#1196) ``                      |
| [`51cc5640`](https://github.com/danth/stylix/commit/51cc5640d9532874274f754c64c2ef32ada1a703) | `` stylix: update all flake inputs ``                                       |
| [`44957b25`](https://github.com/danth/stylix/commit/44957b251b236ec89dc1923885141cd04e5e82ab) | `` fcitx5: use upstream options (#1158) ``                                  |
| [`e11bc9a5`](https://github.com/danth/stylix/commit/e11bc9a59d45c36c7e5e47f4ff0fab21a1f52f8c) | `` wofi: add testbed (#1180) ``                                             |
| [`764fd329`](https://github.com/danth/stylix/commit/764fd32955e79f2742a7975f0150175f93add2fb) | `` btop: add testbed (#1106) ``                                             |
| [`8a35410a`](https://github.com/danth/stylix/commit/8a35410a28d346622936cb9f3f9d2592d71a6a9f) | `` treewide: add stylix.testbed.ui.{command,application} options (#1110) `` |
| [`de0870f0`](https://github.com/danth/stylix/commit/de0870f075737eac147c31fcef77df9b9525abfa) | `` wezterm: adapt for breaking change in hm (#1182) ``                      |
| [`594336f4`](https://github.com/danth/stylix/commit/594336f425edb579f11a61d76e3d866412358486) | `` stylix: switch to using treefmt (#1076) ``                               |
| [`11ceb2fd`](https://github.com/danth/stylix/commit/11ceb2fde1901dc227421bbbef2d0800339f5126) | `` spotify-player: init (#1177) ``                                          |
| [`245a167c`](https://github.com/danth/stylix/commit/245a167c75a221e5692c08b8a4aa15c76e32c041) | `` ci: backport dependabot by default (#1149) ``                            |
| [`2dc32d8b`](https://github.com/danth/stylix/commit/2dc32d8bf0239ed025971853a1b6ad9ebddd93ba) | `` stylix: switch back to original base16.nix (#1173) ``                    |