### PR TITLE
chore(flake/home-manager): `a5159823` -> `e95a7c5b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746727295,
-        "narHash": "sha256-0364XVBdfEA8rWfqEPvsgBqGFfq5r9LAo9CS9tvT7tg=",
+        "lastModified": 1746798521,
+        "narHash": "sha256-axfz/jBEH9XHpS7YSumstV7b2PrPf7L8bhWUtLBv3nA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a51598236f23c89e59ee77eb8e0614358b0e896c",
+        "rev": "e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`e95a7c5b`](https://github.com/nix-community/home-manager/commit/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) | `` Revert "direnv: update nushell env conversion logic (#6999)" (#7014) ``        |
| [`b706037a`](https://github.com/nix-community/home-manager/commit/b706037a60acc727f1b5c037e84dc61a35ef1db1) | `` distrobox: make systemd unit optional (#7007) ``                               |
| [`e9bd9568`](https://github.com/nix-community/home-manager/commit/e9bd9568db6b627155664090ea39a1b6ece0af47) | `` jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms (#6994) ``  |
| [`f2b5bf55`](https://github.com/nix-community/home-manager/commit/f2b5bf55aa439a6c517adfcb9715a5a952020c5f) | `` direnv: update nushell env conversion logic (#6999) ``                         |
| [`3be7c80a`](https://github.com/nix-community/home-manager/commit/3be7c80a11b3b1c3c14d0061dfaa44f1c96673ff) | `` wayprompt: add news entry for linux (#7009) ``                                 |
| [`cbd8e8e9`](https://github.com/nix-community/home-manager/commit/cbd8e8e9a040db35d6a74a8f8903a32a2e47b8c5) | `` PR_TEMPLATE: update example for module maintainer (#7011) ``                   |
| [`8f723d61`](https://github.com/nix-community/home-manager/commit/8f723d613588e4a55e8838197741727e4dea4944) | `` lutris: fix runners not working due to wrong config name (#7008) ``            |
| [`9e10d73c`](https://github.com/nix-community/home-manager/commit/9e10d73cea313708e9f9b98114963fbaac6ec99b) | `` onlyoffice: use pkgs.formats and use mkIf in config file generation (#7006) `` |
| [`ce1ba0e9`](https://github.com/nix-community/home-manager/commit/ce1ba0e9f34df84e1e1d7c8ab3d4c948e81f0e20) | `` neovide: fix error when no settings are declared (#7005) ``                    |
| [`8d2ee399`](https://github.com/nix-community/home-manager/commit/8d2ee39915119dead6b794f7d2b63d6a1554941d) | `` waveterm: add module (#7004) ``                                                |
| [`5d428b68`](https://github.com/nix-community/home-manager/commit/5d428b68dd56b98f023f5360002e3fe4b66a2b63) | `` docs: update filename of generated HTML manual (#7010) ``                      |