### PR TITLE
chore(flake/stylix): `98444a94` -> `b460904a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747248043,
-        "narHash": "sha256-uEEhchsf9l2u7JJk04GZIMRIkuCeJFPSAuTMByqYfIQ=",
+        "lastModified": 1747277033,
+        "narHash": "sha256-CXlOnolot/OYiDoG391q2dQVmdtuznpDRlsY+m55oHo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "98444a942a85072baf12c4a1c4cd5ef9531c8ab0",
+        "rev": "b460904a6fc6273345d5e2525dc89ec033d68be9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`b460904a`](https://github.com/danth/stylix/commit/b460904a6fc6273345d5e2525dc89ec033d68be9) | `` doc: use hash instead of sha256 in example (#1270) ``   |
| [`71f8b116`](https://github.com/danth/stylix/commit/71f8b1166b88751e59648c94ff919cfb94966b3d) | `` nixcord: change theme location on nix-darwin (#1221) `` |
| [`cb42af55`](https://github.com/danth/stylix/commit/cb42af5571ed53c402dc956380a3f0511a9b0d4b) | `` foliate: use upstream option (#1260) ``                 |
| [`2dcb1888`](https://github.com/danth/stylix/commit/2dcb18884f186771285e453a77b8a4778fd18f81) | `` stylix: gitignore .worktree (#1268) ``                  |