### PR TITLE
chore(flake/home-manager): `04672588` -> `cef3e0ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749999552,
-        "narHash": "sha256-iCUuEq9qXUh8L1c2bRyCayAqfuUEs9nGAUlXv2RcoF8=",
+        "lastModified": 1750031117,
+        "narHash": "sha256-A6iD8FldV90tJifbfJb6+OMdJhJ5D3zJWIcICeN+QKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "04672588c61aebd18c0d0ada66dd7bb4d8edab0d",
+        "rev": "cef3e0adc0b671062c2f911b46d9aacfd7235816",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`cef3e0ad`](https://github.com/nix-community/home-manager/commit/cef3e0adc0b671062c2f911b46d9aacfd7235816) | `` maintainers: update aguirre-matteo email (#7279) ``  |
| [`83030f0e`](https://github.com/nix-community/home-manager/commit/83030f0e4a82a1f39f13fc057e3510938841c761) | `` ci: labeler issues permission (#7278) ``             |
| [`676e40a2`](https://github.com/nix-community/home-manager/commit/676e40a2464783e05146ab5cb196a68230dffc45) | `` sketchybar: inherit meta in finalPackage (#7276) ``  |
| [`30b6daf8`](https://github.com/nix-community/home-manager/commit/30b6daf8723429190e56bc2f296837578c41aca8) | `` kakoune: implement a final package option (#7275) `` |