### PR TITLE
chore(flake/home-manager): `6c2eb1e2` -> `f9186c64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747834438,
-        "narHash": "sha256-AHJt79W8wADzur2htCx1U8FtEk4XjvrHb9/3iDfNedI=",
+        "lastModified": 1747875884,
+        "narHash": "sha256-tdVx4kghhdy62LKuTnwE2RytOe8o88tah/yhpyuL0D4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c2eb1e24cd0e76d88bdd633ef4c50d6286586e0",
+        "rev": "f9186c64fcc6ee5f0114547acf9e814c806a640b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f9186c64`](https://github.com/nix-community/home-manager/commit/f9186c64fcc6ee5f0114547acf9e814c806a640b) | `` Revert "fontconfig: Fix missing default fontconfig files (#7045)" (#7103) `` |
| [`a69ebd97`](https://github.com/nix-community/home-manager/commit/a69ebd97025969679de9f930958accbe39b4c705) | `` direnv: Fix `default` syntax for nushell integration (#7081) ``              |