### PR TITLE
chore(flake/home-manager): `96482a53` -> `2d7d65f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749221014,
-        "narHash": "sha256-mqrpuP/lfyDmta5hJWTwWgdF5lwdiubcGs7oRvcTZ2s=",
+        "lastModified": 1749243446,
+        "narHash": "sha256-P1gumhZN5N9q+39ndePHYrtwOwY1cGx+VoXGl+vTm7A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "96482a538e6103579d254b139759d0536177370b",
+        "rev": "2d7d65f65b61fdfce23278e59ca266ddd0ef0a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2d7d65f6`](https://github.com/nix-community/home-manager/commit/2d7d65f65b61fdfce23278e59ca266ddd0ef0a36) | `` fish: fix the binds.*.erase option (#7186) ``     |
| [`1d595a5b`](https://github.com/nix-community/home-manager/commit/1d595a5b64fb887dd67dd98866af30b1a37b0f7a) | `` zed-editor: allow for nullable package (#7220) `` |