### PR TITLE
chore(flake/stylix): `0db3ec02` -> `a057acc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749051426,
-        "narHash": "sha256-gt9qPBmZHMl0r5F3Ka8b0FH68vy1/8bqjIMEdwi0P8I=",
+        "lastModified": 1749053445,
+        "narHash": "sha256-tf4MNRwJ5ikyg4+UfGuC1+GwMBQYh4dK4sdow1MEGVk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0db3ec021518c6f7724a08f1d28bdf8fcc8c3935",
+        "rev": "a057acc112856352e77d42ac4685134b2213a810",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------- |
| [`a057acc1`](https://github.com/nix-community/stylix/commit/a057acc112856352e77d42ac4685134b2213a810) | `` blender: init (#1147) `` |