### PR TITLE
chore(flake/treefmt-nix): `1f3f7b78` -> `a05be418`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -956,11 +956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748243702,
-        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
+        "lastModified": 1749194973,
+        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`a05be418`](https://github.com/numtide/treefmt-nix/commit/a05be418a1af1198ca0f63facb13c985db4cb3c5) | `` Add cabal-gild, a cabal formatter (#361) ``                             |
| [`6a846d38`](https://github.com/numtide/treefmt-nix/commit/6a846d387e641a534c388de44c6cf804c3380feb) | `` Use `flake.nix` for the project root when dealing with flakes (#364) `` |
| [`4a098324`](https://github.com/numtide/treefmt-nix/commit/4a0983243bc1b3c34150dc88307d543e96bc052c) | `` templ: adds needed go pkg (#365) ``                                     |