### PR TITLE
chore(flake/home-manager): `d23d20f5` -> `ad22169e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748227609,
-        "narHash": "sha256-SaSdslyo6UGDpPUlmrPA4dWOEuxCy2ihRN9K6BnqYsA=",
+        "lastModified": 1748391018,
+        "narHash": "sha256-EABV++OYe8ZtLUUNFoIn0cQwkliRYqmZZrLXyaokVjE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d23d20f55d49d8818ac1f1b2783671e8a6725022",
+        "rev": "ad22169efa67448badd870076e441778f4cf7948",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`ad22169e`](https://github.com/nix-community/home-manager/commit/ad22169efa67448badd870076e441778f4cf7948) | `` jellyfin-mpv-shim: add module (#7129) ``            |
| [`8cb8a04c`](https://github.com/nix-community/home-manager/commit/8cb8a04cb1383fe08bb6cbf672f00ed60c92bbbd) | `` home-cursor: set hyprcursor size default (#7145) `` |