### PR TITLE
chore(flake/nix-fast-build): `c9c3cd5e` -> `285f2b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746941085,
-        "narHash": "sha256-ZMwYbtNoNVqccgyXcU0J9TiG6enBSusrUicfwhYy+sk=",
+        "lastModified": 1746962684,
+        "narHash": "sha256-p3oKztqwv6QF3e1/EbdEpASwt9yPJcjuYpwEnII11kA=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "c9c3cd5e340b53a6e4489297e4430ea5e1496e0b",
+        "rev": "285f2b83cceb85b163f185bf36394f3baef3f44e",
         "type": "github"
       },
       "original": {
@@ -902,11 +902,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1746961151,
+        "narHash": "sha256-jCKoQycs5GB04JeGdj5kdpLJuKukJp+8H91EzJuMBlM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "4819332186ee7058f9973ab5c2f245d6936e9530",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`285f2b83`](https://github.com/Mic92/nix-fast-build/commit/285f2b83cceb85b163f185bf36394f3baef3f44e) | `` chore(deps): update treefmt-nix digest to 4819332 (#150) `` |