### PR TITLE
chore(flake/home-manager): `450f06ec` -> `faeab325`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749628652,
-        "narHash": "sha256-f8jDF4G9m7pPySeQc6KskqMgtcJq6X1o2CytMx66qAE=",
+        "lastModified": 1749657191,
+        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "450f06ec3cd0d86f67db58a7245db8848773e895",
+        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`faeab325`](https://github.com/nix-community/home-manager/commit/faeab32528a9360e9577ff4082de2d35c6bbe1ce) | `` ci: fix bars labeler (#7253) `` |
| [`02040b77`](https://github.com/nix-community/home-manager/commit/02040b7777f65342b96c7f826a5c6aef95585057) | `` flake.lock: Update (#7251) ``   |