### PR TITLE
chore(flake/nixos-hardware): `d1d68fe8` -> `e81fd167`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747083103,
-        "narHash": "sha256-dMx20S2molwqJxbmMB4pGjNfgp5H1IOHNa1Eby6xL+0=",
+        "lastModified": 1747129300,
+        "narHash": "sha256-L3clA5YGeYCF47ghsI7Tcex+DnaaN/BbQ4dR2wzoiKg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d1d68fe8b00248caaa5b3bbe4984c12b47e0867d",
+        "rev": "e81fd167b33121269149c57806599045fd33eeed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ff949f78`](https://github.com/NixOS/nixos-hardware/commit/ff949f78d6b04a5294ff059cf7cdce9638ea8a86) | `` ideacentr-k330: include nvidia-fermi architecture ``     |
| [`5aa1b0f0`](https://github.com/NixOS/nixos-hardware/commit/5aa1b0f04942d01cb51b4e865d2ca161ce14a818) | `` dell-xps-15-9530-nvidia: include ada-lovelace profile `` |
| [`91dc75a8`](https://github.com/NixOS/nixos-hardware/commit/91dc75a805501815969342ad1672e9b553d1f95b) | `` fix system.stateVersion for tests ``                     |
| [`d371c70b`](https://github.com/NixOS/nixos-hardware/commit/d371c70b454935c787c237550bc21debab684f30) | `` docs/CONTRIBUTING: replace bors with mergify ``          |
| [`b83e517b`](https://github.com/NixOS/nixos-hardware/commit/b83e517bfc92868c6e7e216d4373ea3edb19d876) | `` bump tests/flake.nix to 24.11 ``                         |