### PR TITLE
chore(flake/home-manager): `d2263ce5` -> `ae755329`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -418,11 +418,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747374689,
-        "narHash": "sha256-JT/aBZqmK1LbExzwT9cPkvxKc0IC4i6tZKOPjsSWFbI=",
+        "lastModified": 1747439237,
+        "narHash": "sha256-5rCGrnkglKKj4cav1U3HC+SIUNJh08pqOK4spQv9RjA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2263ce5f4c251c0f7608330e8fdb7d1f01f0667",
+        "rev": "ae755329092c87369b9e9a1510a8cf1ce2b1c708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`ae755329`](https://github.com/nix-community/home-manager/commit/ae755329092c87369b9e9a1510a8cf1ce2b1c708) | `` templates/nix-darwin: nixpkgs track nixpkgs-unstable `` |
| [`5d132608`](https://github.com/nix-community/home-manager/commit/5d13260881eae0e9894f2c1dffd2cb97d6b79a07) | `` treewide: lnl7 -> nix-darwin ``                         |
| [`74d31e11`](https://github.com/nix-community/home-manager/commit/74d31e1165341bf510ee2017841a599f5cfc1608) | `` ptyxis: init module (#7075) ``                          |