### PR TITLE
chore(flake/stylix): `4d68f1f7` -> `101d23df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747440440,
-        "narHash": "sha256-4ivmspXhGLSDF/0avY+E3qP2uVBYVG0C0MQ+ZDI+uCw=",
+        "lastModified": 1747441332,
+        "narHash": "sha256-On+cwR/dMW9s+YWsYifIaRs18nNyK5HVFJav6HsRrU8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4d68f1f761285a6236e7d45efa227d6f4af09c80",
+        "rev": "101d23dfacbb2704c40639ae9b6ac1d41de7143a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                         |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`101d23df`](https://github.com/danth/stylix/commit/101d23dfacbb2704c40639ae9b6ac1d41de7143a) | `` ci: fix dependabot backport label (#1288) `` |