### PR TITLE
chore(flake/home-manager): `559f6d36` -> `29dda415`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747753534,
-        "narHash": "sha256-hbDBa5a6jnxoD0OqijmCKF45Hiv4uubb340OMr5DJhc=",
+        "lastModified": 1747763032,
+        "narHash": "sha256-9j3oCbemeH7bTVXJ3pDWxOptbxDx2SdK1jY2AHpjQiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "559f6d36b32dd2180ebac40c522dd36290430fc5",
+        "rev": "29dda415f5b2178278283856c6f9f7b48a2a4353",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`29dda415`](https://github.com/nix-community/home-manager/commit/29dda415f5b2178278283856c6f9f7b48a2a4353) | `` qutebrowser: add support for per domain settings (#7078) ``         |
| [`3f591550`](https://github.com/nix-community/home-manager/commit/3f591550a99fe5a2a57927ccab15dedb4210e53e) | `` formatter: remove script, add treefmt.toml + keep-sorted (#7056) `` |