### PR TITLE
chore(flake/lovesegfault-vim-config): `06f14b87` -> `7589ff18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747958933,
-        "narHash": "sha256-GtV/nrTGqrdRmYCwpKg6YaZ/WJdwHwg4g2Am7N/ZFss=",
+        "lastModified": 1748045208,
+        "narHash": "sha256-ep5fr05Q4snMBEYOGAhC0/R8zeka2Pf48RKRcYilroM=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "06f14b875dbbd856a68c432eec3b07678102b91c",
+        "rev": "7589ff1861fa1e530c23d41dd6d9cd8c9faf8fde",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1747945641,
-        "narHash": "sha256-Ts16c+kptbC3YDwPcB/NqXFVMHPNYKeFD7LkiawbWCU=",
+        "lastModified": 1748034126,
+        "narHash": "sha256-7nPv+Qi3PKxgeE4i9c4ErMCaBjVhnVYEzDmWA+8Kalw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "46fd0b184cbc5f1bdc5a8325cb973fc54e49ab68",
+        "rev": "2f610f97541a9cdebcdb485fe8f41e09bd46420d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`7589ff18`](https://github.com/lovesegfault/vim-config/commit/7589ff1861fa1e530c23d41dd6d9cd8c9faf8fde) | `` chore(flake/nixvim): 46fd0b18 -> 2f610f97 `` |