### PR TITLE
chore(flake/nixos-hardware): `fc7c4714` -> `029bd66f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1748942041,
-        "narHash": "sha256-HEu2gTct7nY0tAPRgBtqYepallryBKR1U8B4v2zEEqA=",
+        "lastModified": 1749056381,
+        "narHash": "sha256-QITcurR19KZlrCngBoCjsFF2BdYsiCG4UqmlrVcLb8Q=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fc7c4714125cfaa19b048e8aaf86b9c53e04d853",
+        "rev": "029bd66faa180e11262dd1bc2732254c33415f52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`938f82a4`](https://github.com/NixOS/nixos-hardware/commit/938f82a4a9829b08beba62cfac32b7ad0b8e62da) | `` remove confusing acronym `` |