### PR TITLE
chore(flake/treefmt-nix): `42dd9289` -> `ab0378b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -957,11 +957,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747417995,
-        "narHash": "sha256-3WY1yVTcS9Vi6vmBjWsNTG6IYDs/ybu2xAQykdeE22k=",
+        "lastModified": 1747469671,
+        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "42dd9289571ae3c6884af9885b1a7432e3278f92",
+        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                          |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ab0378b6`](https://github.com/numtide/treefmt-nix/commit/ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb) | `` buf: doesn't support multiple file targets `` |