### PR TITLE
chore(flake/stylix): `25793957` -> `4a121321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748450356,
-        "narHash": "sha256-r4ftEbA22jCoLnaB0w58wo5Pp8jgSGwwAEfGgvZGFcs=",
+        "lastModified": 1748541432,
+        "narHash": "sha256-TZ4wAfDsXYWVRozSlYWKPxveQFxujl5R3LlJABib1ik=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "257939576384a9057a8259e76689090643f5a127",
+        "rev": "4a121321d320e17f2cfb7ed9eebff5c233b6420e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`4a121321`](https://github.com/nix-community/stylix/commit/4a121321d320e17f2cfb7ed9eebff5c233b6420e) | `` waybar: add bluetooth configuration (#1412) ``                               |
| [`37736ba4`](https://github.com/nix-community/stylix/commit/37736ba403131717c4258eb95f3ca51798cffdaa) | `` home-manager: cast cursor size to int (#1401) ``                             |
| [`3a4599a3`](https://github.com/nix-community/stylix/commit/3a4599a330a0bb1c544fe81e5f83b522f02c6106) | `` stylix: check base16Scheme is not null before using mkSchemeAttrs (#1408) `` |