### PR TITLE
chore(flake/stylix): `e22f96de` -> `aa70426f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748213724,
-        "narHash": "sha256-ppmdSruEH7sKzhMNdrY+0NVGOe5Q68LDNVcBZuHuU5o=",
+        "lastModified": 1748269774,
+        "narHash": "sha256-jIvkWbhsrBSV492OuKJwBLAdearm0jmvXoYSMRNseI0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e22f96de3f57b1ab1a393607bc08c003925f68fc",
+        "rev": "aa70426f8f4373da2f454de3e27b565241960599",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`aa70426f`](https://github.com/nix-community/stylix/commit/aa70426f8f4373da2f454de3e27b565241960599) | `` console: improve color consistency (#1388) `` |
| [`225b2ddb`](https://github.com/nix-community/stylix/commit/225b2ddbbaa4ae3c2076c1bd1616fefd35e11670) | `` doc: explain testbed options (#1383) ``       |