### PR TITLE
chore(flake/nix-fast-build): `22c2ade4` -> `e9476294`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746333004,
-        "narHash": "sha256-RZyb7mJ5e9HfYVkiA6qLeNR0UZKOUI2VrkXf1nyb7zo=",
+        "lastModified": 1746390439,
+        "narHash": "sha256-b9kKckpMGXAWwwRcD4Y9PRQH2GPCEmJ6M4FK9S28ykI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "22c2ade40d443015f8adb5707bc9873157a9a158",
+        "rev": "e947629455fa6f36701f5c39669d0e5a634324dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`e9476294`](https://github.com/Mic92/nix-fast-build/commit/e947629455fa6f36701f5c39669d0e5a634324dd) | `` chore(deps): update nixpkgs digest to 0ab7cd9 (#137) `` |