### PR TITLE
chore(flake/nixos-hardware): `e81fd167` -> `e8f38b2c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747129300,
-        "narHash": "sha256-L3clA5YGeYCF47ghsI7Tcex+DnaaN/BbQ4dR2wzoiKg=",
+        "lastModified": 1747684167,
+        "narHash": "sha256-l6jbonaboCBlB8lCjBkrqgh2zEnvt6F3f4dOU/8CLd4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e81fd167b33121269149c57806599045fd33eeed",
+        "rev": "e8f38b2c19c0647e39021c3d47172ff5469af8a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`687c8fcf`](https://github.com/NixOS/nixos-hardware/commit/687c8fcf681371df084ad98b6211b928163b7394) | `` X1 Yoga: Enable fingerprint reader and FW update ``           |
| [`45da8c8a`](https://github.com/NixOS/nixos-hardware/commit/45da8c8ad8f77302ab3cbbcda7a113507f8ecebb) | `` lenovo/legion/15ich: Use Coffee Lake CPU ``                   |
| [`f139290a`](https://github.com/NixOS/nixos-hardware/commit/f139290af12744eca2a5b460ea6cfb1dceded227) | `` TUXEDO Infinitybook: Enable bluetooth by default ``           |
| [`33d083f5`](https://github.com/NixOS/nixos-hardware/commit/33d083f55bab2d3ce5b02666630860038e9867fb) | `` feat(nvidia-prime): automatic battery-saver specialisation `` |