### PR TITLE
chore(flake/nix-fast-build): `689861d6` -> `f59908e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -522,11 +522,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747203326,
-        "narHash": "sha256-c6bwNqfzG0zK016zFo+iPeEKbibPacaEA+FqNpSvkhk=",
+        "lastModified": 1747265771,
+        "narHash": "sha256-XCJuEIQ3gC3UZYNEZBh6q6fdpm+5AqusSGEPUdWZkwo=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "689861d60a91614c1010bb6b5b006c18f115a9dd",
+        "rev": "f59908e2b7a9e04579dace6b5728957f5dfbd058",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f59908e2`](https://github.com/Mic92/nix-fast-build/commit/f59908e2b7a9e04579dace6b5728957f5dfbd058) | `` chore(deps): update nixpkgs digest to b112281 (#156) `` |