### PR TITLE
chore(flake/home-manager): `379c9fb8` -> `7c60ea02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748627197,
-        "narHash": "sha256-7dTtcq4Yi78cHfZcJaxlqkNs+cDBotrHjR9mkXfiUz4=",
+        "lastModified": 1748648449,
+        "narHash": "sha256-5mhG43yYEEpLxEp6e683A8YiW4JHmWihF7XECjMM6Ns=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "379c9fb858ef9abe92d5590e7502a7c1387c076a",
+        "rev": "7c60ea029602851cdeb2f3246e991fcc117195bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`7c60ea02`](https://github.com/nix-community/home-manager/commit/7c60ea029602851cdeb2f3246e991fcc117195bc) | `` ci: add 'GitHub App' TODO to update workflow `` |
| [`9d2ae595`](https://github.com/nix-community/home-manager/commit/9d2ae59579b61a2137f12d87452733e3ab04d721) | `` ci: add backport workflow ``                    |