### PR TITLE
chore(flake/home-manager): `cb809ec1` -> `bb846c03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748925027,
-        "narHash": "sha256-BJ0qRIdvt5aeqm3zg/5if7b5rruG05zrSX3UpLqjDRk=",
+        "lastModified": 1748955489,
+        "narHash": "sha256-OmZXyW2g5qIuo5Te74McwR0TwauCO2sF3/SjGDVuxyg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cb809ec1ff15cf3237c6592af9bbc7e4d983e98c",
+        "rev": "bb846c031be68a96466b683be32704ef6e07b159",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`bb846c03`](https://github.com/nix-community/home-manager/commit/bb846c031be68a96466b683be32704ef6e07b159) | `` dwm-status: run with --quiet (#7144) ``                       |
| [`593b0c66`](https://github.com/nix-community/home-manager/commit/593b0c667d93404972ad8459ffdfc4f5af465d53) | `` doc: fix instructions for enabling flakes in NixOS (#7189) `` |