### PR TITLE
chore(flake/disko): `cec44d77` -> `58e72c6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747621015,
-        "narHash": "sha256-j0fo1rNxZvmFLMaE945UrbLJZAHTlQmq0/QMgOP4GTs=",
+        "lastModified": 1747724474,
+        "narHash": "sha256-HG6DeCae97L0mYepwFedsLDueetX/KdihY3HvJqhwLk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "cec44d77d9dacf0c91d3d51aff128fefabce06ee",
+        "rev": "58e72c6ec29a9df611ed5cdef37db1081797a6e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`58e72c6e`](https://github.com/nix-community/disko/commit/58e72c6ec29a9df611ed5cdef37db1081797a6e0) | `` build(deps): bump DeterminateSystems/update-flake-lock from 24 to 25 `` |