### PR TITLE
chore(flake/nix-index-database): `18752471` -> `137fd2bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745725746,
-        "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
+        "lastModified": 1746330942,
+        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "187524713d0d9b2d2c6f688b81835114d4c2a7c6",
+        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`137fd2bd`](https://github.com/nix-community/nix-index-database/commit/137fd2bd726fff343874f85601b51769b48685cc) | `` update generated.nix to release 2025-05-04-033656 ``                      |
| [`1a67f9bd`](https://github.com/nix-community/nix-index-database/commit/1a67f9bd3d2de450cbc81ffea8de0fe4a59bf189) | `` flake.lock: Update ``                                                     |
| [`4181625d`](https://github.com/nix-community/nix-index-database/commit/4181625d0140d261b62bbac10b4d3dfbad03f806) | `` Revert "treewide: disable programs.nix-index.enable option by default" `` |
| [`fcd80500`](https://github.com/nix-community/nix-index-database/commit/fcd8050007dabcc7f17a31407882d90f3c10a9c2) | `` treewide: disable programs.nix-index.enable option by default ``          |