### PR TITLE
chore(flake/nixpkgs): `8a2f738d` -> `f771eb40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -593,11 +593,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745391562,
-        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "lastModified": 1745526057,
+        "narHash": "sha256-ITSpPDwvLBZBnPRS2bUcHY3gZSwis/uTe255QgMtTLA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "rev": "f771eb401a46846c1aebd20552521b233dd7e18b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`5ac04acb`](https://github.com/NixOS/nixpkgs/commit/5ac04acb1a281c05b6919b15caa9b8226c1b06de) | `` qownnotes: 25.4.3 -> 25.4.4 ``                                               |
| [`759e1028`](https://github.com/NixOS/nixpkgs/commit/759e1028ead7811a0c1e4b58fd89602638dcce57) | `` tpnote: 1.25.7 -> 1.25.8 ``                                                  |
| [`7ab53600`](https://github.com/NixOS/nixpkgs/commit/7ab53600713848a84f1d3ca19dc1d76b2918682b) | `` plasmusic-toolbar: 2.3.0 -> 2.4.0 ``                                         |
| [`f63e7487`](https://github.com/NixOS/nixpkgs/commit/f63e74871f46b4bad723740799298aca7416511c) | `` bitcoin-knots: 26.1.knots20240325 -> 28.1.knots20250305 ``                   |
| [`d80437f4`](https://github.com/NixOS/nixpkgs/commit/d80437f44f92ed26155aebc7951d53e98f77db64) | `` fabric-ai: 1.4.171 -> 1.4.183 ``                                             |
| [`dd41ce9d`](https://github.com/NixOS/nixpkgs/commit/dd41ce9d35247c5f99f6df9feb251e9da32d7ca9) | `` grafana: fix yarn vendor hash ``                                             |
| [`d050496f`](https://github.com/NixOS/nixpkgs/commit/d050496fb8da9cf8984f797a63e7b4fa5ab04126) | `` ollama: fix tests in darwin sandbox ``                                       |
| [`b82e30c2`](https://github.com/NixOS/nixpkgs/commit/b82e30c251566a88ef75e7b092f2ea53691a60d6) | `` ollama: remove maintainer ``                                                 |
| [`e6432339`](https://github.com/NixOS/nixpkgs/commit/e6432339227b3d0ef009501dcacf3b27d29dd831) | `` python312Packages.docling-core: 2.26.4 -> 2.28.0 ``                          |
| [`97607ae7`](https://github.com/NixOS/nixpkgs/commit/97607ae705d5ddadaddc2440e178f440f55b926e) | `` drip: add awwpotato as maintainer ``                                         |
| [`fdf8c773`](https://github.com/NixOS/nixpkgs/commit/fdf8c7731c68d49207370f16e708e3e69ca2d8ee) | `` drip: unbreak, modernize ``                                                  |
| [`499ac361`](https://github.com/NixOS/nixpkgs/commit/499ac361bb102fff6197211149506f5a7f61acf8) | `` python312Packages.csaps: init at 1.3.2 ``                                    |
| [`a104d101`](https://github.com/NixOS/nixpkgs/commit/a104d1010cc19cdef9033e667d91da2212d0a4d0) | `` python312Packages.ipydatagrid: init at 1.4.0 ``                              |
| [`94bd5a40`](https://github.com/NixOS/nixpkgs/commit/94bd5a4018861c3164b635638658f0b02d71cef4) | `` py2vega: init at 0.6.1 ``                                                    |
| [`5314ba3d`](https://github.com/NixOS/nixpkgs/commit/5314ba3d164abcc5a3a9f47c71564222dc5dad77) | `` python313Packages.aiocron: fix build ``                                      |
| [`6cf9cd9f`](https://github.com/NixOS/nixpkgs/commit/6cf9cd9f88efbeedfae43c31d53eaced704d3436) | `` libretro.vice-x128: 0-unstable-2025-03-28 -> 0-unstable-2025-04-22 ``        |
| [`7afbcbfd`](https://github.com/NixOS/nixpkgs/commit/7afbcbfd2debe91d6060dc8173d18cc9562c5e8e) | `` oh-my-zsh: 2025-04-13 -> 2025-04-19 (#401220) ``                             |
| [`75fbb79e`](https://github.com/NixOS/nixpkgs/commit/75fbb79e339bc0dbc045485edfffbfc365b509f2) | `` slint-lsp: 1.10.0 -> 1.11.0 ``                                               |
| [`11eea631`](https://github.com/NixOS/nixpkgs/commit/11eea631d0379632ad3469f9866386717f7540f7) | `` vimPlugins.sonarlint-nvim: 0-unstable-2025-04-18 -> 0-unstable-2025-04-24 `` |
| [`9910c1b1`](https://github.com/NixOS/nixpkgs/commit/9910c1b112b7828eaa4c6b8d258e38955a50a99e) | `` yay: 12.4.2 -> 12.5.0 ``                                                     |
| [`7b062bd7`](https://github.com/NixOS/nixpkgs/commit/7b062bd784e7c5a872c0b271d027e130c995c171) | `` mongodb-atlas-cli: 1.42.0 -> 1.42.1 ``                                       |
| [`88d498fe`](https://github.com/NixOS/nixpkgs/commit/88d498febe47fe9ed95d5409aaf5f6ce47c3375b) | `` proton-vpn-local-agent: run pre/postInstall hooks ``                         |
| [`fddf0079`](https://github.com/NixOS/nixpkgs/commit/fddf0079b936bfc7c39bdf024de9dd1f9ac3baa0) | `` python312Packages.aioesphomeapi: 29.10.0 -> 30.0.1 ``                        |
| [`6851a509`](https://github.com/NixOS/nixpkgs/commit/6851a5096be11e33e24f723aaa45d0e805e21e77) | `` hugo: 0.146.4 -> 0.146.7 ``                                                  |
| [`e180d488`](https://github.com/NixOS/nixpkgs/commit/e180d4888b657d153b15a4d8952d403a698dbfdc) | `` zed-editor: 0.182.11 -> 0.183.10 ``                                          |
| [`7b1ffc2b`](https://github.com/NixOS/nixpkgs/commit/7b1ffc2b47a292b635cafaa4df01b01da1c78759) | `` flirt: 0.3 -> 0.4 ``                                                         |
| [`b91da058`](https://github.com/NixOS/nixpkgs/commit/b91da0582c0cc2e5458e609c60fddba76b2fc203) | `` openmolcas: use cmakeFlagsArray only for options where needed. ``            |
| [`da540a72`](https://github.com/NixOS/nixpkgs/commit/da540a729cb4523b9ab684d3993c992eed89661b) | `` gitlab-container-registry: nixfmt ``                                         |
| [`5a9475bf`](https://github.com/NixOS/nixpkgs/commit/5a9475bf053a03ffcb12044aca3875bc6debf940) | `` cyclonedx-python: 5.3.0 -> 5.5.0 ``                                          |
| [`b4f5e9ff`](https://github.com/NixOS/nixpkgs/commit/b4f5e9ff8162d40ee6a14adc9450e0c653d4657e) | `` svt-av1-psy: 2.3.0-B-unstable-2025-02-02 -> 3.0.2-unstable-2025-04-21 ``     |
| [`e5480e62`](https://github.com/NixOS/nixpkgs/commit/e5480e62cc8df0c8550beef547c9b4597b585330) | `` gitlab-container-registry: use teams directly (#401350) ``                   |
| [`f0720581`](https://github.com/NixOS/nixpkgs/commit/f07205812cc90d15bea0b06a313b1c6720416bb5) | `` paretosecurity: 0.1.9 -> 0.2.12 ``                                           |
| [`099ca6ff`](https://github.com/NixOS/nixpkgs/commit/099ca6ffbfdfda6ba93fd3eff9b5c3a25cf90cd2) | `` python313Packages.getjump: 2.7.2 -> 2.7.3 ``                                 |
| [`591d01b4`](https://github.com/NixOS/nixpkgs/commit/591d01b474a14d81ec115e969b7836b8416ab348) | `` anydesk: 6.4.3 -> 7.0.0 ``                                                   |
| [`0a89065c`](https://github.com/NixOS/nixpkgs/commit/0a89065c71ef4b0d037aab17617e710af482f45a) | `` python313Packages.django-annoying: 0.10.7 -> 0.10.8 ``                       |
| [`851112ed`](https://github.com/NixOS/nixpkgs/commit/851112edac3c4b2186e7922e8e2e49597a6ae695) | `` rat-king-adventure: 2.1.0 -> 2.1.1 ``                                        |
| [`c249979a`](https://github.com/NixOS/nixpkgs/commit/c249979afde25dfd420dc36f4e0768b3c7b63910) | `` trivy: 0.61.0 -> 0.61.1 ``                                                   |
| [`9d972ef4`](https://github.com/NixOS/nixpkgs/commit/9d972ef4da7b92f12704be7908491da14f6ae2f8) | `` python313Packages.githubkit: 0.12.10 -> 0.12.11 ``                           |
| [`4a7a588e`](https://github.com/NixOS/nixpkgs/commit/4a7a588e90adf9c931ad7dd717fe9fb6019cd3bc) | `` python313Packages.tldextract: 5.2.0 -> 5.3.0 ``                              |
| [`b528fe84`](https://github.com/NixOS/nixpkgs/commit/b528fe84bd692d9d372aee95c35539bf1ea20b82) | `` python313Packages.yaramod: 4.3.0 -> 4.3.1 ``                                 |
| [`92e9ff93`](https://github.com/NixOS/nixpkgs/commit/92e9ff932da08d377b130f72391a8e1ec935d5c7) | `` python313Packages.yara-x: 0.13.0 -> 0.14.0 ``                                |
| [`a54c2613`](https://github.com/NixOS/nixpkgs/commit/a54c261334e9263b93f4afe42b9b8d7a43003f8f) | `` vengi-tools: 0.0.35 -> 0.0.36 ``                                             |
| [`b3ea8039`](https://github.com/NixOS/nixpkgs/commit/b3ea80394151ab7ae090991936526a047e9bce80) | `` python313Packages.typer-shell: relax rich ``                                 |
| [`4322dfdb`](https://github.com/NixOS/nixpkgs/commit/4322dfdbac97abd48a4d9f7ad033cd58dbdafb24) | `` smbclient-ng: relax rich ``                                                  |
| [`44d600da`](https://github.com/NixOS/nixpkgs/commit/44d600dad98fde8e8124009ca6689b34baa323de) | `` python313Packages.boto3-stubs: 1.38.0 -> 1.38.1 ``                           |
| [`0ff244bf`](https://github.com/NixOS/nixpkgs/commit/0ff244bf52b737116f32a3be8b5e57e0439723ea) | `` python313Packages.botocore-stubs: 1.38.0 -> 1.38.1 ``                        |
| [`429b6498`](https://github.com/NixOS/nixpkgs/commit/429b649849d15eb532e27918c87c13d0b795419c) | `` python312Packages.mypy-boto3-resource-explorer-2: 1.38.0 -> 1.38.1 ``        |
| [`ebac5b39`](https://github.com/NixOS/nixpkgs/commit/ebac5b39404c6175c30bd323dfcaa592f639dd1b) | `` python312Packages.mypy-boto3-imagebuilder: 1.38.0 -> 1.38.1 ``               |
| [`096f10c9`](https://github.com/NixOS/nixpkgs/commit/096f10c9e35ce95424276d3a5e958e10796ba90c) | `` python312Packages.mypy-boto3-ecs: 1.38.0 -> 1.38.1 ``                        |
| [`e54984aa`](https://github.com/NixOS/nixpkgs/commit/e54984aa25e7df29034e3f4f754950fe807419a7) | `` python312Packages.mypy-boto3-codebuild: 1.38.0 -> 1.38.1 ``                  |
| [`1f63458e`](https://github.com/NixOS/nixpkgs/commit/1f63458ea4c1369b68ff50f8085e13aa5c345943) | `` python313Packages.aiohomekit: 3.2.13 -> 3.2.14 ``                            |
| [`91afa81d`](https://github.com/NixOS/nixpkgs/commit/91afa81d15260b29a34e806b1cf657ba1fca6d44) | `` gitlab: 17.10.4 -> 17.11.1 ``                                                |
| [`295bb10f`](https://github.com/NixOS/nixpkgs/commit/295bb10f93c1325361c62839c57957aa8d9eeeef) | `` gitlab: Reformat gemset.nix after updating with update.py ``                 |
| [`f80e8ba5`](https://github.com/NixOS/nixpkgs/commit/f80e8ba5d4b8863faaace9d70b51b6e12e4ffcd6) | `` gitlab: Repair --commit functionality in update.py ``                        |
| [`28136b54`](https://github.com/NixOS/nixpkgs/commit/28136b54b54e369e2e8343e658245b2b14a321b9) | `` postgresqlPackages.timescaledb_toolkit: fix passthru tests ``                |
| [`1a2cd368`](https://github.com/NixOS/nixpkgs/commit/1a2cd3683e1e5fae14ebad993f1a872759e365d3) | `` postgresqlPackages: remove left-over nixosTests arguments ``                 |
| [`5178484f`](https://github.com/NixOS/nixpkgs/commit/5178484fffa5873d14a4f0645edb7e5c2e65b332) | `` metals: use fixed-point mkDerivation ``                                      |
| [`1190b54d`](https://github.com/NixOS/nixpkgs/commit/1190b54d4ccfa9d41493d3287a3bc1c22e9ad19c) | `` gitlab-container-registry: 4.19.0 -> 4.20.0 ``                               |
| [`6699a10b`](https://github.com/NixOS/nixpkgs/commit/6699a10bc2f77d89af4791ff3d47f75e97d4cd35) | `` goaccess: 1.9.3 -> 1.9.4 ``                                                  |
| [`d8caa892`](https://github.com/NixOS/nixpkgs/commit/d8caa8926741e81cb50fa39bc805b5d16f5b7e8e) | `` gh: 2.70.0 -> 2.71.0 ``                                                      |
| [`896d3df5`](https://github.com/NixOS/nixpkgs/commit/896d3df5c19e5f1e7ef338d9fa7f29eeb4f52f0d) | `` monolith: 2.10.0 -> 2.10.1 ``                                                |
| [`d21dbdac`](https://github.com/NixOS/nixpkgs/commit/d21dbdac6612852909f43c94f791bcafabdf5f5b) | `` virtnbdbackup: 2.26 -> 2.28 ``                                               |
| [`4041875c`](https://github.com/NixOS/nixpkgs/commit/4041875cf23e9455d7b23a2a0b1472a8181b0164) | `` dnf5: 5.2.12.0 -> 5.2.13.0 ``                                                |
| [`265bfbd5`](https://github.com/NixOS/nixpkgs/commit/265bfbd502b97af71d0e408c269a4045057825a0) | `` firefox-unwrapped: Move nasm to nativeBuildInputs ``                         |
| [`684ae3f7`](https://github.com/NixOS/nixpkgs/commit/684ae3f7d0cdc067b09e22a0bf7b1306e2a67990) | `` mqtt-explorer: fix macos architecture specific build ``                      |
| [`0931f4e8`](https://github.com/NixOS/nixpkgs/commit/0931f4e8618417869bb2cbfddfcb4baecfa20f56) | `` Revert "pkgs/top-level/stage.nix: add pkgsLLVMLibc" ``                       |
| [`422bbbf1`](https://github.com/NixOS/nixpkgs/commit/422bbbf1bc0ad0186177e0bc34fad6085a424803) | `` xk6: 0.18.0 -> 0.19.1 ``                                                     |
| [`803e2ac3`](https://github.com/NixOS/nixpkgs/commit/803e2ac34ad62eed67a02fd48c3d3e7057f050cb) | `` mdq: 0.5.0 -> 0.6.1 ``                                                       |
| [`7917b1ed`](https://github.com/NixOS/nixpkgs/commit/7917b1ed572d5626d7abe8bb8d5566afac015bed) | `` shopware-cli: 0.5.16 -> 0.5.18 ``                                            |
| [`3a92caf8`](https://github.com/NixOS/nixpkgs/commit/3a92caf8b2932f119dd552f6c5447e5e144ab7c7) | `` vimPlugins.ecolog-nvim: init at 2025-04-23 ``                                |
| [`9b833000`](https://github.com/NixOS/nixpkgs/commit/9b8330001b13a484aeada27f5add7a2e04705712) | `` nvidia_oc: 0.1.19 -> 0.1.20 ``                                               |
| [`35672b64`](https://github.com/NixOS/nixpkgs/commit/35672b64a80ae8a664305d240917ede0f7f69d69) | `` bilibili: 1.16.3-3 -> 1.16.4-1 ``                                            |
| [`b7a31bd0`](https://github.com/NixOS/nixpkgs/commit/b7a31bd09a06fda60de553b50f5d9467609d5d77) | `` git-absorb: 0.7.0 -> 0.8.0 ``                                                |
| [`c40d0677`](https://github.com/NixOS/nixpkgs/commit/c40d06771ff4ca9c449bd44595fdbe848dd9a108) | `` clouddrive2: 0.8.15 -> 0.8.16 ``                                             |
| [`d1a8eb51`](https://github.com/NixOS/nixpkgs/commit/d1a8eb518fc8c0a553cf784a0d911ef0916aea4b) | `` freetube: 0.23.3 -> 0.23.4 ``                                                |
| [`f65f587b`](https://github.com/NixOS/nixpkgs/commit/f65f587b42e8e3e6e3e720cfa1c21bacac25e839) | `` python312Packages.cx-freeze: 8.0.0 -> 8.2.0 ``                               |
| [`2c88eb33`](https://github.com/NixOS/nixpkgs/commit/2c88eb3331d2f5d697b44a5b8a3bd5b0d9f8a8c6) | `` sudo-rs: refactor module ``                                                  |
| [`aa1bfa77`](https://github.com/NixOS/nixpkgs/commit/aa1bfa77bd7607400186d4a312fd30326363f594) | `` yandex-cloud: 0.146.1 -> 0.147.0 ``                                          |
| [`c31fc218`](https://github.com/NixOS/nixpkgs/commit/c31fc21824c9b397bdc27c005555632eb57b24ad) | `` cargo-semver-checks: 0.40.0 -> 0.41.0 ``                                     |
| [`05f9554f`](https://github.com/NixOS/nixpkgs/commit/05f9554f6ccc2cab1bd4e2e82e33978ec989e9d1) | `` fulcrum: 1.11.1 -> 1.12.0.1 ``                                               |
| [`b7d20dbe`](https://github.com/NixOS/nixpkgs/commit/b7d20dbed14b3e3418f9bf25305fbd1133d0b312) | `` nixos/exwm: add option to specify Emacs package ``                           |
| [`0657b8a1`](https://github.com/NixOS/nixpkgs/commit/0657b8a1c854c53928af77e0809e7c536a78e8e3) | `` bruno: 2.0.1 -> 2.2.0 ``                                                     |
| [`5ad330ea`](https://github.com/NixOS/nixpkgs/commit/5ad330eaa842f3793160a0b7389fb89b91fa1403) | `` wl-mirror: 0.17.0 -> 0.18.1 ``                                               |
| [`d9f717f6`](https://github.com/NixOS/nixpkgs/commit/d9f717f6e153e6f35213cf67c452937e1ae08901) | `` inv-sig-helper: 0-unstable-2025-04-03 -> 0-unstable-2025-04-23 ``            |
| [`71c787b1`](https://github.com/NixOS/nixpkgs/commit/71c787b1f79076100f7b942c1c0e593e6d4f10d7) | `` spyder: 6.1.0a1 -> 6.1.0a2 ``                                                |
| [`389f944b`](https://github.com/NixOS/nixpkgs/commit/389f944b222d6bd0eb54ee29bd39847276c6c0b3) | `` aider-chat: 0.82.1 -> 0.82.2 ``                                              |
| [`959a1aa1`](https://github.com/NixOS/nixpkgs/commit/959a1aa1ab0d3fb6f28c4c12d0bec4c705c4cfd7) | `` python312Packages.pymilvus: 2.5.6 -> 2.5.7 ``                                |