### PR TITLE
chore(flake/darwin): `d46a0721` -> `fa6120c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748998583,
-        "narHash": "sha256-X8kkfgfqdYa/sqGpMdDkrLytS6mj89PJW+x22+r29Yg=",
+        "lastModified": 1749012745,
+        "narHash": "sha256-Cax/k9ZRPKqTz18vZtmqGR45pHRXM+sDvEVd4V/3NrU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "d46a07214fc25b6313f2ea3ba789cd7ff036aeb2",
+        "rev": "fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                    |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`f6b29e4a`](https://github.com/nix-darwin/nix-darwin/commit/f6b29e4af88c74b2f19101a5693ea3f2983e326b) | `` defaults: support `AppleKeyboardUIMode = 2` for newer macOS versions `` |