### PR TITLE
chore(flake/darwin): `acd6aa5a` -> `e0a7c377`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748065210,
-        "narHash": "sha256-dFqlLNW6UW19m0vg5FHWLH2G2LGkqYyPs/4YqfoZMoM=",
+        "lastModified": 1748130652,
+        "narHash": "sha256-lHwMkKdqE2nUw8+DynnmZlVwd4e0tyNp0KjwfExgXz0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "acd6aa5a9065c6695212be313e06f08f7184cb25",
+        "rev": "e0a7c37735338d5155d70cf46e24b4b0db42a612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                            |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`5374405a`](https://github.com/nix-darwin/nix-darwin/commit/5374405a015f02e866bd4a9bbc551d07d7d3a0c2) | `` config/terminfo: init module `` |