### PR TITLE
chore(flake/lovesegfault-vim-config): `5616f576` -> `ed079217`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749427747,
-        "narHash": "sha256-67hgh7/b/A9YW+XsNL50hXdF333pA5eABfvYaC28r8Y=",
+        "lastModified": 1749427909,
+        "narHash": "sha256-XIXcOFo/Zeo03cVBGZ2mUcbobxmgOsRXicRLoAxDl+w=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "5616f576ec4f777f26f7f553db3fa6ba4ec9e640",
+        "rev": "ed079217af10f18c591a6db13f0e5dd4c20d3074",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`ed079217`](https://github.com/lovesegfault/vim-config/commit/ed079217af10f18c591a6db13f0e5dd4c20d3074) | `` chore(flake/nixpkgs): d3d2d80a -> 3e3afe51 `` |