### PR TITLE
chore(flake/nix-index-database): `69716041` -> `18752471`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745120797,
-        "narHash": "sha256-owQ0VQ+7cSanTVPxaZMWEzI22Q4bGnuvhVjLAJBNQ3E=",
+        "lastModified": 1745725746,
+        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "69716041f881a2af935021c1182ed5b0cc04d40e",
+        "rev": "187524713d0d9b2d2c6f688b81835114d4c2a7c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`18752471`](https://github.com/nix-community/nix-index-database/commit/187524713d0d9b2d2c6f688b81835114d4c2a7c6) | `` update generated.nix to release 2025-04-27-033009 `` |
| [`b2603713`](https://github.com/nix-community/nix-index-database/commit/b2603713d5a3d92d2eaf1532838f3726f8646d60) | `` flake.lock: Update ``                                |