### PR TITLE
chore(flake/home-manager): `c1e67103` -> `901f8fef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748134483,
-        "narHash": "sha256-5PBK1nV8X39K3qUj8B477Aa2RdbLq3m7wRxUKRtggX4=",
+        "lastModified": 1748182899,
+        "narHash": "sha256-r6MHSalDFydlUmjorVTSsyhLjIt8VWNtGc5+mffXvFQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1e671036224089937e111e32ea899f59181c383",
+        "rev": "901f8fef7f349cf8a8e97b3230b22fd592df9160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`901f8fef`](https://github.com/nix-community/home-manager/commit/901f8fef7f349cf8a8e97b3230b22fd592df9160) | `` flake.lock: Update (#7125) `` |