### PR TITLE
chore(flake/lovesegfault-vim-config): `ed079217` -> `c73d0aa5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749427909,
-        "narHash": "sha256-XIXcOFo/Zeo03cVBGZ2mUcbobxmgOsRXicRLoAxDl+w=",
+        "lastModified": 1749513998,
+        "narHash": "sha256-gOtJiOzmaL0wwvDYQoXZhd2tTwJJvJLnohdweT1g2l0=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "ed079217af10f18c591a6db13f0e5dd4c20d3074",
+        "rev": "c73d0aa50d7ec8f7abab3be57b8eab7658c77c0b",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1749420898,
-        "narHash": "sha256-QiB3xDyHuj2VzS6AaALTeikLt6EsZyMjDRmzb4y2vFM=",
+        "lastModified": 1749496904,
+        "narHash": "sha256-eNDMzrcDBOprdJs7DpMOJfCEcxribxDJP2OjozSC3Wo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2b6f694b48f43bbd89dcc21e8aa7aa676eb18eb8",
+        "rev": "e0b3d8bc3a0ab5a7cc0792c7705e92f9c5c598f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`c73d0aa5`](https://github.com/lovesegfault/vim-config/commit/c73d0aa50d7ec8f7abab3be57b8eab7658c77c0b) | `` chore(flake/nixvim): 2b6f694b -> e0b3d8bc `` |