### PR TITLE
chore(flake/home-manager): `5adc1a51` -> `cb809ec1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748923085,
-        "narHash": "sha256-wXguCR+auZ5eoW8fKlm0C/6LNXL+1r4UXNLylwV7wQU=",
+        "lastModified": 1748925027,
+        "narHash": "sha256-BJ0qRIdvt5aeqm3zg/5if7b5rruG05zrSX3UpLqjDRk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5adc1a51a2fa8efec9d4eaa4f7df97908cded00d",
+        "rev": "cb809ec1ff15cf3237c6592af9bbc7e4d983e98c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`cb809ec1`](https://github.com/nix-community/home-manager/commit/cb809ec1ff15cf3237c6592af9bbc7e4d983e98c) | `` fzf: prefer `source` for Zsh integration (#7191) `` |