### PR TITLE
chore(flake/nix-fast-build): `a132dbcf` -> `689861d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747118174,
-        "narHash": "sha256-FfamGaHSmd5qDPK42qN25pvch1Y7kWGzSi0lNs2VjpY=",
+        "lastModified": 1747203326,
+        "narHash": "sha256-c6bwNqfzG0zK016zFo+iPeEKbibPacaEA+FqNpSvkhk=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "a132dbcf4d172216df12e971308a7e78b29f71f7",
+        "rev": "689861d60a91614c1010bb6b5b006c18f115a9dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`689861d6`](https://github.com/Mic92/nix-fast-build/commit/689861d60a91614c1010bb6b5b006c18f115a9dd) | `` chore(deps): update nixpkgs digest to 3a00b4e (#155) `` |