### PR TITLE
chore(flake/home-manager): `b44c39cf` -> `7c1cefb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747181178,
-        "narHash": "sha256-Svvx3mlfGRyta0yMQmqW6FyAKtCH7KQxlcRnJPh/k6Q=",
+        "lastModified": 1747184352,
+        "narHash": "sha256-GBZulv50wztp5cgc405t1uOkxQYhSkMqeKLI+iSrlpk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b44c39cf4618ccf58df2b68827ca95a3fecf0655",
+        "rev": "7c1cefb98369cc85440642fdccc1c1394ca6dd2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) | `` zsh: avoid IFD while sourcing prezto ``                        |
| [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) | `` zsh: consider zsh.{profile,login,logout,env}Extra in prezto `` |