### PR TITLE
chore(flake/home-manager): `6bf057fc` -> `954615c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747225851,
-        "narHash": "sha256-4IbmZrNOdXP143kZEUzxBS5SqyxUlaSHLgdpeJfP2ZU=",
+        "lastModified": 1747279714,
+        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6bf057fc8326e83bda05a669fc08d106547679fb",
+        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`954615c5`](https://github.com/nix-community/home-manager/commit/954615c510c9faa3ee7fb6607ff72e55905e69f2) | `` flake.lock: Update (#7058) ``                       |
| [`02ea7985`](https://github.com/nix-community/home-manager/commit/02ea79853ce42853d019ce689f533dc93e462862) | `` emacs: respect `defaultEditor` on Darwin (#7063) `` |