### PR TITLE
chore(flake/stylix): `b63f6640` -> `14667935`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747099958,
-        "narHash": "sha256-erIu7Nw2mPeh9xITU+eZLn1Hk4IvDIStUrTm142HEro=",
+        "lastModified": 1747170169,
+        "narHash": "sha256-LRP/8RejiA1IkdN7WEcmEMQC+FSoqyvZ5UYfU12JjiI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b63f66408631fcc04d74e2ad61cab1b1cfd7d587",
+        "rev": "1466793570f22c56fc9f606151bcb306fcaa3551",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`14667935`](https://github.com/danth/stylix/commit/1466793570f22c56fc9f606151bcb306fcaa3551) | `` stylix: use keep-sorted (#1263) ``  |
| [`2fbe00ae`](https://github.com/danth/stylix/commit/2fbe00aebe3653a84862395bc77c69038a1b4f0f) | `` doc: wrap to width of 80 (#1262) `` |