### PR TITLE
chore(flake/disko): `d74db625` -> `17d08c65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749147380,
-        "narHash": "sha256-UvCI5f1qD9l1fCQkoG/kJI0yNjDQIiJaN7gkve8fmII=",
+        "lastModified": 1749200714,
+        "narHash": "sha256-W8KiJIrVwmf43JOPbbTu5lzq+cmdtRqaNbOsZigjioY=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d74db625a5cf3f46cf8fa545d6ef10bd3463ea07",
+        "rev": "17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                      |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`17d08c65`](https://github.com/nix-community/disko/commit/17d08c65c241b1d65b3ddf79e3fac1ddc870b0f6) | `` CONTRIBUTING.md: add documentation on how to run tests `` |
| [`6d06f63f`](https://github.com/nix-community/disko/commit/6d06f63fc03e7a61608145ab9731aa6941d48fae) | `` use fileset when building disko ``                        |