### PR TITLE
chore(flake/deploy-rs): `aa07eb05` -> `6bc76b87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -144,11 +144,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727447169,
-        "narHash": "sha256-3KyjMPUKHkiWhwR91J1YchF6zb6gvckCAY1jOE+ne0U=",
+        "lastModified": 1749105467,
+        "narHash": "sha256-hXh76y/wDl15almBcqvjryB50B0BaiXJKk20f314RoE=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "aa07eb05537d4cd025e2310397a6adcedfe72c76",
+        "rev": "6bc76b872374845ba9d645a2f012b764fecd765f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                         |
| --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`3adb9c1e`](https://github.com/serokell/deploy-rs/commit/3adb9c1e228a9f0a7330aed7551f86af4b906bc6) | `` fix tests need the switch-to-configuration binary for successfull deploys `` |
| [`6fc0024f`](https://github.com/serokell/deploy-rs/commit/6fc0024f184b34089175722778e331b1e5ddadff) | `` fix the deprecated overlay flake output ``                                   |
| [`23aafa56`](https://github.com/serokell/deploy-rs/commit/23aafa564f50451e034087e3579c9f8edc2ada68) | `` fix error handling for activation timeout ``                                 |
| [`38d14da6`](https://github.com/serokell/deploy-rs/commit/38d14da6a1fc5e3156a89c608c9480335302362d) | `` remove deprecated flake attributes ``                                        |
| [`a6b0cb2c`](https://github.com/serokell/deploy-rs/commit/a6b0cb2c5e1c1efea2d48fdf7bb5b36b6675e40e) | `` update flake and rust dependencies ``                                        |
| [`e1a3bddc`](https://github.com/serokell/deploy-rs/commit/e1a3bddcf8aeda7391fe6c55204ec7dbdc3ac5fe) | `` src/cli.rs: remove forgotten comment ``                                      |
| [`1dcce82f`](https://github.com/serokell/deploy-rs/commit/1dcce82f5d6863013b3c3af283a0bea40209a98a) | `` src/lib.rs: refactor parse_flake & parse_file ``                             |
| [`589bde5b`](https://github.com/serokell/deploy-rs/commit/589bde5bb6e620566da2656195198e18b13fee0e) | `` tests: fix mistaken name of the non-flake-build test ``                      |
| [`d6b582dc`](https://github.com/serokell/deploy-rs/commit/d6b582dcfe228c5d5b1c83a4c4f1f09e6842011b) | `` allow remote builds with non-flake nix ``                                    |
| [`6c12d844`](https://github.com/serokell/deploy-rs/commit/6c12d8447de9873b259780b871a1f3d7b7addbb4) | `` allow non-flake builds with flake-enabled nix ``                             |