### PR TITLE
chore(flake/nixpkgs): `4faa5f53` -> `96ec055e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -592,11 +592,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748370509,
-        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`96ec055e`](https://github.com/NixOS/nixpkgs/commit/96ec055edbe5ee227f28cdbc3f1ddf1df5965102) | `` nixos/filebrowser: init module ``                                                               |
| [`80b13363`](https://github.com/NixOS/nixpkgs/commit/80b13363b929209f94ccac678d0abcc662361c9f) | `` spicedb: add squat as maintainer ``                                                             |
| [`21db980e`](https://github.com/NixOS/nixpkgs/commit/21db980e6f6bb129fd973cb247702e6d1ecdf279) | `` curl: patch CVE-2025-4947 and CVE-2025-5025 for WolfSSL backend ``                              |
| [`ebb74b08`](https://github.com/NixOS/nixpkgs/commit/ebb74b0864d5715184d117ff0ebf0299b288197b) | `` android-studio: wrap with libsecret ``                                                          |
| [`1dbd1023`](https://github.com/NixOS/nixpkgs/commit/1dbd102380a237b497a45d5a6a4476f4f86c7c79) | `` OWNERS: take ownership of androidenv, android-studio and related packages and documentations `` |
| [`36554abf`](https://github.com/NixOS/nixpkgs/commit/36554abfa4e01feb0f85492208b9c159efdb9e31) | `` Revert "android-studio: fix for bot not requesting maintainers" ``                              |
| [`e7b9c5d6`](https://github.com/NixOS/nixpkgs/commit/e7b9c5d67f069581946c61aca1ecf137ec41a26b) | `` parseable: 2.2.0 -> 2.3.1 ``                                                                    |
| [`04ecd415`](https://github.com/NixOS/nixpkgs/commit/04ecd4150d37ecb90bbe2cb90f0ee78e9cbf4f8f) | `` firefox-beta-bin-unwrapped: 139.0b4 -> 140.0b2 ``                                               |
| [`dcab2816`](https://github.com/NixOS/nixpkgs/commit/dcab281674561967203dbb92e20cb969236b5473) | `` firefox-devedition-bin-unwrapped: 139.0b3 -> 140.0b2 ``                                         |
| [`b831f39f`](https://github.com/NixOS/nixpkgs/commit/b831f39f79b62fd9c3f0d9c1a7f62be6bf2f7787) | `` firefox-beta-unwrapped: 138.0b4 -> 140.0b2 ``                                                   |
| [`0ffe03a9`](https://github.com/NixOS/nixpkgs/commit/0ffe03a91899a323965ee52c74de9268e2114fd1) | `` firefox-devedition-unwrapped: 138.0b9 -> 140.0b2 ``                                             |
| [`f83e7a30`](https://github.com/NixOS/nixpkgs/commit/f83e7a305fbb57780ca2d81d7c1a29063125ae70) | `` python3{13,14}FreeThreading: pass interpreter as self ``                                        |
| [`76239a04`](https://github.com/NixOS/nixpkgs/commit/76239a04354b501e6cd0bd9526da9a6b8bf1e433) | `` limine: 9.3.2 -> 9.3.3 ``                                                                       |
| [`15ac0ea8`](https://github.com/NixOS/nixpkgs/commit/15ac0ea8cb56c4ff2ae2485896936113490baeb6) | `` vscode-extensions.saoudrizwan.claude-dev: 3.16.1 -> 3.17.7 ``                                   |
| [`2b9bdd28`](https://github.com/NixOS/nixpkgs/commit/2b9bdd28caf08cf77206e6c10ce177b54fccc69c) | `` cargo-clone: 1.2.3 -> 1.2.4 ``                                                                  |
| [`978c04ed`](https://github.com/NixOS/nixpkgs/commit/978c04ed74800486689b68d6e9d4399308519966) | `` yazi: 25.4.8 -> 25.5.28 ``                                                                      |
| [`17501d77`](https://github.com/NixOS/nixpkgs/commit/17501d776b9af5a30f4dba37fb9c34a60a44bebb) | `` agda.withPackages: allow installing Agda without GHC using `ghc = null;` ``                     |
| [`0ae21fc3`](https://github.com/NixOS/nixpkgs/commit/0ae21fc32a4cdeb9abaaa801bfa9d3b82952408e) | `` geminicommit: 0.3.1 -> 0.4.0 ``                                                                 |
| [`81d2a488`](https://github.com/NixOS/nixpkgs/commit/81d2a488e6f8a4f9cfb99c7fc261afdf5f77da32) | `` nixos/mediagoblin: fix initial media reprocessing with gmg ``                                   |
| [`dd63ca89`](https://github.com/NixOS/nixpkgs/commit/dd63ca898e0d0a3780a830a71242b29d7c7baea9) | `` nixos/mediagoblin: fix gmg argument parsing ``                                                  |
| [`1948ad4b`](https://github.com/NixOS/nixpkgs/commit/1948ad4bb5aa16054e07cbfd0b585bd58763965b) | `` nixos/nvidia-container-toolkit: allow to provide CSV files ``                                   |
| [`dfaefc05`](https://github.com/NixOS/nixpkgs/commit/dfaefc053531399e9359f4d41054be4f7b597e45) | `` ci/check-cherry-picks: fail without proper cherry-pick ``                                       |
| [`a9b718b7`](https://github.com/NixOS/nixpkgs/commit/a9b718b79640e9c0ad4366391654fd4138248187) | `` ci/check-cherry-picks: never check older stable branches ``                                     |
| [`ea636d17`](https://github.com/NixOS/nixpkgs/commit/ea636d1728f25328511401c4919eec96e7426de0) | `` ci/check-cherry-picks: allow cherry-picking from haskell-updates and python-updates ``          |
| [`66c3fb9d`](https://github.com/NixOS/nixpkgs/commit/66c3fb9d01bd029a253995765864aad87dd80519) | `` bird3: 3.1.1 -> 3.1.2 ``                                                                        |
| [`81e2ec5b`](https://github.com/NixOS/nixpkgs/commit/81e2ec5bbf4d085978c63df3581a42fe660e2a5f) | `` spicedb-zed: 0.27.0 -> 0.30.2 (#404447) ``                                                      |
| [`ff4ae73e`](https://github.com/NixOS/nixpkgs/commit/ff4ae73e20782c2cbe348770c784707478867c72) | `` rclone: 1.69.2 -> 1.69.3 ``                                                                     |
| [`e575364a`](https://github.com/NixOS/nixpkgs/commit/e575364ae613c5e208862350c48a60e6234b3086) | `` workflows/check-cherry-picks: reduce checkout time ``                                           |
| [`245b1c1c`](https://github.com/NixOS/nixpkgs/commit/245b1c1c4859d4e5636dd2d3bccb3e4d3c44558e) | `` ci/check-cherry-picks: never use a pager ``                                                     |
| [`f204042a`](https://github.com/NixOS/nixpkgs/commit/f204042a37ff26330b38363f2b3d60e93ce76baa) | `` libfaketime: fix tests on loongarch64 and riscv64 ``                                            |
| [`02699958`](https://github.com/NixOS/nixpkgs/commit/0269995815f734088a9d547701fa1e3aafd1d256) | `` nixVersions.nix_2_29: fix loongarch64-linux build ``                                            |
| [`c464c44a`](https://github.com/NixOS/nixpkgs/commit/c464c44a42739a53a019e616055cbf4b8357871b) | `` nixos/gnome & nixos/gdm: move out of x11 ``                                                     |
| [`2fea2bbf`](https://github.com/NixOS/nixpkgs/commit/2fea2bbf527ec30a62892f146d1a42305f7aa8f8) | `` ci/check-cherry-picks: support different remotes than "origin" ``                               |
| [`54a8cac5`](https://github.com/NixOS/nixpkgs/commit/54a8cac5ca672001c4cae44aebdb40cdbbca9ed0) | `` python313Packages.python-bsblan: 1.2.1 -> 1.2.2 ``                                              |
| [`226d943b`](https://github.com/NixOS/nixpkgs/commit/226d943beb25844ab3bdef026d97da2f493438be) | `` tbls: 1.85.3 -> 1.85.4 ``                                                                       |
| [`99c53376`](https://github.com/NixOS/nixpkgs/commit/99c53376ed0273ef8200f3c27157b4199e9e38e9) | `` google-chrome: 136.0.7103.113->137.0.7151.55 ``                                                 |
| [`6cf5f9e8`](https://github.com/NixOS/nixpkgs/commit/6cf5f9e83bad75cb431661e35c7e15afe1fdc1e9) | `` ci/check-cherry-picks: run shellcheck ``                                                        |
| [`e2a37921`](https://github.com/NixOS/nixpkgs/commit/e2a37921691a3c0131114795d4b756aa7bd5d4a4) | `` ci/check-cherry-picks: improve error handling ``                                                |
| [`ad4b36d2`](https://github.com/NixOS/nixpkgs/commit/ad4b36d2d23e01c9c7303f4c9c6e1270a93dfe7f) | `` ci/check-cherry-picks: move from maintainers/scripts ``                                         |
| [`07a2ef8a`](https://github.com/NixOS/nixpkgs/commit/07a2ef8a4aedf3cb67b444455a5e7815fcce7946) | `` dotnet-repl: 0.3.239 -> 0.3.247 ``                                                              |
| [`0a2ca468`](https://github.com/NixOS/nixpkgs/commit/0a2ca468f8e17d2f1ea82213a58069fefcd95b23) | `` nh: 4.0.3 -> 4.1.0 ``                                                                           |
| [`1c2e5e19`](https://github.com/NixOS/nixpkgs/commit/1c2e5e194f786095373bc6667cf90fb419d89e11) | `` bird2: switch from fetching tarball to fetchFromGitLab ``                                       |
| [`3aa5c1af`](https://github.com/NixOS/nixpkgs/commit/3aa5c1af39347531f77b57cc5f367411c23e2afb) | `` thunderbird-latest-bin-unwrapped: 138.0.1 -> 139.0 ``                                           |
| [`8eee3798`](https://github.com/NixOS/nixpkgs/commit/8eee3798969670e8c3850e1eb05a5018f7064e94) | `` python312Packages.nutpie: 0.14.3 -> 0.15.0 ``                                                   |
| [`447ef0aa`](https://github.com/NixOS/nixpkgs/commit/447ef0aac68be22e8b4c6cc0e1370d215e264fc3) | `` showmethekey: 1.18.1 -> 1.18.2 ``                                                               |
| [`57e45731`](https://github.com/NixOS/nixpkgs/commit/57e45731129ea83f281301b4e6ab52917f616c1b) | `` openstack-rs: 0.12.0 -> 0.12.1 ``                                                               |
| [`af0cee18`](https://github.com/NixOS/nixpkgs/commit/af0cee180a0126056cf5f50c03e1846778bd8456) | `` vscode-extensions.svelte.svelte-vscode: 109.8.0 -> 109.8.1 ``                                   |
| [`547b2b43`](https://github.com/NixOS/nixpkgs/commit/547b2b43756b4b5c3313a3e1f528113603a77f19) | `` ocamlPackages.containers: 3.15 -> 3.16 ``                                                       |
| [`fb24b403`](https://github.com/NixOS/nixpkgs/commit/fb24b403c17c5faa6ea69b7b3c658a9061b8bf26) | `` nixosTests: fix eval ``                                                                         |
| [`b0e6c71f`](https://github.com/NixOS/nixpkgs/commit/b0e6c71f954eddb8822d031f33ab773bcfbde908) | `` python312Packages.pymc: 5.22.0 -> 5.23.0 ``                                                     |
| [`42a6689a`](https://github.com/NixOS/nixpkgs/commit/42a6689a17eb69046c5bb26aa5eee0d30f017242) | `` rl-2505: remove note about OpenSSH memlocking ``                                                |
| [`7c7d6c43`](https://github.com/NixOS/nixpkgs/commit/7c7d6c432113bca02ca6bbd6a2390272ecde8956) | `` libretro.stella: 0-unstable-2025-05-17 -> 0-unstable-2025-05-21 ``                              |
| [`9e287e88`](https://github.com/NixOS/nixpkgs/commit/9e287e88e85887cd7c7dc3c4514d249171ae0838) | `` initial coq package parseque version 0.2.2 ``                                                   |
| [`25c2b295`](https://github.com/NixOS/nixpkgs/commit/25c2b295bf5041ae0585bd978194b411c5b08b5c) | `` python3Packages.elevenlabs: 2.0.0 -> 2.2.0 ``                                                   |
| [`39c7929c`](https://github.com/NixOS/nixpkgs/commit/39c7929c6ec3c584d01b69c63914a1eaf9eef3ab) | `` openssh: disable memlocking when building with PAM support ``                                   |
| [`8c28147a`](https://github.com/NixOS/nixpkgs/commit/8c28147a8900b905fb1f83381f54b8683cb6b9ba) | `` pyfa: 2.62.3 -> 2.63.0 ``                                                                       |
| [`20b87a2b`](https://github.com/NixOS/nixpkgs/commit/20b87a2b145996abee2a8a40c60a5f8ab7c2f08e) | `` polarity: latest-unstable-2025-05-14 -> latest-unstable-2025-05-19 ``                           |
| [`16cbbb37`](https://github.com/NixOS/nixpkgs/commit/16cbbb374d78f9156a118ea816382ed3f03b4a9d) | `` ocamlPackages.lwt_eio: init at 0.5.1 ``                                                         |
| [`9cd1c58a`](https://github.com/NixOS/nixpkgs/commit/9cd1c58ae8f781aabecb9b3e4e8ece8a2aa21f7b) | `` amp-cli: 0.0.1748347293-g7a57b5 -> 0.0.1748404992-ga3f78f ``                                    |
| [`230ca6f2`](https://github.com/NixOS/nixpkgs/commit/230ca6f245d37eb979832ed28dc9a91c1cda31cc) | `` libretro.pcsx-rearmed: 0-unstable-2025-04-13 -> 0-unstable-2025-05-23 ``                        |
| [`56aa78f1`](https://github.com/NixOS/nixpkgs/commit/56aa78f17e210f3f0391bec4eec95184e5282406) | `` python3Packages.ocrmypdf: 16.10.1 -> 16.10.2 ``                                                 |
| [`9026992b`](https://github.com/NixOS/nixpkgs/commit/9026992bf0fd428dd490ecda33cdc23800fed446) | `` railway: 4.5.1 -> 4.5.3 ``                                                                      |
| [`721bad58`](https://github.com/NixOS/nixpkgs/commit/721bad584ec2e962e4d1d804f049a6b52592391d) | `` python3Packages.django-tenants: 3.7.0 -> 3.7.8 ``                                               |
| [`3d1f2964`](https://github.com/NixOS/nixpkgs/commit/3d1f29646e4b57ed468d60f9d286cde23a8d1707) | `` gqrx: 2.17.6 -> 2.17.7 ``                                                                       |
| [`5aba71fa`](https://github.com/NixOS/nixpkgs/commit/5aba71fa5ff6d2692954b0b34dc76acd423a6d72) | `` xpipe: 14.2 -> 16.4.1 ``                                                                        |
| [`905d8b75`](https://github.com/NixOS/nixpkgs/commit/905d8b756529b9682d23d4aacfc5d05ab87ab727) | `` linux_xanmod_latest: 6.14.6 -> 6.14.8 ``                                                        |
| [`3aa5e9ac`](https://github.com/NixOS/nixpkgs/commit/3aa5e9ac6bf873c771c87fc982341cc2e749670e) | `` linux_xanmod: 6.12.28 -> 6.12.30 ``                                                             |
| [`18ca00d0`](https://github.com/NixOS/nixpkgs/commit/18ca00d03e1b1ff8a3d7f2536e369dac14221500) | `` nixos/cryptpad: add selenium test ``                                                            |
| [`9d64a0b4`](https://github.com/NixOS/nixpkgs/commit/9d64a0b45266133d8f6b394e116f8f59c11dc098) | `` cryptpad: fix broken symlink that renders cryptpad unusable ``                                  |
| [`9ecb1568`](https://github.com/NixOS/nixpkgs/commit/9ecb156898854647eda171d499401f1f6e27167f) | `` linuxPackages.openafs: Patch for Linux kernel 6.15 ``                                           |
| [`3ce3fd1a`](https://github.com/NixOS/nixpkgs/commit/3ce3fd1aa51465839a1058a7fa2b3917f03662b3) | `` amdgpu_top: 0.10.4 -> 0.10.5 ``                                                                 |
| [`c65eab4d`](https://github.com/NixOS/nixpkgs/commit/c65eab4d427f73c9a227f6e72fdec01af19d3558) | `` cargo-shear: 1.2.7 -> 1.3.0 ``                                                                  |
| [`8d399f35`](https://github.com/NixOS/nixpkgs/commit/8d399f35cc57dfbfc09658fe7fdd284a0fd34dbc) | `` chromium,chromedriver: 136.0.7103.113 -> 137.0.7151.55 ``                                       |
| [`43032752`](https://github.com/NixOS/nixpkgs/commit/4303275296251ae6c18b0062811286f19dce28c3) | `` deepin.dde-tray-loader: 1.0.7 -> 1.0.9 ``                                                       |
| [`5de973ef`](https://github.com/NixOS/nixpkgs/commit/5de973ef09ab899254e6178ee582d940db044d74) | `` lint-staged: 16.0.0 -> 16.1.0 ``                                                                |
| [`d4519a6f`](https://github.com/NixOS/nixpkgs/commit/d4519a6f74c14cb7d800ac2e793cba65bc3c421e) | `` mona-sans: 1.0.1 -> 2.0 ``                                                                      |
| [`c689a968`](https://github.com/NixOS/nixpkgs/commit/c689a968aee514f8e9eafa3b6e2c40191f693ea6) | `` e1s: 1.0.47 -> 1.0.48 ``                                                                        |
| [`ce8805df`](https://github.com/NixOS/nixpkgs/commit/ce8805df96329509ddfaceadf1c94948d04621fc) | `` fastp: 0.24.1 -> 0.24.2 ``                                                                      |
| [`aa012865`](https://github.com/NixOS/nixpkgs/commit/aa01286569e779f544a68ea40127b8ac69c175b5) | `` wgpu-native: 24.0.3.1 -> 25.0.2.1 ``                                                            |
| [`ce08d17c`](https://github.com/NixOS/nixpkgs/commit/ce08d17cb5e32ecc41beb900df1c865f8d99b7db) | `` libretro-shaders-slang: 0-unstable-2025-05-17 -> 0-unstable-2025-05-20 ``                       |