### PR TITLE
chore(flake/stylix): `ce5fcf85` -> `685deb9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746455300,
-        "narHash": "sha256-SxHatwTIR1qEqAHJrThUHYM86hauXsJud3o/L+oEyYY=",
+        "lastModified": 1746575057,
+        "narHash": "sha256-kBlPMNZXPzDG4HUmdqYpvjvVYkoDdDrVvO14cKgHaiU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ce5fcf851d6546a24e5b5b17ee7051b4b384be79",
+        "rev": "685deb9bae2e4c463e953ff39bd54fd448feaf05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                         |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`685deb9b`](https://github.com/danth/stylix/commit/685deb9bae2e4c463e953ff39bd54fd448feaf05) | `` Revert "stylix: bump base16.nix flake" (#1237) ``                            |
| [`e6ea1865`](https://github.com/danth/stylix/commit/e6ea186571a14da8dab46ffc4801ad87a76af6e4) | `` stylix: bump base16.nix flake (#1234) ``                                     |
| [`965865bc`](https://github.com/danth/stylix/commit/965865bc36033ead241e107f486418e6f600d58b) | `` sxiv: add testbed (#1190) ``                                                 |
| [`a2b80b90`](https://github.com/danth/stylix/commit/a2b80b900647f28658a2c9456d9a10ab4aa3b250) | `` doc: direct to all issues instead of open ones in issue templates (#1232) `` |
| [`78a96c5c`](https://github.com/danth/stylix/commit/78a96c5c5a0289d17c0f8be4fa3eef955c780f5c) | `` doc: fix longestFence usage of lib.max (#1231) ``                            |
| [`6e55a894`](https://github.com/danth/stylix/commit/6e55a89494c01ad9be6b90212dc79344b402979e) | `` doc: ensure code blocks are safely fenced (#1218) ``                         |
| [`45aa0e84`](https://github.com/danth/stylix/commit/45aa0e849282dba5979e7bb3d0f6676bbd9dc130) | `` fzf: add testbed (#1201) ``                                                  |