### PR TITLE
chore(flake/stylix): `940de011` -> `2eaa338e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747543091,
-        "narHash": "sha256-rBQefDJngM8ZKWS3W37U/9r2ZNSyMDDgrTy1p2KupSE=",
+        "lastModified": 1747578370,
+        "narHash": "sha256-7pk8quDMQcGIVmm7KXMQLI5CbfamwPv/vO20cTcT/wI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "940de011bb02a41e4b005beea42032e71abc5719",
+        "rev": "2eaa338eb879b8432f7e252d6ab8725ada98f52d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`2eaa338e`](https://github.com/nix-community/stylix/commit/2eaa338eb879b8432f7e252d6ab8725ada98f52d) | `` gnome: install User Themes extension (#1306) ``      |
| [`8778cde5`](https://github.com/nix-community/stylix/commit/8778cde5fe6fc5a891558b2b0c7379f7741df9b9) | `` doc: set site-url (#1307) ``                         |
| [`3993363c`](https://github.com/nix-community/stylix/commit/3993363c0ca4e2872df00b57db51551267c76c9f) | `` doc: simplify 'Development Setup' section (#1261) `` |
| [`e2fe2df9`](https://github.com/nix-community/stylix/commit/e2fe2df9b00bf5d65bf17f3d4e77c1a27ad20db8) | `` doc: restructure module rendering (#1083) ``         |