### PR TITLE
chore(flake/stylix): `3ca2c447` -> `aa5e3c03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748887638,
-        "narHash": "sha256-AExfT8rMb6Ya37Gm3dimm+e4eeLGzya55JS6VWb3nfQ=",
+        "lastModified": 1748959135,
+        "narHash": "sha256-+zuNZIAbVGvGFnnCFrl0WVMvF4kHw9P5hRamgKoMy20=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3ca2c4478a1e984d2007c57467c6986bcdcb2629",
+        "rev": "aa5e3c03330b8daec5c249d5d58ee970a1afed86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`aa5e3c03`](https://github.com/nix-community/stylix/commit/aa5e3c03330b8daec5c249d5d58ee970a1afed86) | `` treewide: use mkTarget (batch 3) (#1371) ``      |
| [`ced2af06`](https://github.com/nix-community/stylix/commit/ced2af06228bdc3de98a68cc7baec4ca0dc6f0ed) | `` ci: use ubuntu-24.04 for update-flake (#1444) `` |