### PR TITLE
chore(flake/stylix): `b460904a` -> `7566bc01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747277033,
-        "narHash": "sha256-CXlOnolot/OYiDoG391q2dQVmdtuznpDRlsY+m55oHo=",
+        "lastModified": 1747365543,
+        "narHash": "sha256-r5HRe9CRFe6qvy7KLkTX9WySTqkNmvlobTR8g5AHLHA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b460904a6fc6273345d5e2525dc89ec033d68be9",
+        "rev": "7566bc015064ed3eb50b436f2225ddab06132beb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`7566bc01`](https://github.com/danth/stylix/commit/7566bc015064ed3eb50b436f2225ddab06132beb) | `` mako: don't use criteria option (#1264) ``                   |
| [`69303679`](https://github.com/danth/stylix/commit/69303679a4e33a407f3fa36fa9b9585d917f2bf8) | `` kubecolor: check `stylix.enable` ``                          |
| [`7051eb4d`](https://github.com/danth/stylix/commit/7051eb4db14d9aa827b6ba4070fe465e5d987879) | `` kitty: check `stylix.enable` ``                              |
| [`d419d335`](https://github.com/danth/stylix/commit/d419d335c011960d60b70d3687348efc5bd718e2) | `` gtk: check `stylix.enable` ``                                |
| [`94e68af4`](https://github.com/danth/stylix/commit/94e68af4a4a05ffcc773fff09c6387e2934e2352) | `` doc: note modules must check `stylix.enable` ``              |
| [`030af3e0`](https://github.com/danth/stylix/commit/030af3e0717e32b8c0c0133d17bcba8659d2d1b2) | `` stylix: remove `cfg.enable` from `mkEnableTarget` default `` |