### PR TITLE
chore(flake/nixos-hardware): `db030f62` -> `61837d2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1749832440,
-        "narHash": "sha256-lfxhuxAaHlYFGr8yOrAXZqdMt8PrFLzjVqH9v3lQaoY=",
+        "lastModified": 1750083401,
+        "narHash": "sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "db030f62a449568345372bd62ed8c5be4824fa49",
+        "rev": "61837d2a33ccc1582c5fabb7bf9130d39fee59ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`9b86fa5d`](https://github.com/NixOS/nixos-hardware/commit/9b86fa5d67f0192d8f2f8d3fcd8a019664b41c55) | `` Add 16iah7h ``                                                  |
| [`16aad554`](https://github.com/NixOS/nixos-hardware/commit/16aad554b0f1a5ac40cce80c8681c06d8907c56b) | `` removed explicit gpu mention as it's included in cpu profile `` |