### PR TITLE
chore(flake/stylix): `685deb9b` -> `b06c1cb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746575057,
-        "narHash": "sha256-kBlPMNZXPzDG4HUmdqYpvjvVYkoDdDrVvO14cKgHaiU=",
+        "lastModified": 1746789001,
+        "narHash": "sha256-aNDOPgv642K5UU0RD87PB7tRFwxmCYJ6sL5m6dCnwKY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "685deb9bae2e4c463e953ff39bd54fd448feaf05",
+        "rev": "b06c1cb60ab83885fe62359257d9d982deea45ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`b06c1cb6`](https://github.com/danth/stylix/commit/b06c1cb60ab83885fe62359257d9d982deea45ad) | `` stylix: simplify font options & use `literalExpression` default packages (#1225) `` |