### PR TITLE
chore(flake/home-manager): `1ad12323` -> `84d26211`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745894335,
-        "narHash": "sha256-m47zhftaod/oHOwoVT25jstdcVLhkrVGyvEHKjbnFHI=",
+        "lastModified": 1745977079,
+        "narHash": "sha256-eEOmrgpenIs+JwuCdqgEYly6sdz8vbCQVgvo8dk3DZM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ad123239957d40e11ef66c203d0a7e272eb48aa",
+        "rev": "84d262115e10ad321ef01cd85903d0f5c3ec113f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`84d26211`](https://github.com/nix-community/home-manager/commit/84d262115e10ad321ef01cd85903d0f5c3ec113f) | `` nixos,darwin: add osClass (_class) as a specialArg (#6906) ``               |
| [`9389f373`](https://github.com/nix-community/home-manager/commit/9389f373bee64cc8459253e0ab00635b05c0bcb6) | `` pls: enableAliases -> enableShellIntegration (#6932) ``                     |
| [`e9c80e27`](https://github.com/nix-community/home-manager/commit/e9c80e277b572f642835afbf0d793b72cf49f551) | `` tests/gpg-agent: add pinentry-program test ``                               |
| [`a4c3ce44`](https://github.com/nix-community/home-manager/commit/a4c3ce44fcd65849751caab203c2076b092e7069) | `` gpg-agent: pinentryPackage -> pinentry.package and add pinentry.program` `` |