### PR TITLE
chore(flake/home-manager): `faeab325` -> `18f3a0d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749657191,
-        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
+        "lastModified": 1749779443,
+        "narHash": "sha256-r6YTIMprNCYcJcA4oZ0x1wPaHPPHUxb8CnyEeMkhGks=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
+        "rev": "18f3a0d21c3739a242aafa17c04c5238bbab5a41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`18f3a0d2`](https://github.com/nix-community/home-manager/commit/18f3a0d21c3739a242aafa17c04c5238bbab5a41) | `` opensnitch-ui: add package option (#7260) ``                                     |
| [`0215073a`](https://github.com/nix-community/home-manager/commit/0215073a704e9b8992d8e59761344d83d8c72e8b) | `` ashell: add module ``                                                            |
| [`dd12be86`](https://github.com/nix-community/home-manager/commit/dd12be8603041a26f56f8d0cc9199c6e88a7fb14) | `` maintainers: add justdeeevin ``                                                  |
| [`09859234`](https://github.com/nix-community/home-manager/commit/09859234f8a8fee31a1e2293f101504324578199) | `` zed-editor: don't add activation scripts if there is nothing to merge (#7254) `` |
| [`5ab15331`](https://github.com/nix-community/home-manager/commit/5ab15331c213350b2c6611454b5f7abb660568af) | `` targets/darwin: fix ShowDate default description (#7256) ``                      |