### PR TITLE
chore(flake/stylix): `5b74d930` -> `75411fe2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749742521,
-        "narHash": "sha256-1ap2sXPuFByrpSrxv4qtF+kcEvzh6CXGss5mhnUDv4M=",
+        "lastModified": 1749755665,
+        "narHash": "sha256-wHj2qCyJLF5RGl7sydnjJVQ8WKZmdkLy5MuqY9zivRs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5b74d930209bdafc186695a7c22da251f05ab790",
+        "rev": "75411fe2b90f67bfb4a2ad9cc3b1379758b64dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`75411fe2`](https://github.com/nix-community/stylix/commit/75411fe2b90f67bfb4a2ad9cc3b1379758b64dbb) | `` swaylock: use mkTarget (#1481) ``           |
| [`dcf0f177`](https://github.com/nix-community/stylix/commit/dcf0f17712d0b07648b24f79b26b8728e2af25c2) | `` vscode: use mkTarget (#1477) ``             |
| [`744385ee`](https://github.com/nix-community/stylix/commit/744385eedf233d53c0701e3845c826b70016a8b7) | `` mkTarget: allow _${arg} ``                  |
| [`5d1ed786`](https://github.com/nix-community/stylix/commit/5d1ed786ff997aafd9021f8de5cef4b21d9e408c) | `` deadnix: ignore bindings starting with _ `` |