### PR TITLE
chore(flake/stylix): `91b23c7b` -> `5f6f08da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747524044,
-        "narHash": "sha256-kqgZvjMPpmzxHhHJX5Ml54xRupy/bs8pO+3HYKSVglY=",
+        "lastModified": 1747533965,
+        "narHash": "sha256-MEbRvR/ZlQHf8vcX1AIby/ILdN/q7SSMGCd2mWIy1DA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "91b23c7bc60b29e0140242db7cf9e46e2bb685be",
+        "rev": "5f6f08daad947b3116ccb878e4226e6bdf7a0c61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`5f6f08da`](https://github.com/nix-community/stylix/commit/5f6f08daad947b3116ccb878e4226e6bdf7a0c61) | `` treewide: change repository owner to nix-community (#1297) `` |
| [`7a0f30b5`](https://github.com/nix-community/stylix/commit/7a0f30b57eb940cd280e2001c73b09a63e6a5311) | `` stylix: update documentation URL in palette.html (#1298) ``   |