### PR TITLE
chore(flake/stylix): `14667935` -> `98444a94`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747170169,
-        "narHash": "sha256-LRP/8RejiA1IkdN7WEcmEMQC+FSoqyvZ5UYfU12JjiI=",
+        "lastModified": 1747248043,
+        "narHash": "sha256-uEEhchsf9l2u7JJk04GZIMRIkuCeJFPSAuTMByqYfIQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1466793570f22c56fc9f606151bcb306fcaa3551",
+        "rev": "98444a942a85072baf12c4a1c4cd5ef9531c8ab0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                          |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`98444a94`](https://github.com/danth/stylix/commit/98444a942a85072baf12c4a1c4cd5ef9531c8ab0) | `` stylix: sort flake inputs (#1265) ``          |
| [`5d28886e`](https://github.com/danth/stylix/commit/5d28886e94835231e9b32d53ab2d76235960c8ab) | `` halloy: use upstream themes option (#1259) `` |