### PR TITLE
chore(flake/nixos-hardware): `daa628a7` -> `fc7c4714`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748634340,
-        "narHash": "sha256-pZH4bqbOd8S+si6UcfjHovWDiWKiIGRNRMpmRWaDIms=",
+        "lastModified": 1748942041,
+        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "daa628a725ab4948e0e2b795e8fb6f4c3e289a7a",
+        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e9dcc95a`](https://github.com/NixOS/nixos-hardware/commit/e9dcc95a38974bcc05718a08a3a1c1629b0b35c3) | `` Add config file ``                                       |
| [`773b4912`](https://github.com/NixOS/nixos-hardware/commit/773b49122afe05a89748f71cff1250e8800e481c) | `` Added config file for Lenovo Thinkpad P14s AMD Gen 5 ``  |
| [`03107726`](https://github.com/NixOS/nixos-hardware/commit/03107726cd65509db5dead83b1599e90efa9e0ed) | `` Change libusb to libusb1 in pinebook keyboard updater `` |