### PR TITLE
chore(flake/stylix): `fb9c2205` -> `69b3dd05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747733212,
-        "narHash": "sha256-/Qqw4QfDIReR+qR9cjtiXE4WmW7lxTsKshTaaC7j94c=",
+        "lastModified": 1747769259,
+        "narHash": "sha256-UGfeK8/iUZVWDOYdEpbcbt0liTRIDNNepVzKzWPp6Zc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fb9c22056faa95f35749f116c49c5c202ceb159c",
+        "rev": "69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`69b3dd05`](https://github.com/nix-community/stylix/commit/69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720) | `` stylix: bump release to 25.11 (#1317) ``                        |
| [`c7feebc3`](https://github.com/nix-community/stylix/commit/c7feebc34ab7374cadea1a5da7ee3393ee692d68) | `` qutebrowser: remove lib.mkDefault option declaration (#1227) `` |
| [`43a652de`](https://github.com/nix-community/stylix/commit/43a652de771aabd206ad9ce137171d0da0966198) | `` alacritty: fix bright-yellow usage, adopt (#1280) ``            |