### PR TITLE
chore(flake/stylix): `b4d3137c` -> `ce5fcf85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746065148,
-        "narHash": "sha256-NR8JCOo9BrK0T7iPmNKR+fa/zS+do+GgAMVg4fwMvYM=",
+        "lastModified": 1746455300,
+        "narHash": "sha256-SxHatwTIR1qEqAHJrThUHYM86hauXsJud3o/L+oEyYY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b4d3137c5ce960073a991bd99a333cad1b233101",
+        "rev": "ce5fcf851d6546a24e5b5b17ee7051b4b384be79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                            |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`ce5fcf85`](https://github.com/danth/stylix/commit/ce5fcf851d6546a24e5b5b17ee7051b4b384be79) | `` kde: apply theme without GUI session and ignore failures (#848) ``              |
| [`6c8b77a7`](https://github.com/danth/stylix/commit/6c8b77a7f5c1ff7059c4b6d749ace3b6f083e4bb) | `` qutebrowser: do not enable darkmode (#1184) ``                                  |
| [`70f331c8`](https://github.com/danth/stylix/commit/70f331c8e7da588e07e70cef15a114f9fcec3cee) | `` stylix: use lib.modules.importApply (#1185) ``                                  |
| [`340a9c54`](https://github.com/danth/stylix/commit/340a9c5455a5690b45dc9812939f824b932bbd7d) | `` mako: remove typo from hm module (#1224) ``                                     |
| [`b8e2e8c7`](https://github.com/danth/stylix/commit/b8e2e8c730abb4b1fc02fea8d9527c15dc69e855) | `` stylix: set _file for overlays (#1214) ``                                       |
| [`003e6770`](https://github.com/danth/stylix/commit/003e6770af4af1e4a49112ecb0ce63c7595f548e) | `` nixvim: move standalone-mode docs from configuration → nixvim readme (#1219) `` |
| [`fa5a34e7`](https://github.com/danth/stylix/commit/fa5a34e7b1a8a7245d54790c6830cb3502c7cb76) | `` mpv: unset custom curtain color for dimming (#1216) ``                          |
| [`b631dffa`](https://github.com/danth/stylix/commit/b631dffa61e04b6d13ef6f1d86020e1e7df4153e) | `` mako: update to new home-manager module (#1211) ``                              |
| [`e51b3e64`](https://github.com/danth/stylix/commit/e51b3e64f90960a523ff39baa271f373cd60321a) | `` lazygit: add testbed (#1191) ``                                                 |
| [`fe3feecf`](https://github.com/danth/stylix/commit/fe3feecf23f8c71067c47a2cfaca5e86c8723450) | `` testbed: wrap autostart command in a shell script (#1204) ``                    |
| [`953e7247`](https://github.com/danth/stylix/commit/953e7247ac340e5036f8af47eaccf1a23f1a0257) | `` mpv: more sensible values (#1199) ``                                            |
| [`bc386295`](https://github.com/danth/stylix/commit/bc38629511dd9cc78c5ca37a6e546fa66330d50e) | `` glance: init nixos module (#1187) ``                                            |
| [`87df2a1d`](https://github.com/danth/stylix/commit/87df2a1d9c0171bcba7dfc3ad9179c40befaf07b) | `` eog: add testbed (#1200) ``                                                     |
| [`716e6669`](https://github.com/danth/stylix/commit/716e6669a9840e4ba0d8deb6ab1d016ef01c475a) | `` {neovim,nixvim}: add transparentBackground.numberLine option (#1178) ``         |