### PR TITLE
chore(flake/lovesegfault-vim-config): `6c68e4f2` -> `5abb689d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748909215,
-        "narHash": "sha256-p2grn0eXxLhi3Oe8s9TZY06yp0P+GeYATqCGdrORmSY=",
+        "lastModified": 1748995624,
+        "narHash": "sha256-S78Fx71rvff2BkfFKhKAho6S2VOgEo7GYe1Y1lK9i1I=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "6c68e4f2b9560b3ceaa12398feec97f9a6b365bc",
+        "rev": "5abb689d88bf996d2794f9651a7687b582f98a72",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1748884506,
-        "narHash": "sha256-P/ldKE0SCGKH6pEVJoW2MJJo2dZCZe10d/h1ree66c0=",
+        "lastModified": 1748942960,
+        "narHash": "sha256-gJf3WxvDbvCpzIBVju/5GY/olW7zs/B1zDmB52AWMUM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d063d0dd5e0b82d8be4dd4bc00b887ac1f92e4b2",
+        "rev": "9328f4437d5f788d1c066b274a0aea492dc5fde2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`5abb689d`](https://github.com/lovesegfault/vim-config/commit/5abb689d88bf996d2794f9651a7687b582f98a72) | `` chore(flake/nixvim): d063d0dd -> 9328f443 `` |