### PR TITLE
chore(flake/darwin): `e2676937` -> `93562b65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747820204,
-        "narHash": "sha256-oY/mH8K1LOd+YbO58sw9ORtOdTxy3rR9lvTzOJKVUtA=",
+        "lastModified": 1747964474,
+        "narHash": "sha256-i73u8NLiqewGy0iIriH4XizatLnAojXxzrBqHJEz49E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e2676937faf868111dcea6a4a9cf4b6549907c9d",
+        "rev": "93562b65cf68612a544779c9f77536f9dff01096",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`0e3b8554`](https://github.com/nix-darwin/nix-darwin/commit/0e3b855456ca38cc2c23cf24eade14b43b72032a) | `` add test ``                                       |
| [`e09c1aef`](https://github.com/nix-darwin/nix-darwin/commit/e09c1aefe489d1cb2f057ed443eb47e21ef3e3d6) | `` feat(services.openssh): add extraConfig option `` |