### PR TITLE
chore(flake/home-manager): `45c29856` -> `559f6d36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688838,
-        "narHash": "sha256-FZq4/3OtGV/cti9Vccsy2tGSUrxTO4hkDF9oeGRTen4=",
+        "lastModified": 1747753534,
+        "narHash": "sha256-hbDBa5a6jnxoD0OqijmCKF45Hiv4uubb340OMr5DJhc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
+        "rev": "559f6d36b32dd2180ebac40c522dd36290430fc5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`559f6d36`](https://github.com/nix-community/home-manager/commit/559f6d36b32dd2180ebac40c522dd36290430fc5) | `` news: add some more missing news items (#7097) ``                                          |
| [`d3f5d870`](https://github.com/nix-community/home-manager/commit/d3f5d870e3f33f69fa6c0f9bcc44f8803a30e38e) | `` home-manager: add force option for gtk-2 config (#7073) ``                                 |
| [`65d2282f`](https://github.com/nix-community/home-manager/commit/65d2282ff6cf560f54997013bd1e575fbd0a7ebf) | `` fontconfig: Fix missing default fontconfig files (#7045) ``                                |
| [`20974416`](https://github.com/nix-community/home-manager/commit/20974416338898f0725a87832e4cd9bd82cbdaad) | `` services.home-manager.autoExpire: add support for darwin ``                                |
| [`04ebd2c4`](https://github.com/nix-community/home-manager/commit/04ebd2c4224ad6a78385bbc30f06dd89f0aa843b) | `` services.home-manager.autoExpire: extract cleanup script to new variable ``                |
| [`382b34f6`](https://github.com/nix-community/home-manager/commit/382b34f6569262e92b0e947ca5c49354c61b7f8c) | `` services.home-manager.autoExpire: wrap systemd configuration within a isLinux condition `` |