### PR TITLE
chore(flake/home-manager): `355a6b93` -> `1e8c62c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746193516,
-        "narHash": "sha256-7KqthzbP7LbJpo6DtxlTg2Fqcs7HL1iV1vd1mM8q/u0=",
+        "lastModified": 1746204974,
+        "narHash": "sha256-Evu4H0/kzaQoCNLGQTp+JGTqkywzPx0IAo20Ci2zNck=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "355a6b937d07a95cb0b753ef513bcaad09128dea",
+        "rev": "1e8c62c651242fc685b10efc4a48ab777635fb7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`1e8c62c6`](https://github.com/nix-community/home-manager/commit/1e8c62c651242fc685b10efc4a48ab777635fb7f) | `` gpg-agent: avoid console output when using ssh `` |
| [`d6b0c054`](https://github.com/nix-community/home-manager/commit/d6b0c054571a444acd2755b038bb7df5eb7954a7) | `` visidata: add module (#6956) ``                   |