### PR TITLE
chore(flake/stylix): `82d9424f` -> `0db3ec02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748970111,
-        "narHash": "sha256-PmdrezN87CNzqTPnlC+YpLS7bZ0naeaD5d2eBFivXdY=",
+        "lastModified": 1749051426,
+        "narHash": "sha256-gt9qPBmZHMl0r5F3Ka8b0FH68vy1/8bqjIMEdwi0P8I=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "82d9424fffa709e162364c1397f816d232e6e1d1",
+        "rev": "0db3ec021518c6f7724a08f1d28bdf8fcc8c3935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`c0398eba`](https://github.com/nix-community/stylix/commit/c0398ebaa4697adf6006931bf8d7896ae1ee6c69) | `` ci: add 'has: port to stable' label for backports (#1367) ``        |
| [`3945a2d3`](https://github.com/nix-community/stylix/commit/3945a2d3495728e00f545b5e6f60be38e7d0b8c8) | `` flake: include 'until' in rename warning ``                         |
| [`47553c06`](https://github.com/nix-community/stylix/commit/47553c06fb6c8524ca7d3a1811d7005571778ff1) | `` flake: rename `packages.«system».docs` → `packages.«system».doc` `` |
| [`88c63899`](https://github.com/nix-community/stylix/commit/88c63899c7862a8dc9571b5a78efa8fafec1487a) | `` flake: introduce a `perSystem.stylix.aliases` option ``             |
| [`5c5d9fbc`](https://github.com/nix-community/stylix/commit/5c5d9fbc3b619dab08f6dd6e9270f78e577a2e9a) | `` flake: move deprecation module to its own directory ``              |
| [`d0a956c2`](https://github.com/nix-community/stylix/commit/d0a956c2c1b3a6a0f666ca689ba6528a665f50f1) | `` fontconfig: init ``                                                 |
| [`da1623ca`](https://github.com/nix-community/stylix/commit/da1623cab0eae5d90b676daf9b190c3a0e83efd9) | `` font-packages: init ``                                              |