### PR TITLE
chore(flake/flake-parts): `49f0870d` -> `9305fe4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -214,11 +214,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1748821116,
-        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                    |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`ba8a81c1`](https://github.com/hercules-ci/flake-parts/commit/ba8a81c1a070b168c07f3f16ef73b592cdf8abbb) | `` Add flake-parts-lib.importAndPublish `` |