### PR TITLE
chore(flake/home-manager): `c7fdb7e9` -> `5adc1a51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748830238,
-        "narHash": "sha256-EB+LzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R+6wMKU=",
+        "lastModified": 1748923085,
+        "narHash": "sha256-wXguCR+auZ5eoW8fKlm0C/6LNXL+1r4UXNLylwV7wQU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
+        "rev": "5adc1a51a2fa8efec9d4eaa4f7df97908cded00d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`5adc1a51`](https://github.com/nix-community/home-manager/commit/5adc1a51a2fa8efec9d4eaa4f7df97908cded00d) | `` ci: use flake lock for tests ``                   |
| [`c3297d77`](https://github.com/nix-community/home-manager/commit/c3297d772174eaffe5601822010c18e2f127e2eb) | `` tests: create `no-big` and `ifd` test outputs. `` |
| [`2ef52bca`](https://github.com/nix-community/home-manager/commit/2ef52bcab55dfbf4b7c2b23add43f549c9351bb7) | `` tests: pass enableLegacyIfd arg ``                |