### PR TITLE
chore(flake/agenix): `e600439e` -> `96e078c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736955230,
-        "narHash": "sha256-uenf8fv2eG5bKM8C/UvFaiJMZ4IpUFaQxk9OH5t/1gA=",
+        "lastModified": 1745630506,
+        "narHash": "sha256-bHCFgGeu8XjWlVuaWzi3QONjDW3coZDqSHvnd4l7xus=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "e600439ec4c273cf11e06fe4d9d906fb98fa097c",
+        "rev": "96e078c646b711aee04b82ba01aefbff87004ded",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`58c55446`](https://github.com/ryantm/agenix/commit/58c554469cf7bbb27b02f7378c6058ea0ffa59b3) | `` fix: use replaceVars instead of substituteAll `` |