### PR TITLE
chore(flake/home-manager): `214f9bd3` -> `379c9fb8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748618795,
-        "narHash": "sha256-XrNoXAbUenzde4NKMsuCYdmW8t+2/Ks+vcFrlwRh4K4=",
+        "lastModified": 1748627197,
+        "narHash": "sha256-7dTtcq4Yi78cHfZcJaxlqkNs+cDBotrHjR9mkXfiUz4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "214f9bd3a693bbc8cc6d705d01421787e04eaacd",
+        "rev": "379c9fb858ef9abe92d5590e7502a7c1387c076a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`379c9fb8`](https://github.com/nix-community/home-manager/commit/379c9fb858ef9abe92d5590e7502a7c1387c076a) | `` yazi: use mgr instead of manager in example (#7160) `` |
| [`6f0a6e7b`](https://github.com/nix-community/home-manager/commit/6f0a6e7ba7ab4fb01ced557378d64740554a0766) | `` Update translation files (#7162) ``                    |