### PR TITLE
chore(flake/stylix): `69b3dd05` -> `4830942f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747769259,
-        "narHash": "sha256-UGfeK8/iUZVWDOYdEpbcbt0liTRIDNNepVzKzWPp6Zc=",
+        "lastModified": 1747813884,
+        "narHash": "sha256-XKkGD2a3GAFNjs1z58K4wb7as2gNqFzc11uvgvWwYQs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720",
+        "rev": "4830942fa2a475c2be5d45ca1267fa77036bf9a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`4830942f`](https://github.com/nix-community/stylix/commit/4830942fa2a475c2be5d45ca1267fa77036bf9a6) | `` treewide: remove unnecessary builtins prefix (#1322) `` |