### PR TITLE
chore(flake/disko): `a4f7deb4` -> `d74db625`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749089136,
-        "narHash": "sha256-A1UgwtAEQYd38Z6VoRAiGs4jZQczAGyP5DF3hhYUdpg=",
+        "lastModified": 1749147380,
+        "narHash": "sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "a4f7deb49f7336feb6c5abaf213b374936421dbe",
+        "rev": "d74db625a5cf3f46cf8fa545d6ef10bd3463ea07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`d74db625`](https://github.com/nix-community/disko/commit/d74db625a5cf3f46cf8fa545d6ef10bd3463ea07) | `` remove quotes from --label creation for bcachefs `` |