### PR TITLE
chore(flake/stylix): `df51c62e` -> `0c0df649`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -750,11 +750,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746901728,
-        "narHash": "sha256-zXF+T/5YkVeblmmjHSgef6xApYACP84sy52vGMS1SL8=",
+        "lastModified": 1747070959,
+        "narHash": "sha256-QJ8kMmkfUmDiJv/aq9obRPG5Z/fB6nXrejJA003+Hd0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "df51c62e43a841c01806d3db62dde7bf833879c5",
+        "rev": "0c0df649f7dcbc597fa1d47e8f9a5c2cedab6145",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`0c0df649`](https://github.com/danth/stylix/commit/0c0df649f7dcbc597fa1d47e8f9a5c2cedab6145) | `` wayprompt: add myself as maintainer ``                               |
| [`787a156f`](https://github.com/danth/stylix/commit/787a156f461b09388150dd2b82f977914968c05a) | `` wayprompt: capitalize name ``                                        |
| [`e020f1e8`](https://github.com/danth/stylix/commit/e020f1e8159cc8999eb3c0b81c8f0711394d2dc2) | `` wayprompt: support opacity ``                                        |
| [`89ebfe95`](https://github.com/danth/stylix/commit/89ebfe959b94f3a9828f97cca8def137a6243aae) | `` wayprompt: drop generation of 0x prefixes ``                         |
| [`6b830955`](https://github.com/danth/stylix/commit/6b8309550e50358b63366d9bf3edb7ef08b9a7cc) | `` wayprompt: init (#1250) ``                                           |
| [`77696d77`](https://github.com/danth/stylix/commit/77696d77ae58afa41ddd93365a11dad5f906ec02) | `` yazi: more color tweaks (#1245) ``                                   |
| [`aaf976a8`](https://github.com/danth/stylix/commit/aaf976a8198be266a5d33b202e1a68363983f4a0) | `` stylix: emphasize compliance with Nixpkgs maintainer list (#1254) `` |
| [`91f71c13`](https://github.com/danth/stylix/commit/91f71c13b52610c9d27d107500489d0c5c1573e3) | `` foliate: init (#1203) ``                                             |
| [`ad7dcca7`](https://github.com/danth/stylix/commit/ad7dcca79d966383807625297bb14390637297cf) | `` ci: add labeler action (#1137) ``                                    |
| [`382ec4b3`](https://github.com/danth/stylix/commit/382ec4b31a1c5ce7bac233d31fbe018b17d974b0) | `` stylix: use call package for check-maintainers-sorted (#1249) ``     |
| [`ce6c8460`](https://github.com/danth/stylix/commit/ce6c8460e7359649f96a34ded63008b2b9f8b578) | `` stylix: update base16 (#1238) ``                                     |