### PR TITLE
chore(flake/stylix): `e7fa0e5c` -> `5b74d930`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749670558,
-        "narHash": "sha256-luB+SFNy+etZK3PVznJSLps1DPYsGya6o/67Emcrtb0=",
+        "lastModified": 1749742521,
+        "narHash": "sha256-1ap2sXPuFByrpSrxv4qtF+kcEvzh6CXGss5mhnUDv4M=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7fa0e5cc2336b6b25310d5e49c149f14fdbc1bb",
+        "rev": "5b74d930209bdafc186695a7c22da251f05ab790",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`5b74d930`](https://github.com/nix-community/stylix/commit/5b74d930209bdafc186695a7c22da251f05ab790) | `` k9s: apply upstream breaking changes (#1382) ``                  |
| [`1a471ee9`](https://github.com/nix-community/stylix/commit/1a471ee95e1c7a69f15ce75b5f6b1fe9ede9a778) | `` neovim: combine Neovim, Neovide, NixVim, nvf, and Vim (#1377) `` |
| [`e9eb2308`](https://github.com/nix-community/stylix/commit/e9eb2308ff5b2cec8ff608edf707fef9c5f8909b) | `` i3bar-river: init (#1415) ``                                     |