### PR TITLE
chore(flake/treefmt-nix): `8d404a69` -> `29ec5026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1746216483,
+        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                          |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`29ec5026`](https://github.com/numtide/treefmt-nix/commit/29ec5026372e0dec56f890e50dbe4f45930320fd) | `` fix defaultText for `pkgs` option using `literalMD` (#350) `` |
| [`82bf32e5`](https://github.com/numtide/treefmt-nix/commit/82bf32e541b30080d94e46af13d46da0708609ea) | `` taplo: add option to pass settings (#348) ``                  |
| [`763f1ce0`](https://github.com/numtide/treefmt-nix/commit/763f1ce0dd12fe44ce6a5c6ea3f159d438571874) | `` programs.dprint: update plugins example (#341) (#327) ``      |
| [`d1863f30`](https://github.com/numtide/treefmt-nix/commit/d1863f30d9ca67f679f9c2583d7adf674b5d9b8a) | `` programs.dprint: update plugins example (#341) ``             |
| [`18966808`](https://github.com/numtide/treefmt-nix/commit/189668081607c1abc3af0f10058ae98f0b4eec59) | `` rustfmt: bump edition (#342) ``                               |
| [`fbdcbaa6`](https://github.com/numtide/treefmt-nix/commit/fbdcbaa61875bc98c4156bd01788b53ab690914f) | `` Supress verbose git stuff (#347) ``                           |
| [`746c838a`](https://github.com/numtide/treefmt-nix/commit/746c838afbe0840fdca05d7bf806e74a030803d9) | `` update examples ``                                            |
| [`0769377e`](https://github.com/numtide/treefmt-nix/commit/0769377ee19721d0770ec21073de738b03eb3005) | `` php-cs-fixer: pin to PHP 8.3 ``                               |
| [`ab08744c`](https://github.com/numtide/treefmt-nix/commit/ab08744c2622abe46646d41d4c415c4882c8c0b8) | `` feat: update nixpkgs input ``                                 |
| [`5298eac2`](https://github.com/numtide/treefmt-nix/commit/5298eac276cd1ed18d3d5971938dfc2ab522faa6) | `` fix example of global.excludes ``                             |