### PR TITLE
chore(flake/treefmt-nix): `e758f274` -> `42dd9289`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -957,11 +957,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747299117,
-        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
+        "lastModified": 1747417995,
+        "narHash": "sha256-3WY1yVTcS9Vi6vmBjWsNTG6IYDs/ybu2xAQykdeE22k=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
+        "rev": "42dd9289571ae3c6884af9885b1a7432e3278f92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`42dd9289`](https://github.com/numtide/treefmt-nix/commit/42dd9289571ae3c6884af9885b1a7432e3278f92) | `` README: fix formatting ``           |
| [`8ceec8b1`](https://github.com/numtide/treefmt-nix/commit/8ceec8b1c06dfaf8a7a8f6335939d96fb69f57e4) | `` Add zizmor as an action linter ``   |
| [`2faace5c`](https://github.com/numtide/treefmt-nix/commit/2faace5cefca955da79be88df944b1c02ac6102d) | `` Add kdlfmt as a formatter (#355) `` |