### PR TITLE
chore(flake/lovesegfault-vim-config): `f29f93fd` -> `05328493`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748650126,
-        "narHash": "sha256-HEmWiNZREFaORq4/VLWf6l9J+SAKMgbN2c13/BMt8do=",
+        "lastModified": 1748822955,
+        "narHash": "sha256-M3la7FsXXPYgG1FuRi7GNa+s+1vqxIo+o5mTQEzZh18=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "f29f93fd646ea9617456dd082a3cf50f72d55b56",
+        "rev": "053284930d5e4a272552e1e042f258aa5569ebb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`05328493`](https://github.com/lovesegfault/vim-config/commit/053284930d5e4a272552e1e042f258aa5569ebb3) | `` chore(flake/nixpkgs): 96ec055e -> 910796ca ``     |
| [`044adb79`](https://github.com/lovesegfault/vim-config/commit/044adb794d82a1ae64cdfac2c973d5f919207ec9) | `` chore(flake/flake-parts): c621e842 -> 49f0870d `` |