### PR TITLE
chore(flake/nix-fast-build): `2b94af42` -> `6f12fbf0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746990252,
-        "narHash": "sha256-w+px507d1d2xqDoH6KSYBb6WXAZL5LsBHTSCxw+nKFw=",
+        "lastModified": 1747044904,
+        "narHash": "sha256-SGZ/0YmsS7gXzzDOxZR1LxCvu5sTLQ3kvQrSqOZGJkk=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "2b94af42cb355865c8bfc4b7068681a4dbb171ef",
+        "rev": "6f12fbf083586fce01b8bfdc9df747eb3672b43f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`6f12fbf0`](https://github.com/Mic92/nix-fast-build/commit/6f12fbf083586fce01b8bfdc9df747eb3672b43f) | `` chore(deps): update nixpkgs digest to e4f52f3 (#152) `` |