### PR TITLE
chore(flake/nixos-hardware): `a4bb30a9` -> `2ea3ad8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746427242,
-        "narHash": "sha256-KvZ6G5sdBdcrglsqcOx8BT6NpHVMVHc8wssMRhv/+1g=",
+        "lastModified": 1746621361,
+        "narHash": "sha256-T9vOxEqI1j1RYugV0b9dgy0AreiZ9yBDKZJYyclF0og=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a4bb30a9000cf0444ecc8fdca8096d072f77f9e8",
+        "rev": "2ea3ad8a1f26a76f8a8e23fc4f7757c46ef30ee5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`aaa8e548`](https://github.com/NixOS/nixos-hardware/commit/aaa8e548c34cd261deb760f1641957d6926c7913) | `` E14-intel: add gen4 configuration ``                          |
| [`9b383cd3`](https://github.com/NixOS/nixos-hardware/commit/9b383cd3f4364ee37728978c8daa33e4f4b2f5f1) | `` Adding gen6 support for lenovo thinkpad e14 (#1470) ``        |
| [`7d9552ef`](https://github.com/NixOS/nixos-hardware/commit/7d9552ef6b02da7b8fafe426c0db5358ab8c4009) | `` Replace symlink references by real path and delete symlink `` |