### PR TITLE
chore(flake/git-hooks): `fa466640` -> `80479b6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -312,11 +312,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746537231,
-        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
+        "lastModified": 1747372754,
+        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`d1deac19`](https://github.com/cachix/git-hooks.nix/commit/d1deac19499042d4fbf2e43eeb117bd97328270c) | `` fix(govet): change to dir before running `` |