### PR TITLE
chore(flake/home-manager): `ffab96a8` -> `86b95fc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749049052,
-        "narHash": "sha256-wIt8ZBc8diKg1H5ibi3Bw9HUcPR2w3xy4ddcuzjgLb0=",
+        "lastModified": 1749062139,
+        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab",
+        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------- |
| [`86b95fc1`](https://github.com/nix-community/home-manager/commit/86b95fc1ed2b9b04a451a08ccf13d78fb421859c) | `` aichat: init (#7207) `` |