### PR TITLE
chore(flake/lovesegfault-vim-config): `7589ff18` -> `7196f365`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748045208,
-        "narHash": "sha256-ep5fr05Q4snMBEYOGAhC0/R8zeka2Pf48RKRcYilroM=",
+        "lastModified": 1748131810,
+        "narHash": "sha256-EqL6bNO759nT1tMxRXqvP5TuYwqZ2MtEFqmP/97/cgk=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "7589ff1861fa1e530c23d41dd6d9cd8c9faf8fde",
+        "rev": "7196f365c6555ed01a5082d3c9ea9ec482201058",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748034126,
-        "narHash": "sha256-7nPv+Qi3PKxgeE4i9c4ErMCaBjVhnVYEzDmWA+8Kalw=",
+        "lastModified": 1748088865,
+        "narHash": "sha256-xfAT2ykSAWcYgxkyZN5n6xRHab93u56zbBjuhoDFKFg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f610f97541a9cdebcdb485fe8f41e09bd46420d",
+        "rev": "2c0a9ff1e2bcc6aab15caa504a7c9670f6e0a929",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`7196f365`](https://github.com/lovesegfault/vim-config/commit/7196f365c6555ed01a5082d3c9ea9ec482201058) | `` chore(flake/nixpkgs): 2795c506 -> 063f43f2 `` |
| [`4680f1e4`](https://github.com/lovesegfault/vim-config/commit/4680f1e4075e05fa6ec3c38ed8aec26fb01287c6) | `` chore(flake/nixvim): 2f610f97 -> 2c0a9ff1 ``  |