### PR TITLE
chore(flake/home-manager): `c3d48a17` -> `c1e67103`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748130923,
-        "narHash": "sha256-e/NSpOYw9ZjrzuNkp5hsrxeXOmYhMUCJ4mEuTFDionE=",
+        "lastModified": 1748134483,
+        "narHash": "sha256-5PBK1nV8X39K3qUj8B477Aa2RdbLq3m7wRxUKRtggX4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c3d48a17aad6778348abb1c4109add90cc42107c",
+        "rev": "c1e671036224089937e111e32ea899f59181c383",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`c1e67103`](https://github.com/nix-community/home-manager/commit/c1e671036224089937e111e32ea899f59181c383) | `` sketchybar: add includeSystemPath ``    |
| [`c096c39a`](https://github.com/nix-community/home-manager/commit/c096c39afc2d09341732681890780a5b0b9537b0) | `` sketchybar: config sourceFileOrLines `` |
| [`abe66194`](https://github.com/nix-community/home-manager/commit/abe66194b93701323ea321a618c969c9050046dc) | `` lib/types: add sourceFileOrLines ``     |
| [`e4b0102f`](https://github.com/nix-community/home-manager/commit/e4b0102f697f97af8f4177ba9552995b0bf70b49) | `` sketchybar: use finalpackage wrapper `` |
| [`5dc3bc33`](https://github.com/nix-community/home-manager/commit/5dc3bc336851e979c95eb18d2498698a49d2a178) | `` sketchybar: add module ``               |