### PR TITLE
chore(flake/home-manager): `74192507` -> `c3d48a17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747978958,
-        "narHash": "sha256-pQQnbxWpY3IiZqgelXHIe/OAE/Yv4NSQq7fch7M6nXQ=",
+        "lastModified": 1748130923,
+        "narHash": "sha256-e/NSpOYw9ZjrzuNkp5hsrxeXOmYhMUCJ4mEuTFDionE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7419250703fd5eb50e99bdfb07a86671939103ea",
+        "rev": "c3d48a17aad6778348abb1c4109add90cc42107c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`c3d48a17`](https://github.com/nix-community/home-manager/commit/c3d48a17aad6778348abb1c4109add90cc42107c) | `` obsidian: add module (#6487) ``                                  |
| [`cf9ff6d9`](https://github.com/nix-community/home-manager/commit/cf9ff6d9930f74dd949ff2fde953470ecde37749) | `` wayvnc: init (#7123) ``                                          |
| [`8fc1e46a`](https://github.com/nix-community/home-manager/commit/8fc1e46ab6d5daac4563c2a3684d68cc0106f458) | `` github: remove Sumner as automatic assignee on issues (#7122) `` |