### PR TITLE
chore(flake/home-manager): `4e9efaa6` -> `214f9bd3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748570847,
-        "narHash": "sha256-XU1a6wFctd+s3ZvBIFB6s4GhPJ+Oc6pkeOrEsbA2fMo=",
+        "lastModified": 1748618795,
+        "narHash": "sha256-XrNoXAbUenzde4NKMsuCYdmW8t+2/Ks+vcFrlwRh4K4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e9efaa68b0be7e19127dad4f0506a9b89e28ef4",
+        "rev": "214f9bd3a693bbc8cc6d705d01421787e04eaacd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`214f9bd3`](https://github.com/nix-community/home-manager/commit/214f9bd3a693bbc8cc6d705d01421787e04eaacd) | `` linux-wallpaperengine: fix evaluation error when passing null (#7161) `` |
| [`d800d198`](https://github.com/nix-community/home-manager/commit/d800d198b8376ffb6d8f34f12242600308b785ee) | `` podman: use quadlet source from file drv (#7102) ``                      |
| [`d36ac1f0`](https://github.com/nix-community/home-manager/commit/d36ac1f0db0bc5e8f6ac4e230c9cca7f9e35a179) | `` hwatch: add module (#7158) ``                                            |
| [`482c306e`](https://github.com/nix-community/home-manager/commit/482c306ef70785f53d9d90839b6b5643521ac031) | `` home-manager: update xgettext and PO files ``                            |
| [`d3a3aee5`](https://github.com/nix-community/home-manager/commit/d3a3aee558979d9b0dde1c0814d8f9f96884aeed) | `` dconf: Fix Gio module variable breakage (#7146) ``                       |