### PR TITLE
chore(flake/home-manager): `8a318641` -> `a5159823`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746413188,
-        "narHash": "sha256-i6BoiQP0PasExESQHszC0reQHfO6D4aI2GzOwZMOI20=",
+        "lastModified": 1746727295,
+        "narHash": "sha256-0364XVBdfEA8rWfqEPvsgBqGFfq5r9LAo9CS9tvT7tg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8a318641ac13d3bc0a53651feaee9560f9b2d89a",
+        "rev": "a51598236f23c89e59ee77eb8e0614358b0e896c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`a5159823`](https://github.com/nix-community/home-manager/commit/a51598236f23c89e59ee77eb8e0614358b0e896c) | `` lutris: add module (#6964) ``                                                    |
| [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) | `` wayprompt: init module (#7002) ``                                                |
| [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) | `` rofi: modes optional (#7003) ``                                                  |
| [`cea975d4`](https://github.com/nix-community/home-manager/commit/cea975d46d08293eae3ad0d9f16207f1ce2dfc81) | `` rofi: modes option (#6115) ``                                                    |
| [`2ede089d`](https://github.com/nix-community/home-manager/commit/2ede089d11b68d7abfcb022c60cf71249504c3b0) | `` git: configure patdiff through [patdiff] git section (#6978) ``                  |
| [`50894120`](https://github.com/nix-community/home-manager/commit/50894120e8ac792a5d3046d23e4e4c4ef32cf09c) | `` modules/modules.nix: drop duplicate entry (#7000) ``                             |
| [`ec71b516`](https://github.com/nix-community/home-manager/commit/ec71b5162848e6369bdf2be8d2f1dd41cded88e8) | `` sbt: Scoping credentials to ThisBuild (#6026) ``                                 |
| [`a8e2d08f`](https://github.com/nix-community/home-manager/commit/a8e2d08ffdc68123316b57cf2ad51244c7eca335) | `` alot: allow commas in maildir path (#6989) ``                                    |
| [`708074ae`](https://github.com/nix-community/home-manager/commit/708074ae6db9e0468e4f48477f856e8c2d059795) | `` treewide: Prevent IFD by default ``                                              |
| [`ae442685`](https://github.com/nix-community/home-manager/commit/ae442685297517b5fcdd85787d95c3927e4aabf5) | `` prezto: Remove unnecessary import-from-derivation ``                             |
| [`f3384e68`](https://github.com/nix-community/home-manager/commit/f3384e688da328fcec78c6a437566b40fd6f8a18) | `` tmpfiles: also remove files that need to be removed during activation (#6980) `` |
| [`1d5fb9da`](https://github.com/nix-community/home-manager/commit/1d5fb9da1061e30012ee68675a489ac5780c1877) | `` flake.lock: Update (#6992) ``                                                    |
| [`5da6eafc`](https://github.com/nix-community/home-manager/commit/5da6eafceb2ea15b39de54d853cc224409e4c1a9) | `` treewide: remove unused code (#6985) ``                                          |
| [`76274a21`](https://github.com/nix-community/home-manager/commit/76274a2130db36a6754f0bf262daac63f2afbd1e) | `` tests/man: index.bt -> index.db ``                                               |
| [`ba454389`](https://github.com/nix-community/home-manager/commit/ba45438996c3bc6c245af9833904c12836923b8d) | `` tests/darwinScrublist: add newsboat ``                                           |
| [`f78a171f`](https://github.com/nix-community/home-manager/commit/f78a171fe4e6a6e0ae5c33c5be8abe72e8a43eb3) | `` mako: use toKebabCase for option transformation ``                               |
| [`327885ce`](https://github.com/nix-community/home-manager/commit/327885ceae1aecc9b966e9370eb4043d2c169b0c) | `` lib/deprecations: add mkSettingsRenamedOptionModules with transform parameter `` |
| [`94d32062`](https://github.com/nix-community/home-manager/commit/94d32062ca42d8149cd77d2b3e3ec5c8c4103084) | `` lib/strings: add toCaseWithSeparator ``                                          |
| [`9cebc4cb`](https://github.com/nix-community/home-manager/commit/9cebc4cb8af0d4f71acadbb5f53bee1e406cec03) | `` lib/strings: add toKebabCase ``                                                  |
| [`e121442b`](https://github.com/nix-community/home-manager/commit/e121442b6583fdbfd968cca6fb7def58af0b6288) | `` lib/strings: add toSnakeCase ``                                                  |
| [`35535345`](https://github.com/nix-community/home-manager/commit/35535345be0be7dbae2e9b787c6cf790f8c893d5) | `` television: add shell integrations (#6983) ``                                    |
| [`60964ff8`](https://github.com/nix-community/home-manager/commit/60964ff845ec5965cde978377f3f73bcef84abe5) | `` mako: fix example config (#6987) ``                                              |