### PR TITLE
chore(flake/home-manager): `7c60ea02` -> `6d09fd37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748648449,
-        "narHash": "sha256-5mhG43yYEEpLxEp6e683A8YiW4JHmWihF7XECjMM6Ns=",
+        "lastModified": 1748654914,
+        "narHash": "sha256-3xn61GBqAaRXvdvr1cSPcDj3kivENs0x9aJHLOHGiNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c60ea029602851cdeb2f3246e991fcc117195bc",
+        "rev": "6d09fd37a7d4110251c1c03cb09fbf6321fbe10d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`6d09fd37`](https://github.com/nix-community/home-manager/commit/6d09fd37a7d4110251c1c03cb09fbf6321fbe10d) | `` ci: alternative fix for backport if condition (#7169) `` |
| [`b65126fa`](https://github.com/nix-community/home-manager/commit/b65126fa71e744c53fbae44d90139d3069711ac4) | `` ci: fix backport if condition (#7167) ``                 |