### PR TITLE
chore(flake/home-manager): `c5f34515` -> `04672588`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749944797,
-        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
+        "lastModified": 1749999552,
+        "narHash": "sha256-iCUuEq9qXUh8L1c2bRyCayAqfuUEs9nGAUlXv2RcoF8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
+        "rev": "04672588c61aebd18c0d0ada66dd7bb4d8edab0d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`04672588`](https://github.com/nix-community/home-manager/commit/04672588c61aebd18c0d0ada66dd7bb4d8edab0d) | `` way-displays: support stateful configuration file (#7138) `` |
| [`dceefa87`](https://github.com/nix-community/home-manager/commit/dceefa87dc19661186f2c519dce6a9670a1d1b36) | `` ncspot: make package nullable ``                             |
| [`6e36b1be`](https://github.com/nix-community/home-manager/commit/6e36b1be0b477547967178422d6b6aedf8efb79b) | `` ncspot: adopt ``                                             |