### PR TITLE
chore(flake/stylix): `230705d5` -> `f9a6a599`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747904607,
-        "narHash": "sha256-2JWxCVAb8qnssrn/4FeIgs+Gk0VZuAfDsF+rUBE7cZU=",
+        "lastModified": 1747929271,
+        "narHash": "sha256-gQcbNdi7xED6/wOtvJa+T1vQFKMoaCacmDEKmBfQslU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "230705d5fb6c308402579b17e0261e9f15de6f46",
+        "rev": "f9a6a599d7212980c97e93701e50a7002d08802f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f9a6a599`](https://github.com/nix-community/stylix/commit/f9a6a599d7212980c97e93701e50a7002d08802f) | `` hyprland: fix hyprpaper enable condition (#1355) `` |
| [`c1ef1efd`](https://github.com/nix-community/stylix/commit/c1ef1efd8fe5d263f3e9ebf34b64c377f27ebe06) | `` qutebrowser: simplify dark mode setting (#1352) ``  |