### PR TITLE
chore(flake/agenix): `8a4516ae` -> `6697e8ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747508675,
-        "narHash": "sha256-p89NHqmZh1j0ZclCW5kEIonaZXsMGy+upes3fIo5RHM=",
+        "lastModified": 1747514353,
+        "narHash": "sha256-E1WjB+zvDw4x058mg3MIdK5j2huvnNpTEEt2brhg2H8=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "8a4516aed6e9083b30dda064bda85075975ecb07",
+        "rev": "6697e8babbd8f323dfd5e28f160a0128582c128b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`bd33a9b9`](https://github.com/ryantm/agenix/commit/bd33a9b9a5a370a7d1599c7c3af1d71df45f0201) | `` doc: strip trailing whitespace `` |