### PR TITLE
chore(flake/darwin): `19346808` -> `e2da3338`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194393,
-        "narHash": "sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo=",
+        "lastModified": 1749711103,
+        "narHash": "sha256-rda+GeR5Szqt7wx4U2zxTGzcHvbZC62eFWryiAUpp4Y=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "19346808c445f23b08652971be198b9df6c33edc",
+        "rev": "e2da3338ab876fb7da480ba0cf3331a229e377f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                               |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`63c31af3`](https://github.com/nix-darwin/nix-darwin/commit/63c31af37a79bd2847243e679fa5bff2537bffcd) | `` etc: add known hashes for zprofile and zshrc in macOS 26 beta 1 `` |