### PR TITLE
chore(flake/nix-fast-build): `3f859bb9` -> `38eecfc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746423884,
-        "narHash": "sha256-LzlXvFmTziZbdJLqQP1YxeeuFo85qglE2sAEDjIEtkE=",
+        "lastModified": 1746689206,
+        "narHash": "sha256-flpLC9bSI7ylfy8hI9gGleG0gt3wtYYFKdJz+Qj6xlA=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "3f859bb966fe65ac15412aaf39387d5e4d10e41b",
+        "rev": "38eecfc45d91aa1e00a740ab39bbd9d33ba5835a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`38eecfc4`](https://github.com/Mic92/nix-fast-build/commit/38eecfc45d91aa1e00a740ab39bbd9d33ba5835a) | `` chore(deps): update nixpkgs digest to 1676224 (#144) `` |
| [`88139228`](https://github.com/Mic92/nix-fast-build/commit/8813922864147f81f1b0d3644f8df6cf24d0d651) | `` chore(deps): update nixpkgs digest to c254c79 (#143) `` |
| [`011c7684`](https://github.com/Mic92/nix-fast-build/commit/011c7684932e9fc89b4251039ec2ed31ab57e518) | `` chore(deps): update nixpkgs digest to 40a6f04 (#142) `` |
| [`3806eebc`](https://github.com/Mic92/nix-fast-build/commit/3806eebcc7c7c9329577ebead0880f287ebfc405) | `` chore(deps): update nixpkgs digest to e7072d1 (#141) `` |
| [`b64c5b0c`](https://github.com/Mic92/nix-fast-build/commit/b64c5b0c5416f5d7824119326a22ada9d565d068) | `` chore(deps): update nixpkgs digest to 5a837cb (#140) `` |
| [`9b271cb4`](https://github.com/Mic92/nix-fast-build/commit/9b271cb42c591a5e031f64d5869fb0212a075bed) | `` chore(deps): update nixpkgs digest to 83c45b9 (#139) `` |