### PR TITLE
chore(flake/home-manager): `68cc9eeb` -> `91287a0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749160002,
-        "narHash": "sha256-IM3xKjsKxhu7Y1WdgTltrLKiOJS8nW7D4SUDEMNr7CI=",
+        "lastModified": 1749178927,
+        "narHash": "sha256-bXcEx1aZUNm5hMLVJeuofcOrZyOiapzvQ7K36HYK3YQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "68cc9eeb3875ae9682c04629f20738e1e79d72aa",
+        "rev": "91287a0e9d42570754487b7e38c6697e15a9aab2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`91287a0e`](https://github.com/nix-community/home-manager/commit/91287a0e9d42570754487b7e38c6697e15a9aab2) | `` nixgl: remove alias (#7218) ``                                              |
| [`355c7d09`](https://github.com/nix-community/home-manager/commit/355c7d09ede3335b6642cf1736de3df0d4fdd136) | `` chawan: fix example for settings (#7210) ``                                 |
| [`bbb31d83`](https://github.com/nix-community/home-manager/commit/bbb31d835230720c7a5bc085412776c61dabc7bc) | `` ludusavi: fix import (#7205) ``                                             |
| [`0ee810c8`](https://github.com/nix-community/home-manager/commit/0ee810c839ee73b2d3973f5683f9a3bf8d430e8a) | `` zed-editor: respect user interactivity with settings and keymaps (#6993) `` |
| [`de8463dd`](https://github.com/nix-community/home-manager/commit/de8463dd3ef259502b937fac37fadd6adc252bfe) | `` zsh: add plugins.*.completions paths to fpath (#7197) ``                    |