### PR TITLE
chore(flake/darwin): `b6fff20c` -> `8817b00b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747297701,
-        "narHash": "sha256-R8mFJL3lREsJNDqPHbsn03imKoH2ocpzgT2kKWsWYBM=",
+        "lastModified": 1747365160,
+        "narHash": "sha256-4ZVr0x+ry6ybym/VhVYACj0HlJo44YxAaPGOxiS88Hg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "b6fff20c692d684d250a39453ed1853dd44c96ab",
+        "rev": "8817b00b0011750381d0d44bb94d61087349b6ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                        |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`14737a96`](https://github.com/nix-darwin/nix-darwin/commit/14737a967691173be76e0c1a77167210b8c2d266) | `` defaults: add `com.apple.iCal` for managing Calendar.app `` |