### PR TITLE
chore(flake/lovesegfault-vim-config): `cb5e5aec` -> `e968a070`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745798911,
-        "narHash": "sha256-0M9foewKulfiAcEwI/fTx+57Z3dUKb0ksB9fKEd2c1Q=",
+        "lastModified": 1745885391,
+        "narHash": "sha256-9UJEwrZwNP7kSBckF4TIMEFqLt7gyEayNOcD3BySqXE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "cb5e5aecc4ea2bd43ece434b8411751ae1a4c18f",
+        "rev": "e968a070b53ea106bcdaeaf83e8c4602031f3467",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745746098,
-        "narHash": "sha256-3f6vvpa2/8XmzTaJjhUYtedlNMHIjwXJ6C2oWXBTubk=",
+        "lastModified": 1745878358,
+        "narHash": "sha256-YImreQ+dij3mLeqcjuIZZvT13Yscj7O1dxOC/+TZdJM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "89c94d9ea72d7080838981295f9b526eb3a960de",
+        "rev": "7a6c5b48031059ace82ce90b9a279ec243999554",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e968a070`](https://github.com/lovesegfault/vim-config/commit/e968a070b53ea106bcdaeaf83e8c4602031f3467) | `` chore(flake/nixvim): 89c94d9e -> 7a6c5b48 ``      |
| [`b9f280f4`](https://github.com/lovesegfault/vim-config/commit/b9f280f403b9a3154bcb15741f4b8bcf4d46fb18) | `` chore(flake/treefmt-nix): b2b6c027 -> 763f1ce0 `` |