### PR TITLE
chore(flake/darwin): `33220d47` -> `acd6aa5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748004251,
-        "narHash": "sha256-XodjkVWTth3A2JpBqGBkdLD9kkWn94rnv98l3xwKukg=",
+        "lastModified": 1748065210,
+        "narHash": "sha256-dFqlLNW6UW19m0vg5FHWLH2G2LGkqYyPs/4YqfoZMoM=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "33220d4791784e4dd4739edd3f6c028020082f91",
+        "rev": "acd6aa5a9065c6695212be313e06f08f7184cb25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`7347f725`](https://github.com/nix-darwin/nix-darwin/commit/7347f7250726dba3557ae6d367f5773a0036ed3f) | `` programs/arqbackup: init module `` |