### PR TITLE
chore(flake/stylix): `aa5e3c03` -> `82d9424f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748959135,
-        "narHash": "sha256-+zuNZIAbVGvGFnnCFrl0WVMvF4kHw9P5hRamgKoMy20=",
+        "lastModified": 1748970111,
+        "narHash": "sha256-PmdrezN87CNzqTPnlC+YpLS7bZ0naeaD5d2eBFivXdY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "aa5e3c03330b8daec5c249d5d58ee970a1afed86",
+        "rev": "82d9424fffa709e162364c1397f816d232e6e1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`82d9424f`](https://github.com/nix-community/stylix/commit/82d9424fffa709e162364c1397f816d232e6e1d1) | `` doc: init server; `nix run .#docs` (#1328) ``                  |
| [`8d829119`](https://github.com/nix-community/stylix/commit/8d829119c5df4ad8064554547f198ea0630905b2) | `` wayprompt: drop '-hex' suffix on single color value (#1449) `` |
| [`d28012b0`](https://github.com/nix-community/stylix/commit/d28012b098421e741b7489493d8d5371d5911a7a) | `` wayfire: capitalize humanName value (#1451) ``                 |