### PR TITLE
chore(flake/stylix): `c79ad485` -> `77a8b265`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749824792,
-        "narHash": "sha256-fhEA3GngWkfktSI/7dLdlirgUS9nmXmJGisOs5ozTMw=",
+        "lastModified": 1749905587,
+        "narHash": "sha256-sZpQM+InPCYwJQiTxs/PCCupwbYNaSCFi2Hvpl1/pOo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c79ad485612a0277c1e25a0bcc562eea11b563d8",
+        "rev": "77a8b26520f48305f3b1bacffaa8740dde8afa2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`77a8b265`](https://github.com/nix-community/stylix/commit/77a8b26520f48305f3b1bacffaa8740dde8afa2a) | `` doc: update docs on building docs (#1499) ``       |
| [`751d6c5d`](https://github.com/nix-community/stylix/commit/751d6c5df0841a0dc213c71f7d43b63abe9449db) | `` doc: Add VSCode color customization tip (#1461) `` |