### PR TITLE
chore(flake/darwin): `43975d78` -> `760a11c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744478979,
-        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
+        "lastModified": 1746254942,
+        "narHash": "sha256-Y062AuRx6l+TJNX8wxZcT59SSLsqD9EedAY0mqgTtQE=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
+        "rev": "760a11c87009155afa0140d55c40e7c336d62d7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                        |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
| [`a6d73d09`](https://github.com/nix-darwin/nix-darwin/commit/a6d73d09045384a325eabe8827edd95ee3969a58) | `` nix-tools: use replaceVarsWith ``           |
| [`9603417d`](https://github.com/nix-darwin/nix-darwin/commit/9603417da1560d5d2286b1f7b810075f0f6b3067) | `` networking: allow users to override FQDN `` |