### PR TITLE
chore(flake/nix-fast-build): `70391676` -> `14b4478b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747915493,
-        "narHash": "sha256-nMcDMTVARFfuuqFM/x3/tps5FsXdwy8Shr5wIGhaBLU=",
+        "lastModified": 1747946189,
+        "narHash": "sha256-FCOmNZeEH028WyC4/JHml1j07niqtacaoRtLWrZWhZc=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "7039167675dddba74e4ebbdfd430d1b42adaeb2c",
+        "rev": "14b4478bf841a53a8d57efa7b0cf849c91f2cddb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`14b4478b`](https://github.com/Mic92/nix-fast-build/commit/14b4478bf841a53a8d57efa7b0cf849c91f2cddb) | `` chore(deps): update nixpkgs digest to ebcc1d6 (#171) `` |