### PR TITLE
chore(flake/stylix): `aa70426f` -> `1fdbf01e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748269774,
-        "narHash": "sha256-jIvkWbhsrBSV492OuKJwBLAdearm0jmvXoYSMRNseI0=",
+        "lastModified": 1748276618,
+        "narHash": "sha256-reC7nvUfJMaIYJb5pVOuTFbOfj/L9eo21drj+9EbrkE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "aa70426f8f4373da2f454de3e27b565241960599",
+        "rev": "1fdbf01ebe4b7838aa3d95334325ce8445625332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`d66135de`](https://github.com/nix-community/stylix/commit/d66135deb39da600a4dcd7c686e9225eb531ec5a) | `` flake: add ruff formatter (#1389) `` |
| [`17398c4f`](https://github.com/nix-community/stylix/commit/17398c4fce431ddda8027b00634393e803576d05) | `` treewide: name default testbeds ``   |
| [`2b7ff59d`](https://github.com/nix-community/stylix/commit/2b7ff59d813d5b243eae5981ca3a598d65c1a352) | `` stylix: reduce testbed names ``      |