### PR TITLE
chore(flake/lovesegfault-vim-config): `477433c7` -> `019385d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747267619,
-        "narHash": "sha256-2QRUUTVbbYCQKQb+D1XY32+1w6zcD5X/PHTZa4My9o4=",
+        "lastModified": 1747354165,
+        "narHash": "sha256-2edhM00VOVe+fAconjd9ZvtNM32g5loare91lNhsaDg=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "477433c75eafb9e9dd5e6431d286958fad785290",
+        "rev": "019385d293717f3b7307247aef0fae424e86dbab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`019385d2`](https://github.com/lovesegfault/vim-config/commit/019385d293717f3b7307247aef0fae424e86dbab) | `` chore(flake/nixpkgs): d89fc19e -> adaa24fb ``     |
| [`cb76a3cc`](https://github.com/lovesegfault/vim-config/commit/cb76a3cc29ae39683d0ed91190a92052d3a2cf30) | `` chore(flake/treefmt-nix): 708ec80c -> e758f274 `` |