### PR TITLE
chore(flake/stylix): `ba217a81` -> `25793957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748447709,
-        "narHash": "sha256-E6VJbT7bdDKEfmYi2XYh96b3EhDZp5G0aq3W108on50=",
+        "lastModified": 1748450356,
+        "narHash": "sha256-r4ftEbA22jCoLnaB0w58wo5Pp8jgSGwwAEfGgvZGFcs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ba217a812810fd788c42d6dc68a0e0e93c6634e2",
+        "rev": "257939576384a9057a8259e76689090643f5a127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f996bf88`](https://github.com/nix-community/stylix/commit/f996bf88703547cb7a21173ba1674fec9b32afe0) | `` stylix: move testbed `isEnabled` to its own file `` |
| [`aaa0517d`](https://github.com/nix-community/stylix/commit/aaa0517d203b7f5f1a6b14d3126fd513de63197c) | `` stylix: move testbed themes to their own files ``   |
| [`7afee8f8`](https://github.com/nix-community/stylix/commit/7afee8f85b8737b28b3f2e96c21c5660c42e967d) | `` stylix: move testbed modules to their own files ``  |
| [`c765b15f`](https://github.com/nix-community/stylix/commit/c765b15fc3949965126db8ca5b4b2b629b2034d2) | `` stylix: move testbed to a dedicated directory ``    |
| [`93507d3c`](https://github.com/nix-community/stylix/commit/93507d3cd775b69cc12ce306ae4aee85e68649aa) | `` stylix: make `testbedFieldSeparator` a file arg ``  |
| [`8ebdc8cc`](https://github.com/nix-community/stylix/commit/8ebdc8cc8b0c242d3d326d86467ae7067b39c26d) | `` stylix: remove `...` from testbed file args ``      |