### PR TITLE
chore(flake/nix-fast-build): `1e462e81` -> `a803b722`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746833729,
-        "narHash": "sha256-Fcag3XPLQ6ZMa0nHicrf3XCwhKbfPcmWz/8Jpw54cks=",
+        "lastModified": 1746887075,
+        "narHash": "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "1e462e81133f0d9137079f89845485ada5b15f3e",
+        "rev": "a803b722190a857768b06b4a804aee53c26ee49b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`a803b722`](https://github.com/Mic92/nix-fast-build/commit/a803b722190a857768b06b4a804aee53c26ee49b) | `` chore(deps): update nixpkgs digest to 5f833dd (#148) `` |