### PR TITLE
chore(flake/nixos-hardware): `4602f7e1` -> `b328aa78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749195551,
-        "narHash": "sha256-W5GKQHgunda/OP9sbKENBZhMBDNu2QahoIPwnsF6CeM=",
+        "lastModified": 1749808356,
+        "narHash": "sha256-VQ2HFRVz0VxjYYFtdRTlAq/PuOT+j876YTWubk0WLJM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4602f7e1d3f197b3cb540d5accf5669121629628",
+        "rev": "b328aa7871068d9f98b656d8f6829b39a541a114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`62acc1db`](https://github.com/NixOS/nixos-hardware/commit/62acc1db8ecebdda404eb86a0e3c947f4ec573ea) | `` xiaomi/redmibook/16-pro-2024: remove boot fix ``    |
| [`ddd49b38`](https://github.com/NixOS/nixos-hardware/commit/ddd49b38e4994c200e9d1f135a5d1c5e52ea8932) | `` Forgot README ``                                    |
| [`12b4b1a9`](https://github.com/NixOS/nixos-hardware/commit/12b4b1a92966020c748097e5feaf8a2ce585abe7) | `` Add support for TUXEDO InfinityBook Pro AMD Gen9 `` |
| [`34762bf4`](https://github.com/NixOS/nixos-hardware/commit/34762bf406b82fd06e71d78556884f04f7d409fd) | `` added inspiron 3442 to the flake ``                 |