### PR TITLE
chore(flake/tinted-schemes): `28c26a62` -> `8c00a361`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -862,11 +862,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744974599,
-        "narHash": "sha256-Fg+rdGs5FAgfkYNCs74lnl8vkQmiZVdBsziyPhVqrlY=",
+        "lastModified": 1747207144,
+        "narHash": "sha256-pHfbM7mF2mF1beycGAmA+7Jt+vmJ2reU7BvRfKURyaY=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "28c26a621123ad4ebd5bbfb34ab39421c0144bdd",
+        "rev": "8c00a361a99b6d356db9572240053a3f8716ea68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                               |
| ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8c00a361`](https://github.com/tinted-theming/schemes/commit/8c00a361a99b6d356db9572240053a3f8716ea68) | `` Change base06 to lowercase in base16-vice (#56) `` |