### PR TITLE
chore(flake/stylix): `8762da95` -> `64b9f2c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748699906,
-        "narHash": "sha256-pu2UKagKKysJ7EYeOcm8vWoZq1lcxfwfu3/C1Y3OFz8=",
+        "lastModified": 1748717073,
+        "narHash": "sha256-Yxo8A7BgNpRXTrB359LyfQ0NjJuiaLIS6sTTUCulEX0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8762da957b8b04b8b73248144f1c0ff7a88924b5",
+        "rev": "64b9f2c2df31bb87bdd2360a2feb58c817b4d16c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`64b9f2c2`](https://github.com/nix-community/stylix/commit/64b9f2c2df31bb87bdd2360a2feb58c817b4d16c) | `` stylix: yamlint ignore truthy for workflows (#1116) `` |
| [`093087e9`](https://github.com/nix-community/stylix/commit/093087e969e2ecfe1175dbf3cbc5c8624fde1c1e) | `` stylix: add imports to mkTarget (#1363) ``             |