### PR TITLE
chore(flake/stylix): `4a121321` -> `0512b0f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748541432,
-        "narHash": "sha256-TZ4wAfDsXYWVRozSlYWKPxveQFxujl5R3LlJABib1ik=",
+        "lastModified": 1748572239,
+        "narHash": "sha256-Of7bmWQUEVILpx1GJz0gLHmRoGrEP/G7q9RnidxW5Go=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4a121321d320e17f2cfb7ed9eebff5c233b6420e",
+        "rev": "0512b0f685ab2ac0586c897460c247f49670460b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`0512b0f6`](https://github.com/nix-community/stylix/commit/0512b0f685ab2ac0586c897460c247f49670460b) | `` ci: fix backport conditions (#1420) ``         |
| [`838df8b8`](https://github.com/nix-community/stylix/commit/838df8b8ad7d993d4de4af144f57bca0d5d1329a) | `` stylix: improve `stylix.image` type (#1414) `` |