### PR TITLE
chore(flake/stylix): `5f841056` -> `3ca2c447`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748803004,
-        "narHash": "sha256-dLGywKYxge3rzD6AqtVP0UmMHONdQNCWXj6i0lfm/UM=",
+        "lastModified": 1748887638,
+        "narHash": "sha256-AExfT8rMb6Ya37Gm3dimm+e4eeLGzya55JS6VWb3nfQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5f841056ca60bea7312aeade957da084cd95b26e",
+        "rev": "3ca2c4478a1e984d2007c57467c6986bcdcb2629",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                       |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`3ca2c447`](https://github.com/nix-community/stylix/commit/3ca2c4478a1e984d2007c57467c6986bcdcb2629) | `` firefox: add naho as maintainer (#1442) `` |
| [`a231e38d`](https://github.com/nix-community/stylix/commit/a231e38dfc995be1a42e8af0079e3506fa895f14) | `` firefox: use mkTarget (#1339) ``           |
| [`599c7619`](https://github.com/nix-community/stylix/commit/599c76190ffa51a78b89bdd5b57d23d95935471d) | `` gnome-text-editor: use mkTarget (#1384) `` |