### PR TITLE
chore(flake/darwin): `72c88d59` -> `2f140d6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749739639,
-        "narHash": "sha256-oubMGIrW/vBdX+xw47LEcxrqYqZUdLYPE8xrLDKoBE8=",
+        "lastModified": 1749873626,
+        "narHash": "sha256-1Mc/D/1RwwmDKY59f4IpDBgcQttxffm+4o0m67lQ8hc=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "72c88d5928196159e3a0d03e67b25d8044546ca6",
+        "rev": "2f140d6ac8840c6089163fb43ba95220c230f22b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                      |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------- |
| [`0721726e`](https://github.com/nix-darwin/nix-darwin/commit/0721726e213d0274b8626f32b4e95617e6ab58bf) | `` Wrap the call with env ``                 |
| [`300af6fc`](https://github.com/nix-darwin/nix-darwin/commit/300af6fcc5303203fa0af5b7ab2e81f2131a6a80) | `` Preserve PATH variable when using sudo `` |