### PR TITLE
chore(flake/home-manager): `c0962eee` -> `8a318641`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746065148,
-        "narHash": "sha256-NR8JCOo9BrK0T7iPmNKR+fa/zS+do+GgAMVg4fwMvYM=",
+        "lastModified": 1746455300,
+        "narHash": "sha256-SxHatwTIR1qEqAHJrThUHYM86hauXsJud3o/L+oEyYY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b4d3137c5ce960073a991bd99a333cad1b233101",
+        "rev": "ce5fcf851d6546a24e5b5b17ee7051b4b384be79",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746243165,
-        "narHash": "sha256-DQycVmlyLQNLjLJ/FzpokVmbxGQ8HjQQ4zN4nyq2vII=",
+        "lastModified": 1746413188,
+        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0962eeeabfb8127713f859ec8a5f0e86dead0f2",
+        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
         "type": "github"
       },
       "original": {

--- a/hosts/hilbert/default.nix
+++ b/hosts/hilbert/default.nix
@@ -37,7 +37,7 @@
       '';
     };
     git.userEmail = lib.mkForce "bemeurer@amazon.com";
-    zsh.initExtraFirst = ''
+    zsh.initContent = lib.mkOrder 0 ''
       if [[ "$ZSH_VERSION" != "${config.programs.zsh.package.version}" ]]; then
         exec "${config.programs.zsh.package}/bin/zsh"
       fi

--- a/hosts/popper/default.nix
+++ b/hosts/popper/default.nix
@@ -37,7 +37,7 @@
       '';
     };
     git.userEmail = lib.mkForce "bemeurer@amazon.com";
-    zsh.initExtraFirst = ''
+    zsh.initContent = lib.mkOrder 0 ''
       if [[ "$ZSH_VERSION" != "${config.programs.zsh.package.version}" ]]; then
         exec "${config.programs.zsh.package}/bin/zsh"
       fi

--- a/users/bemeurer/graphical/sway/mako.nix
+++ b/users/bemeurer/graphical/sway/mako.nix
@@ -9,13 +9,15 @@
     in
     {
       enable = true;
-      defaultTimeout = 30 * 1000; # millis
-      iconPath = "${homeIcons}:${systemIcons}:${homePixmaps}:${systemPixmaps}";
-      icons = true;
-      maxIconSize = 96;
-      maxVisible = 3;
-      sort = "-time";
-      width = 500;
+      settings = {
+        icons = true;
+        icon-path = "${homeIcons}:${systemIcons}:${homePixmaps}:${systemPixmaps}";
+        default-timeout = 30 * 1000; # millis
+        max-icon-size = 96;
+        max-visible = 3;
+        sort = "-time";
+        width = 500;
+      };
     };
 
   systemd.user.services.mako = {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`8a318641`](https://github.com/nix-community/home-manager/commit/8a318641ac13d3bc0a53651feaee9560f9b2d89a) | `` sway-easyfocus: add module (#6976) ``                                   |
| [`5f1f4725`](https://github.com/nix-community/home-manager/commit/5f1f472565ee59b5001ae5022bbb1a9a64239f91) | `` mako: use ini atom type (#6977) ``                                      |
| [`1a1793f6`](https://github.com/nix-community/home-manager/commit/1a1793f6d940d22c6e49753548c5b6cb7dc5545d) | `` ghostty: fix config syntax file location on darwin (#6970) ``           |
| [`8167af65`](https://github.com/nix-community/home-manager/commit/8167af657c0aa58fbe1fabfe7cce0520380c1bb3) | `` mako: fix criterias typo (#6968) ``                                     |
| [`3a185176`](https://github.com/nix-community/home-manager/commit/3a185176e48206026b8c1e6dc3f3a37ffff4b9f7) | `` flake.lock: Update (#6969) ``                                           |
| [`621986fe`](https://github.com/nix-community/home-manager/commit/621986fed37c5d0cb8df010ed8369694dc47c09b) | `` i3bar-river: add module (#6967) ``                                      |
| [`64f7d5e6`](https://github.com/nix-community/home-manager/commit/64f7d5e6b94e2e66e3b344fe8e002c9da97a57b1) | `` wofi: allow path to style.css (#6966) ``                                |
| [`d1bbab6b`](https://github.com/nix-community/home-manager/commit/d1bbab6b04d865d759505f33a5c6743bbb544074) | `` mako: refactor (#6948) ``                                               |
| [`94f4c666`](https://github.com/nix-community/home-manager/commit/94f4c66660faa994676176d1d3d94618a796c39e) | `` tests/darwinScrublist: add more packages (#6965) ``                     |
| [`75268f62`](https://github.com/nix-community/home-manager/commit/75268f62525920c4936404a056f37b91e299c97e) | `` tests: enable all firefox tests on darwin (plus derivations) (#6960) `` |
| [`929f8ee8`](https://github.com/nix-community/home-manager/commit/929f8ee8362aec0a2bcbcbbd485e86e701496a73) | `` thunderbird: deprecate darwinSetupWarning option (#6531) ``             |