### PR TITLE
chore(flake/stylix): `0e5b1613` -> `4d68f1f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -231,7 +231,6 @@
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
-          "nur",
           "nixpkgs"
         ]
       },
@@ -653,7 +652,10 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
         "nixpkgs": [
           "stylix",
           "nixpkgs"
@@ -731,9 +733,7 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "flake-utils": [
-          "flake-utils"
-        ],
+        "flake-parts": "flake-parts_2",
         "git-hooks": "git-hooks_2",
         "gnome-shell": "gnome-shell",
         "home-manager": [
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747406390,
-        "narHash": "sha256-rDUCzrFPKCOrwJ0Pg9Mo6+8q/7EcSTstl+SotwDL3tA=",
+        "lastModified": 1747440440,
+        "narHash": "sha256-4ivmspXhGLSDF/0avY+E3qP2uVBYVG0C0MQ+ZDI+uCw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0e5b1613bd9285700c99e5ecf0a4e31da8cb5e04",
+        "rev": "4d68f1f761285a6236e7d45efa227d6f4af09c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`4d68f1f7`](https://github.com/danth/stylix/commit/4d68f1f761285a6236e7d45efa227d6f4af09c80) | `` ci: bump DeterminateSystems/update-flake-lock from 24 to 25 ``    |
| [`ecfa5c40`](https://github.com/danth/stylix/commit/ecfa5c40b6a063a8d20272c123d05a3b91e14608) | `` flake: include packages in checks (#1285) ``                      |
| [`88e1c23d`](https://github.com/danth/stylix/commit/88e1c23df2d8c47e23f744389822e3c45f1bfc19) | `` flake: fix and refactor the `homeManagerModules` alias (#1287) `` |
| [`31fff1c5`](https://github.com/danth/stylix/commit/31fff1c5335eea957df5c00f89ace2e72ba4b91e) | `` doc: use callPackage (#1282) ``                                   |
| [`c7282414`](https://github.com/danth/stylix/commit/c72824147e51bf7e76738500f3ed4c7bf8c3cf5c) | `` flake: use importApply for modules (#1281) ``                     |
| [`8b015b5f`](https://github.com/danth/stylix/commit/8b015b5fa0d7f5aaf1a414fa8f1d10aef17fd606) | `` flake: use flake-parts (#1208) ``                                 |
| [`49b1eb93`](https://github.com/danth/stylix/commit/49b1eb937152b686626be269ee3fe462d1541d5a) | `` cava: refactor + fix rainbow.enable description (#1276) ``        |