### PR TITLE
chore(flake/nix-fast-build): `eb8c7bc1` -> `b1dae483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1749399339,
-        "narHash": "sha256-agVRwgbNaKMVRZOqthP6buxa2PkTbJ3bxSC0jSOz6G4=",
+        "lastModified": 1749427739,
+        "narHash": "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "eb8c7bc1619c4e6b232173893e95cb5957e43e85",
+        "rev": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`b1dae483`](https://github.com/Mic92/nix-fast-build/commit/b1dae483ab7d4139a6297e02b6de9e5d30e43d48) | `` chore(deps): lock file maintenance (#184) `` |