### PR TITLE
chore(flake/nixos-hardware): `3c5e1267` -> `d1d68fe8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1746814339,
-        "narHash": "sha256-hf2lICJzwACWuzHCmZn5NI6LUAOgGdR1yh8ip+duyhk=",
+        "lastModified": 1747083103,
+        "narHash": "sha256-dMx20S2molwqJxbmMB4pGjNfgp5H1IOHNa1Eby6xL+0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3c5e12673265dfb0de3d9121420c0c2153bf21e0",
+        "rev": "d1d68fe8b00248caaa5b3bbe4984c12b47e0867d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`16023fe3`](https://github.com/NixOS/nixos-hardware/commit/16023fe3d4d48a79deaa3ebd9385716ef038a211) | `` lenovo/yoga/7/14ILL10: init `` |
| [`0d3ca753`](https://github.com/NixOS/nixos-hardware/commit/0d3ca7531030e2a405e6e7f885cc07681cac6aba) | `` add asus-rog-strix-g533zw ``   |