### PR TITLE
chore(flake/treefmt-nix): `020cb423` -> `1f3f7b78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -956,11 +956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747912973,
-        "narHash": "sha256-XgxghfND8TDypxsMTPU2GQdtBEsHTEc3qWE6RVEk8O0=",
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "020cb423808365fa3f10ff4cb8c0a25df35065a3",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                      |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`1f3f7b78`](https://github.com/numtide/treefmt-nix/commit/1f3f7b784643d488ba4bf315638b2b0a4c5fb007) | `` Add nixf-diagnose, a Nix linter (#360) `` |