### PR TITLE
chore(flake/darwin): `e2da3338` -> `72c88d59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749711103,
-        "narHash": "sha256-rda+GeR5Szqt7wx4U2zxTGzcHvbZC62eFWryiAUpp4Y=",
+        "lastModified": 1749739639,
+        "narHash": "sha256-oubMGIrW/vBdX+xw47LEcxrqYqZUdLYPE8xrLDKoBE8=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e2da3338ab876fb7da480ba0cf3331a229e377f0",
+        "rev": "72c88d5928196159e3a0d03e67b25d8044546ca6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`7c284a65`](https://github.com/nix-darwin/nix-darwin/commit/7c284a650484c90cf928779d77d9faa3f173522e) | `` Avoid confusing users with future deprecations `` |