### PR TITLE
chore(flake/darwin): `f0fbf2db` -> `b6fff20c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747294196,
-        "narHash": "sha256-GVwvgXh2K8LM4/wIBfFuDHEIVEIVB+G09+JO1TfWVwY=",
+        "lastModified": 1747297701,
+        "narHash": "sha256-R8mFJL3lREsJNDqPHbsn03imKoH2ocpzgT2kKWsWYBM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f0fbf2dbe7433c65439286d47b4dc053b647d77b",
+        "rev": "b6fff20c692d684d250a39453ed1853dd44c96ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                               |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`d693997a`](https://github.com/nix-darwin/nix-darwin/commit/d693997a324d92253772ebfc7fe5d48f3633861a) | `` defaults: update docs for `AppleInterfaceStyle` `` |