### PR TITLE
chore(flake/nix-index-database): `137fd2bd` -> `e9b21b01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746330942,
-        "narHash": "sha256-ShizFaJCAST23tSrHHtFFGF0fwd72AG+KhPZFFQX/0o=",
+        "lastModified": 1746934494,
+        "narHash": "sha256-3n6i+F0sDASjkhbvgFDpPDZGp7z19IrRtjfF9TwJpCA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "137fd2bd726fff343874f85601b51769b48685cc",
+        "rev": "e9b21b01e4307176b9718a29ac514838e7f6f4ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e9b21b01`](https://github.com/nix-community/nix-index-database/commit/e9b21b01e4307176b9718a29ac514838e7f6f4ff) | `` flake.lock: Update `` |