### PR TITLE
chore(flake/stylix): `75411fe2` -> `34393859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749755665,
-        "narHash": "sha256-wHj2qCyJLF5RGl7sydnjJVQ8WKZmdkLy5MuqY9zivRs=",
+        "lastModified": 1749767991,
+        "narHash": "sha256-tgKABKKmQMEU6Mlsi5fJ37AgWCQVnf8bQUd2Pv9x/sk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "75411fe2b90f67bfb4a2ad9cc3b1379758b64dbb",
+        "rev": "343938594e57483635d6fb34d90c227e8dd46072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`34393859`](https://github.com/nix-community/stylix/commit/343938594e57483635d6fb34d90c227e8dd46072) | `` doc: remove redundant documentation dummy values (#1318) ``                  |
| [`9724654e`](https://github.com/nix-community/stylix/commit/9724654e8d8ac2e48205efa33497ec1bc9540e62) | `` yazi: update tabs theming style (#1480) ``                                   |
| [`58b1de7e`](https://github.com/nix-community/stylix/commit/58b1de7ebf6e133f12bac249901fe701ad17f3f1) | `` stylix: refactor `base16Scheme` and `lib.stylix.colors` assertion (#1446) `` |