### PR TITLE
chore(flake/lovesegfault-vim-config): `a30c3bfb` -> `c1aa4902`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746230916,
-        "narHash": "sha256-QlNR/z/39OT/GVbE9M/9kzSSRIi1Tie0wHflhZPQVXo=",
+        "lastModified": 1746317374,
+        "narHash": "sha256-xubKfQtory3Bs0AB/uyZeW9DZeQI7v4zbtli49sxteU=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "a30c3bfba3fb601d5e66db8c3e6d342d6f613dc8",
+        "rev": "c1aa4902a36c4a5ef5200cba70a5799e0fa8be5c",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746221140,
-        "narHash": "sha256-lXFXddrfTY47kF3IGmUQHgJssvGnYY5T4luL+1UmCkc=",
+        "lastModified": 1746309817,
+        "narHash": "sha256-oqOpTyjdeY+LP+WiU9LxGdZ/bZ9YK7MNzNMDUw98kPM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4b27678512c4b8a3c16676fd6d5d885f2fb84cb3",
+        "rev": "c978122396a4208bf1965d346b7456e7256fe70c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`c1aa4902`](https://github.com/lovesegfault/vim-config/commit/c1aa4902a36c4a5ef5200cba70a5799e0fa8be5c) | `` chore(flake/nixpkgs): f02fddb8 -> 7a2622e2 `` |
| [`0b0f9d88`](https://github.com/lovesegfault/vim-config/commit/0b0f9d8896141239e47f22eab63e65f5af425e2b) | `` chore(flake/nixvim): 4b276785 -> c9781223 ``  |
| [`e7737ee6`](https://github.com/lovesegfault/vim-config/commit/e7737ee6642c1a43708d04aa23e0b5881238c440) | `` chore(flake/nixpkgs): 46e634be -> f02fddb8 `` |