### PR TITLE
chore(flake/lanzaboote): `fa81496a` -> `8f27abb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1746717538,
-        "narHash": "sha256-mBPMdT19oLO6zRxTiuoKIKPQ4smlD8om3CZC3F34ZNo=",
+        "lastModified": 1746809399,
+        "narHash": "sha256-rMYfYaUpKuyMpDnodIfgFOnj6Wn0duItZvG4kQODcZo=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "fa81496ad7359f62deec2f52882479250b237fc7",
+        "rev": "8f27abb5e623d83db4988ee3e864df48181e7c30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                           |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`08d2d49e`](https://github.com/nix-community/lanzaboote/commit/08d2d49e940ed8197380ef5a4c375d53de2ecd35) | `` mark boot.lanzaboote.enrollKeys for testing `` |