### PR TITLE
chore(flake/darwin): `93562b65` -> `33220d47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747964474,
-        "narHash": "sha256-i73u8NLiqewGy0iIriH4XizatLnAojXxzrBqHJEz49E=",
+        "lastModified": 1748004251,
+        "narHash": "sha256-XodjkVWTth3A2JpBqGBkdLD9kkWn94rnv98l3xwKukg=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "93562b65cf68612a544779c9f77536f9dff01096",
+        "rev": "33220d4791784e4dd4739edd3f6c028020082f91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                           |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`acf6b460`](https://github.com/nix-darwin/nix-darwin/commit/acf6b46011d044d1e99fedf111a8e7c4ef6c93cd) | `` system.build: Treat as variables, make lazy `` |