### PR TITLE
chore(flake/home-manager): `be7cf170` -> `c54a8ab0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745810134,
-        "narHash": "sha256-WfnYH/i7DFzn4SESQfWviXiNUZjohZhzODqLwKYHIPI=",
+        "lastModified": 1745853192,
+        "narHash": "sha256-ardehuT9qtSXtY1XdOY6fEM3Kf3bQa3LZxxKdAScCnU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "be7cf1709b469a2a2c62169172a167d1fed3509f",
+        "rev": "c54a8ab0d2ea7486eadb14f1dc498817ff164f59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`c54a8ab0`](https://github.com/nix-community/home-manager/commit/c54a8ab0d2ea7486eadb14f1dc498817ff164f59) | `` rofi: remove thiagokokada from maintainers (#6928) `` |
| [`6f974faa`](https://github.com/nix-community/home-manager/commit/6f974faa1962e2ee081635124ab96a1bfacb2f25) | `` gh: add `hosts` option (#6925) ``                     |
| [`69c60b03`](https://github.com/nix-community/home-manager/commit/69c60b035e6bb51a4c5607f184bf64312c294139) | `` kickoff: add module (#6918) ``                        |