### PR TITLE
chore(flake/disko): `d0c543d7` -> `7b636423`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745812220,
-        "narHash": "sha256-hotBG0EJ9VmAHJYF0yhWuTVZpENHvwcJ2SxvIPrXm+g=",
+        "lastModified": 1746390295,
+        "narHash": "sha256-TAfIbY/OWEn/3Kvq6L0NkN3AaMoIo2FPQLLj/W3+cI4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d0c543d740fad42fe2c035b43c9d41127e073c78",
+        "rev": "7b636423586635985f91bd2f0f0cb0511c340627",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`7b636423`](https://github.com/nix-community/disko/commit/7b636423586635985f91bd2f0f0cb0511c340627) | `` Make bcachefs subvolumes boot-time mount tests pass + more tests `` |