### PR TITLE
chore(flake/home-manager): `2f5819a9` -> `50bb714a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745703610,
-        "narHash": "sha256-KgaGPlmjJItZ+Xf8mSoRmrsso+sf3K54n9oIP9Q17LY=",
+        "lastModified": 1745764360,
+        "narHash": "sha256-GJEUJpZLkczMN6HXD0wdFX6KyDbvZe3v5orUhqEfK6w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f5819a962489e037a57835f63ed6ff8dbc2d5fb",
+        "rev": "50bb714a8259b0c29b6c3429099a3b837771dab4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`50bb714a`](https://github.com/nix-community/home-manager/commit/50bb714a8259b0c29b6c3429099a3b837771dab4) | `` rmpc: add module (#6910) ``   |
| [`ef47f364`](https://github.com/nix-community/home-manager/commit/ef47f36450b36d437f5c2f6953022648d76c0638) | `` flake.lock: Update (#6912) `` |