### PR TITLE
chore(flake/stylix): `5869510e` -> `d73d8f6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749398498,
-        "narHash": "sha256-Usx6sGnT/D8ZnWiZg+J1OY3dp4ZssMQiN1XeXcsL/cs=",
+        "lastModified": 1749481862,
+        "narHash": "sha256-CXZL1Kt4rP1SAQhT4wCM207pcjkTeZMza9iIVFKV71c=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5869510e48e64d916dc6905dc664a02b0f85f1bd",
+        "rev": "d73d8f6a4834716496bf8930a492b115cc3d7d17",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`289356d0`](https://github.com/nix-community/stylix/commit/289356d03169542e5ef90f37fafa165e0fe8bae9) | `` treewide: use `mkEnableTargetWith` for dynamic conditions ``           |
| [`67b4644e`](https://github.com/nix-community/stylix/commit/67b4644e700747cb1b6e4748d9f04646c29f7295) | `` stylix: use `mkEnableTargetWith` in `mkTarget` ``                      |
| [`0449dae6`](https://github.com/nix-community/stylix/commit/0449dae6d4b31e269a1c6ccfcd2c1af0916dc916) | `` stylix: allow specifying `autoEnableExpr` in `mkEnableTargetWith` ``   |
| [`a4d92fea`](https://github.com/nix-community/stylix/commit/a4d92fea8771b608d1b4db27b9b13cb8f84e65f7) | `` stylix: split `mkEnableTarget` into `mkEnableTargetWith` ``            |
| [`92276a14`](https://github.com/nix-community/stylix/commit/92276a14a70b87578a31730974d18a243207d028) | `` stylix: add `mkEnableIf` ``                                            |
| [`93eb9c54`](https://github.com/nix-community/stylix/commit/93eb9c5401b0efe517d9fe782638012fec99ebef) | `` stylix: simplify `mkEnableTarget` & `mkEnableWallpaper` defaultText `` |
| [`df428b56`](https://github.com/nix-community/stylix/commit/df428b562dec0c4a31f257962ab93bc6c998608d) | `` qt: use a static `autoEnable=true` on NixOS ``                         |