### PR TITLE
chore(flake/nixos-hardware): `e8f38b2c` -> `6ac6ec6f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1747684167,
-        "narHash": "sha256-l6jbonaboCBlB8lCjBkrqgh2zEnvt6F3f4dOU/8CLd4=",
+        "lastModified": 1747723695,
+        "narHash": "sha256-lSXzv33yv1O9r9Ai1MtYFDX3OKhWsZMn/5FFb4Rni/k=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8f38b2c19c0647e39021c3d47172ff5469af8a9",
+        "rev": "6ac6ec6fcb410e15a60ef5ec94b8a2b35b5dd282",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`ee94f43c`](https://github.com/NixOS/nixos-hardware/commit/ee94f43c05e80c7a7e5d94ec78426f2bc92a63dd) | `` Add Lenovo Ideapad 5 Pro 14IMH9 / XiaoXin Pro 14IMH9 2024 `` |
| [`a9a7323a`](https://github.com/NixOS/nixos-hardware/commit/a9a7323a067284b5546beef7221ce49a1f3b8d24) | `` framework: Add framework12 ``                                |