### PR TITLE
chore(flake/home-manager): `13a45ede` -> `68cc9eeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749131129,
-        "narHash": "sha256-tJ+93i7N4QttM75bE8T09LlSU3Mv6Dfi9WaVBvlWilo=",
+        "lastModified": 1749160002,
+        "narHash": "sha256-IM3xKjsKxhu7Y1WdgTltrLKiOJS8nW7D4SUDEMNr7CI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "13a45ede6c17b5e923dfc18a40a3f646436f4809",
+        "rev": "68cc9eeb3875ae9682c04629f20738e1e79d72aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`68cc9eeb`](https://github.com/nix-community/home-manager/commit/68cc9eeb3875ae9682c04629f20738e1e79d72aa) | `` jellyfin-mpv-shim: merge settings with existing config file ``   |
| [`7707ebb0`](https://github.com/nix-community/home-manager/commit/7707ebb05c6a021e730fdefdb41c2b7e8133251d) | `` jellyfin-mpv-shim: make sure the config file is read properly `` |
| [`09b0a4b0`](https://github.com/nix-community/home-manager/commit/09b0a4b0da86c12a57976028bbda3897137c9528) | `` dconf: revert: dconf: Provide dconf (#7215) ``                   |