### PR TITLE
chore(flake/home-manager): `fb061f55` -> `f0a7db5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747021744,
-        "narHash": "sha256-IDsM/9/tHQBlhG3tXI2fTM84AUN1uRa7JDPT1LMlGes=",
+        "lastModified": 1747081732,
+        "narHash": "sha256-VnR33UmH0KzvTuVg+6oYkDVpnPuHanQisNUXytCRBPQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52",
+        "rev": "f0a7db5ec1d369721e770a45e4d19f8e48186a69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`f0a7db5e`](https://github.com/nix-community/home-manager/commit/f0a7db5ec1d369721e770a45e4d19f8e48186a69) | `` direnv: update nushell env conversion logic (#7015) `` |
| [`0b24658e`](https://github.com/nix-community/home-manager/commit/0b24658ec09908e5a6515cacc54f29d589c8423b) | `` halloy: add themes option (#7043) ``                   |
| [`58795314`](https://github.com/nix-community/home-manager/commit/587953146298b13e897b827181967ff2298fb63c) | `` wayprompt: tweak example (#7040) ``                    |