### PR TITLE
chore(flake/disko): `b5d1320e` -> `85555d27`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746411114,
-        "narHash": "sha256-mLlkVX1kKbAa/Ns5u26wDYw4YW4ziMFM21fhtRmfirU=",
+        "lastModified": 1746729224,
+        "narHash": "sha256-9R4sOLAK1w3Bq54H3XOJogdc7a6C2bLLmatOQ+5pf5w=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "b5d1320ebc2f34dbea4655f95167f55e2130cdb3",
+        "rev": "85555d27ded84604ad6657ecca255a03fd878607",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`85555d27`](https://github.com/nix-community/disko/commit/85555d27ded84604ad6657ecca255a03fd878607) | `` remove broken flakestry github action ``                              |
| [`6ca7c94d`](https://github.com/nix-community/disko/commit/6ca7c94d6a50eae797ba8f73773d5b37b1bbb1ca) | `` create-release: indent version.nix according to nixfmt ``             |
| [`14afb101`](https://github.com/nix-community/disko/commit/14afb10129f010809fa3422438777998b7f04be4) | `` release: reset released flag ``                                       |
| [`a956a7c2`](https://github.com/nix-community/disko/commit/a956a7c25513db89d0d8a7ac22c721423080d4aa) | `` release: v1.12.0 ``                                                   |
| [`6bb82b77`](https://github.com/nix-community/disko/commit/6bb82b77ce140137177e30df067759931ab60a73) | `` luks: drop unnecessary subshell ``                                    |
| [`06fb9283`](https://github.com/nix-community/disko/commit/06fb9283caf5a8e86bd140de014ff0011bbe8ff4) | `` Unlock luks devices once and only once ``                             |
| [`69265ccd`](https://github.com/nix-community/disko/commit/69265ccde5c29ffe8632dcf94b7d348cbc69d691) | `` Fix _destroy ``                                                       |
| [`cbc1f418`](https://github.com/nix-community/disko/commit/cbc1f418d0cd79bf84aae3490ba8bb6222d8e81d) | `` Improve luks device detection ``                                      |
| [`aa5d53ae`](https://github.com/nix-community/disko/commit/aa5d53aee80eaae33383e9d65b9b1c706be44792) | `` Add disk.destroy option ``                                            |
| [`c7e0b000`](https://github.com/nix-community/disko/commit/c7e0b00007ff6c0e2a6dd5c521aeef22ccdad026) | `` diskoImagesScript: unset NIX_REMOTE ``                                |
| [`aba0ae38`](https://github.com/nix-community/disko/commit/aba0ae38df216a3e0983388c7702ef7fcf93d5e4) | `` fix evaluation of disko-images example ``                             |
| [`b5cfd59e`](https://github.com/nix-community/disko/commit/b5cfd59e9ad08b08fbe8d683be0cc041190938c5) | `` fix documentation on booting disko inside a VM ``                     |
| [`c4fe2d10`](https://github.com/nix-community/disko/commit/c4fe2d108b186ff2126f5d62c67a8fdc5d0cd860) | `` flake.lock: Update ``                                                 |
| [`78d6a136`](https://github.com/nix-community/disko/commit/78d6a1365cde90a479edc9ff7ea5dbd8b2e0cfb8) | `` Use a hard-coded UUID for the failing example to get it to work ``    |
| [`8d789638`](https://github.com/nix-community/disko/commit/8d789638196313791196910770dda94adc1de8ce) | `` fix: addresses: https://github.com/koverstreet/bcachefs/issues/812 `` |