### PR TITLE
chore(flake/treefmt-nix): `29ec5026` -> `48193321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -944,11 +944,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746216483,
-        "narHash": "sha256-4h3s1L/kKqt3gMDcVfN8/4v2jqHrgLIe4qok4ApH5x4=",
+        "lastModified": 1746961151,
+        "narHash": "sha256-jCKoQycs5GB04JeGdj5kdpLJuKukJp+8H91EzJuMBlM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "29ec5026372e0dec56f890e50dbe4f45930320fd",
+        "rev": "4819332186ee7058f9973ab5c2f245d6936e9530",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                       |
| ---------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`966db02d`](https://github.com/numtide/treefmt-nix/commit/966db02dee09fea0b1c81e035d0f632882b46aaf) | `` just: format justfile in subdirectories `` |