### PR TITLE
chore(flake/nix-fast-build): `82293603` -> `5f5ff111`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748054105,
-        "narHash": "sha256-HmDEeLoonzQhxVg0JAYx6JjXtmF8qmp+cXZMrlT6b7A=",
+        "lastModified": 1748081099,
+        "narHash": "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "82293603648a1ecb7c3ceb1b57ec8736444e7ad6",
+        "rev": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`5f5ff111`](https://github.com/Mic92/nix-fast-build/commit/5f5ff111255393c6ff3bca40fbd627f039aa8eb8) | `` chore(deps): update nixpkgs digest to c3ee76c (#175) `` |