### PR TITLE
chore(flake/stylix): `d3fadda7` -> `c32026ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747837303,
-        "narHash": "sha256-m4ZaL9rosLM0XHNdUBO2+7ZzLs13x7FdLXlLnPrE7vI=",
+        "lastModified": 1747853856,
+        "narHash": "sha256-5Vn08CLJfXnJKOspVU8G5uT+o0tSvDck/LRBRfK7tNM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d3fadda72abb5d0958b5ce4c0eb551eecc7d538e",
+        "rev": "c32026eab2b314c4599fe4a4f6070229d2d7a5f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`c32026ea`](https://github.com/nix-community/stylix/commit/c32026eab2b314c4599fe4a4f6070229d2d7a5f5) | `` mpv: use mkTarget (#1334) ``             |
| [`4ce349da`](https://github.com/nix-community/stylix/commit/4ce349da56e075f7e3456b48731cbbf5ae8b1eb8) | `` alacritty: fix mkTarget usage (#1332) `` |