### PR TITLE
chore(flake/nixpkgs): `063f43f2` -> `62b852f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -592,11 +592,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748026106,
-        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
+        "lastModified": 1748190013,
+        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
+        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`de1d5812`](https://github.com/NixOS/nixpkgs/commit/de1d581210a475747026974e600698a4f3a597cc) | `` python3Packages.hatch-vcs: apply pep517 lingo ``                                |
| [`197d700c`](https://github.com/NixOS/nixpkgs/commit/197d700cfd530db38ab8c03ce824bcc9ec765062) | `` python3Packages.aiodocker: unstable-2022-01-20 -> 0.24.0 ``                     |
| [`c2f043aa`](https://github.com/NixOS/nixpkgs/commit/c2f043aafd2d07ec4e16414fff4b3a772d5554d7) | `` ruqola: init at 2.5.0 ``                                                        |
| [`f1c69b60`](https://github.com/NixOS/nixpkgs/commit/f1c69b60ad81d9942207698bbf776273de6c3b4d) | `` dclib: remove ``                                                                |
| [`952db324`](https://github.com/NixOS/nixpkgs/commit/952db324ea7f9f50981f6d53b02c48647ad608d4) | `` gjay:drop ``                                                                    |
| [`0e1c284b`](https://github.com/NixOS/nixpkgs/commit/0e1c284b1321a3a2cacf96068fdba7b59ed0602b) | `` workflows: checkout nixpkgs in get-merge-commit action ``                       |
| [`942c3774`](https://github.com/NixOS/nixpkgs/commit/942c377476675848155e860b9d41d869589b8a47) | `` workflows/nixpkgs-vet: use nixpkgs-vet from pinned nixpkgs ``                   |
| [`c8d36fe7`](https://github.com/NixOS/nixpkgs/commit/c8d36fe7be9ef579621f5f560eecdd09df2e0440) | `` nexusmods-app: 0.10.2 -> 0.11.3 ``                                              |
| [`c47da7fb`](https://github.com/NixOS/nixpkgs/commit/c47da7fbc81ed640a7a26ea37dbd1ea108eb92a2) | `` doc/rl-2505: reword nexusmods-app entry ``                                      |
| [`94c59406`](https://github.com/NixOS/nixpkgs/commit/94c59406f9c01e3d0961ef12a9ca01e9cebc43a4) | `` doc/rl-2505: move nexusmods-app entry back to "incompatibilities" ``            |
| [`6720d254`](https://github.com/NixOS/nixpkgs/commit/6720d254294220cdfce18c3f981a8aabffb3de94) | `` workflows: checkout nixpkgs into trusted/untrusted directories ``               |
| [`539e8d4f`](https://github.com/NixOS/nixpkgs/commit/539e8d4f66323b87aa1b8e715ec01b9f5199ca82) | `` actions/get-merge-conflict: refactor ``                                         |
| [`cd9a22d7`](https://github.com/NixOS/nixpkgs/commit/cd9a22d7530baf33890971b01af8798069c3fea9) | `` workflows/eval: fix comparison with merge conflicts ``                          |
| [`a81cfab9`](https://github.com/NixOS/nixpkgs/commit/a81cfab95226f0e2945a5068edb566dd28b2cc6e) | `` openvscode-server: 1.88.1 -> 1.99.3; unbreak ``                                 |
| [`daeba318`](https://github.com/NixOS/nixpkgs/commit/daeba3186a9b96aeb49998ec00736aed2abbe8b5) | `` python313Packages.smolagents: 1.13.0 -> 1.16.1 ``                               |
| [`35df7fd7`](https://github.com/NixOS/nixpkgs/commit/35df7fd7276c6197364aff797f577fae7d7dc887) | `` openvscode-server: add bendlas as maintainer ``                                 |
| [`4bd7a015`](https://github.com/NixOS/nixpkgs/commit/4bd7a0155f8fd5f3d0ec12abb1d4915cd42bc23c) | `` servo: 0-unstable-2025-05-15 -> 0-unstable-2025-05-25 ``                        |
| [`c5f35290`](https://github.com/NixOS/nixpkgs/commit/c5f3529083d802375f4851bb2a5f10c528fc6486) | `` python3Packages.flufl-lock: 8.1.0 -> 8.2.0 ``                                   |
| [`96c3a525`](https://github.com/NixOS/nixpkgs/commit/96c3a525927c3e484e5105dcd37f71e0b8e14d68) | `` gtkmm3: update homepage ``                                                      |
| [`ab979f47`](https://github.com/NixOS/nixpkgs/commit/ab979f479674883b70e37dc7bc8bb19daefe76d7) | `` libretro.mgba: 0-unstable-2025-02-17 -> 0-unstable-2025-05-18 ``                |
| [`c2509dc9`](https://github.com/NixOS/nixpkgs/commit/c2509dc9db837388da9664479b824f2dc08ea3b6) | `` python3Packages.optimum: update optional dependencies ``                        |
| [`ae1c56ad`](https://github.com/NixOS/nixpkgs/commit/ae1c56ad7fbcf88c9899c3c83f0db258d339ef8d) | `` python3Packages.optimum: 1.24.0 -> 1.25.3 ``                                    |
| [`aa852f23`](https://github.com/NixOS/nixpkgs/commit/aa852f2301984fb797532cc18aa050b6a3ee694b) | `` cloud-hypervisor: 45.0 -> 46.0 ``                                               |
| [`18dc2804`](https://github.com/NixOS/nixpkgs/commit/18dc2804822355cc02d63d862973eb3d60d3f4c2) | `` python3Packages.testresources: 2.0.1 -> 2.0.2 ``                                |
| [`dd082b81`](https://github.com/NixOS/nixpkgs/commit/dd082b8161531372f6746da0859f62a17dbe814f) | `` jenkins: 2.492.3 -> 2.504.1 ``                                                  |
| [`d0f4918a`](https://github.com/NixOS/nixpkgs/commit/d0f4918a8ab578bf2813a5d8fd126752f8cca033) | `` lunar-client: 3.3.7 -> 3.3.8 ``                                                 |
| [`f57fbc28`](https://github.com/NixOS/nixpkgs/commit/f57fbc289bb4167a9606b2bb6feb653d73fa9357) | `` roddhjav-apparmor-rules: 0-unstable-2025-05-14 -> 0-unstable-2025-05-20 ``      |
| [`eb3dd361`](https://github.com/NixOS/nixpkgs/commit/eb3dd361dad7dbec937de5e3919fa08b17e1adad) | `` niri: 25.05 -> 25.05.1 ``                                                       |
| [`fd25cbd7`](https://github.com/NixOS/nixpkgs/commit/fd25cbd7596cd8a6a338fcbbc1e91457b90fe7b6) | `` postgres-lsp: 0.6.0 -> 0.7.0 ``                                                 |
| [`975c19cb`](https://github.com/NixOS/nixpkgs/commit/975c19cb475dd1ca85453c8635a8b089f6b9a693) | `` nixos/scrutiny: change collector schedule to daily ``                           |
| [`25d2690f`](https://github.com/NixOS/nixpkgs/commit/25d2690f74d0d69b28ae4b4847619c39ba684b5f) | `` borgmatic: 2.0.5 -> 2.0.6 ``                                                    |
| [`1f316344`](https://github.com/NixOS/nixpkgs/commit/1f3163445011b667ea5ba8316b96a24c107f1802) | `` github-mcp-server: 0.3.0 -> 0.4.0 ``                                            |
| [`65874600`](https://github.com/NixOS/nixpkgs/commit/658746009918ba76df5f475259be8a9133afbd52) | `` typstyle: 0.13.8 -> 0.13.9 ``                                                   |
| [`69c74cb4`](https://github.com/NixOS/nixpkgs/commit/69c74cb4387e5aa88d0c0443782b9fa6bd8469e2) | `` python3Packages.snakemake-storage-plugin-fs: 1.1.1 -> 1.1.2 ``                  |
| [`b5410fd1`](https://github.com/NixOS/nixpkgs/commit/b5410fd1d414491c1394c2af13492a15bc5e4e4d) | `` flashprog: Add changelog link to meta information ``                            |
| [`ab80816d`](https://github.com/NixOS/nixpkgs/commit/ab80816d9270654c3776100ad8e4df32d1d89474) | `` naev: 0.12.4 -> 0.12.5 ``                                                       |
| [`e66f3478`](https://github.com/NixOS/nixpkgs/commit/e66f34783ebac25be3bd791dbdd3e933baf6f0af) | `` treewide: substitute pname for strings (python3Packages.[a-g].*) ``             |
| [`e5782299`](https://github.com/NixOS/nixpkgs/commit/e5782299ea225ff7ab238495edbfcee857df6d1e) | `` glamoroustoolkit: 1.1.22 -> 1.1.24 ``                                           |
| [`00eb1a7f`](https://github.com/NixOS/nixpkgs/commit/00eb1a7f781eb10aa39076fdc29c5bb6fd0bcead) | `` telegraf: 1.34.3 -> 1.34.4 ``                                                   |
| [`a66500f7`](https://github.com/NixOS/nixpkgs/commit/a66500f738266333c6f5fcc963f110a8417b0830) | `` python3Packages.types-typed-ast: drop ``                                        |
| [`813189a9`](https://github.com/NixOS/nixpkgs/commit/813189a99f1836b48b86340b672659bd24498003) | `` nixosTests.lomiri-mediaplayer-app: Optimise OCR ``                              |
| [`fb7f603d`](https://github.com/NixOS/nixpkgs/commit/fb7f603d2db140375fe9ba774fa0147e888ff52d) | `` python3Packages.typed-ast: drop ``                                              |
| [`e2928d8b`](https://github.com/NixOS/nixpkgs/commit/e2928d8bc9d13ef8bfb9c14ae3e282dae0a2e921) | `` python3Packages.aiosonic: remove unused dependencies ``                         |
| [`45991097`](https://github.com/NixOS/nixpkgs/commit/45991097c5140990575ff61aa05d9604c1258ada) | `` manual: Use a `postPatch` instead of a `patchPhase` ``                          |
| [`b0005689`](https://github.com/NixOS/nixpkgs/commit/b0005689544930e3d0085a04f998d29c9603f3bc) | `` libretro.play: 0-unstable-2025-05-09 -> 0-unstable-2025-05-23 ``                |
| [`5e6bbf4e`](https://github.com/NixOS/nixpkgs/commit/5e6bbf4edaba355af9034484d338d613f07aa8e4) | `` python313Packages.reflex-chakra: 0.7.0 -> 0.7.1 ``                              |
| [`86e581ec`](https://github.com/NixOS/nixpkgs/commit/86e581ec89b428924132400a29ad945527da17c6) | `` python313Packages.mcpadapt: 0.1.5 -> 0.1.9 ``                                   |
| [`17f60e67`](https://github.com/NixOS/nixpkgs/commit/17f60e675e7f2234e5365eecd73bb1937bfcbde6) | `` python313Packages.androidtvremote2: 0.2.1 -> 0.2.2 ``                           |
| [`e7f1f6f7`](https://github.com/NixOS/nixpkgs/commit/e7f1f6f7e165d118e43a9eaf60aca78429717cea) | `` rattler-build: 0.41.0 -> 0.42.1 ``                                              |
| [`a6dab786`](https://github.com/NixOS/nixpkgs/commit/a6dab786438e3ec31c159896a312e74e8e30829c) | `` python3Packages.types-psycopg2: 2.9.21.20250318 -> 2.9.21.20250516 ``           |
| [`20932506`](https://github.com/NixOS/nixpkgs/commit/209325068056921282bc77b6315726438d013fa5) | `` phpunit: 12.1.5 -> 12.1.6 ``                                                    |
| [`0622d5fd`](https://github.com/NixOS/nixpkgs/commit/0622d5fd0245fa0c0962f8cdcd4440232df772ce) | `` sleek: 0.3.0 -> 0.4.0 ``                                                        |
| [`e380e29c`](https://github.com/NixOS/nixpkgs/commit/e380e29c67e4da103e50eca6ef9cff24ddbb8353) | `` ghostfolio: 2.161.0 -> 2.162.0 ``                                               |
| [`93ab2d88`](https://github.com/NixOS/nixpkgs/commit/93ab2d8822936a8ee14af24b8c36e145e1cf78be) | `` ladybird: 0-unstable-2025-05-18 -> 0-unstable-2025-05-24 ``                     |
| [`d10660b9`](https://github.com/NixOS/nixpkgs/commit/d10660b946be542749deb7eacbf8c68dd84f191e) | `` tpnote: 1.25.9 -> 1.25.10 ``                                                    |
| [`86dd94e4`](https://github.com/NixOS/nixpkgs/commit/86dd94e458168ef467d4c0aee06df90ef649951a) | `` python3Packages.pyais: 2.9.2 -> 2.9.4 ``                                        |
| [`e9f87be2`](https://github.com/NixOS/nixpkgs/commit/e9f87be223fda88844f60930af32480a329958ac) | `` tflint: 0.57.0 -> 0.58.0 ``                                                     |
| [`3f90d5b9`](https://github.com/NixOS/nixpkgs/commit/3f90d5b9065e1d481da76205fa807e56b6892933) | `` touchegg: 2.0.17 -> 2.0.18 ``                                                   |
| [`cb3f7bdb`](https://github.com/NixOS/nixpkgs/commit/cb3f7bdbf8c0d9ed3a79bb2cbbab2b6553be534b) | `` python3Packages.django-stubs-ext: 5.1.3 -> 5.2.0 ``                             |
| [`441f5a13`](https://github.com/NixOS/nixpkgs/commit/441f5a13acfbe391960756cc56796eb341f0a8e1) | `` nelm: 1.4.0 -> 1.4.1 ``                                                         |
| [`27e13d37`](https://github.com/NixOS/nixpkgs/commit/27e13d37f5b5b1b55dc6b1d7f5e17dae1f7f7158) | `` python3Packages.dj-database-url: 2.3.0 -> 3.0.0 ``                              |
| [`a5a7b272`](https://github.com/NixOS/nixpkgs/commit/a5a7b272ee007aabade4b6e89c7609bc9ac88b0f) | `` komikku: 1.76.1 -> 1.77.0 ``                                                    |
| [`a3564f44`](https://github.com/NixOS/nixpkgs/commit/a3564f44239a3941574f32048efacd5cef1a3545) | `` python3Packages.asn1: 3.0.1 -> 3.1.0 ``                                         |
| [`020c1daa`](https://github.com/NixOS/nixpkgs/commit/020c1daaf9062c0066f43646bd8b86b562b412a7) | `` python3Packages.type-infer: pkgs.symlinkJoin -> python3Packages.nltk.dataDir `` |
| [`8aa49dac`](https://github.com/NixOS/nixpkgs/commit/8aa49dac246c0ff3657823556fd6b52534cf6aed) | `` python3Packages.aider-chat: pkgs.symlinkJoin -> python3Packages.nltk.dataDir `` |
| [`0bb5be9a`](https://github.com/NixOS/nixpkgs/commit/0bb5be9addc86bff92d3ede45ec094755055cba5) | `` unstructured-api: pkgs.symlinkJoin -> python.pkgs.nltk.dataDir ``               |
| [`fd7cdab6`](https://github.com/NixOS/nixpkgs/commit/fd7cdab61f9f4e793379d57922e5956c360ed082) | `` nixos/tests/lasuite-docs: init ``                                               |
| [`f3120f07`](https://github.com/NixOS/nixpkgs/commit/f3120f071074397fe4b45414c2733f756887d027) | `` nixos/lasuite-docs: init ``                                                     |
| [`279f2c03`](https://github.com/NixOS/nixpkgs/commit/279f2c0308682c2177595cc3af6d1e26fc084160) | `` python3Packages.nltk: run tests ``                                              |
| [`a2d01ca3`](https://github.com/NixOS/nixpkgs/commit/a2d01ca3d18cb5ce7e51ea6c1afd94ebd3db5e1e) | `` linuxPackages.prl-tools: 20.3.0-55895 -> 20.3.1-55959 ``                        |
| [`acc6352e`](https://github.com/NixOS/nixpkgs/commit/acc6352eeb3e1b4fb10f6d17954bc0eb4edf07f7) | `` python3Packages.nltk: propagatedBuildInputs -> dependencies ``                  |
| [`aee430ee`](https://github.com/NixOS/nixpkgs/commit/aee430ee47e1e80e4d555722e3d6ba1bf7899c00) | `` python3Packages.nltk.dataDir: init ``                                           |
| [`9562488e`](https://github.com/NixOS/nixpkgs/commit/9562488efb1b8e2d60e60203e9ea752c131cad2c) | `` python3Packages.nltk.data: access `nltk-data` packages via `passthru` ``        |
| [`c9caba6f`](https://github.com/NixOS/nixpkgs/commit/c9caba6f7d6d0d768246ff72f877733be5f35a60) | `` python3Packages.nltk: add bengsparks to maintainers ``                          |
| [`90b83812`](https://github.com/NixOS/nixpkgs/commit/90b83812360e84a3f284666a8eebfe9bcfe99437) | `` libretro.dosbox-pure: 0-unstable-2025-05-09 -> 0-unstable-2025-05-24 ``         |
| [`77353d78`](https://github.com/NixOS/nixpkgs/commit/77353d78711d7496f282f7330b471b0c5e5a6023) | `` mint-themes: 2.2.3 -> 2.2.6 ``                                                  |
| [`3277dd22`](https://github.com/NixOS/nixpkgs/commit/3277dd227d0298a06702b684c0937c0100a2ef9a) | `` gitlab-container-registry: fix build on darwin with sandbox ``                  |
| [`55b8857b`](https://github.com/NixOS/nixpkgs/commit/55b8857bc1384237bfdb0289b5a6fc094473da23) | `` pantheon.elementary-notifications: 8.0.0 -> 8.1.0 ``                            |
| [`1ccff76a`](https://github.com/NixOS/nixpkgs/commit/1ccff76a47de1739518fcb4ea7939783298d1b08) | `` eww: 0.6.0-unstable-2025-05-13 -> 0.6.0-unstable-2025-05-18 ``                  |
| [`af93b70d`](https://github.com/NixOS/nixpkgs/commit/af93b70ddcccc8cb429f486d7938cba33d8b6401) | `` nixos/boot: add boot.tmp.useZram options ``                                     |
| [`b924dfeb`](https://github.com/NixOS/nixpkgs/commit/b924dfebeb1d6072172777e8e19f62463fe3a28e) | `` python3Packages.roadrecon: 1.6.1 -> 1.6.2 ``                                    |
| [`6c3175a0`](https://github.com/NixOS/nixpkgs/commit/6c3175a04289d9564cc1572a6b336ae8430591a3) | `` smatch: fix build by applying custom fix ``                                     |
| [`245edb75`](https://github.com/NixOS/nixpkgs/commit/245edb755d351b3a33ae3e3e0f292b9794ee1cb4) | `` nototools: remove unused dependency ``                                          |
| [`19855938`](https://github.com/NixOS/nixpkgs/commit/19855938fc607e36c1c7209a7eda1651981f3523) | `` nototools: move to top-level ``                                                 |
| [`a91fbe12`](https://github.com/NixOS/nixpkgs/commit/a91fbe120df3d35cb16d3de469a7421faf274ca8) | `` unzoo: drop ``                                                                  |
| [`dd612da3`](https://github.com/NixOS/nixpkgs/commit/dd612da33a2ab4c81a8c2fb0e05b080b23e142bf) | `` libretro.gambatte: 0-unstable-2025-05-02 -> 0-unstable-2025-05-16 ``            |
| [`13be7c05`](https://github.com/NixOS/nixpkgs/commit/13be7c056b7e2a0b6d8ef4a01ed1187538d95cce) | `` quaternion-qt5: remove ``                                                       |
| [`963babe8`](https://github.com/NixOS/nixpkgs/commit/963babe8514638c8e97b1f304d434d377caef7ce) | `` nvme-rs: init at 0.1.0 ``                                                       |
| [`fd6f086c`](https://github.com/NixOS/nixpkgs/commit/fd6f086ce306085ab4dfeead6fe681a51713aa5f) | `` xfce.xfce4-xkb-plugin: 0.8.5 -> 0.9.0 ``                                        |
| [`68d2dfa8`](https://github.com/NixOS/nixpkgs/commit/68d2dfa8d67db7b598075a8b18ffb3b735be925c) | `` xfce.xfce4-windowck-plugin: 0.5.2 -> 0.6.0 ``                                   |
| [`09540994`](https://github.com/NixOS/nixpkgs/commit/09540994a0bb30cdad850cde92f40896d06da969) | `` xfce.xfce4-whiskermenu-plugin: 2.9.2 -> 2.10.0 ``                               |
| [`e68f1b45`](https://github.com/NixOS/nixpkgs/commit/e68f1b45d4d241adc798535a232c4a455fc8baa2) | `` xfce.xfce4-weather-plugin: 0.11.3 -> 0.12.0 ``                                  |
| [`b9ad8620`](https://github.com/NixOS/nixpkgs/commit/b9ad8620b1b87e8356a527c8eba61e097b0f5db8) | `` xfce.xfce4-verve-plugin: 2.0.4 -> 2.1.0 ``                                      |
| [`9007ca07`](https://github.com/NixOS/nixpkgs/commit/9007ca07f5ceace0b1567b691edd29ab01518285) | `` xfce.xfce4-timer-plugin: 1.7.3 -> 1.8.0 ``                                      |
| [`f13f2576`](https://github.com/NixOS/nixpkgs/commit/f13f2576def3fb6d376a467f29b75d6285cf323a) | `` protolint: remove me as maintainer ``                                           |
| [`961f336e`](https://github.com/NixOS/nixpkgs/commit/961f336e8cc6c37f79ca65f26ca375c0ceca45e9) | `` exaile: 4.1.3 -> 4.1.4 ``                                                       |