### PR TITLE
chore(flake/home-manager): `34a13086` -> `ffab96a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748979197,
-        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
+        "lastModified": 1749049052,
+        "narHash": "sha256-wIt8ZBc8diKg1H5ibi3Bw9HUcPR2w3xy4ddcuzjgLb0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
+        "rev": "ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`ffab96a8`](https://github.com/nix-community/home-manager/commit/ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab) | `` qutebrowser: null package support (#7203) ``                 |
| [`3830a21a`](https://github.com/nix-community/home-manager/commit/3830a21aa2313239b582e4e4ac97f0b25243cb7a) | `` xdg.desktopEntries: Update outdated links in docs (#7201) `` |