### PR TITLE
chore(flake/stylix): `101d23df` -> `91b23c7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747441332,
-        "narHash": "sha256-On+cwR/dMW9s+YWsYifIaRs18nNyK5HVFJav6HsRrU8=",
+        "lastModified": 1747524044,
+        "narHash": "sha256-kqgZvjMPpmzxHhHJX5Ml54xRupy/bs8pO+3HYKSVglY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "101d23dfacbb2704c40639ae9b6ac1d41de7143a",
+        "rev": "91b23c7bc60b29e0140242db7cf9e46e2bb685be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                          |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`91b23c7b`](https://github.com/danth/stylix/commit/91b23c7bc60b29e0140242db7cf9e46e2bb685be) | `` doc: explain how to build & check the docs locally (#1273) `` |
| [`3c172cbb`](https://github.com/danth/stylix/commit/3c172cbbc6a657039c6eb0c2eec83c27c69342e2) | `` gnome-text-editor: update style path (#1296) ``               |