### PR TITLE
chore(flake/lovesegfault-vim-config): `dfd3d3a3` -> `d34728d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750032409,
-        "narHash": "sha256-o9IEEFUkbHCrVvBNENKb2LNFWp4jzA7iAoCFZ/vLpbg=",
+        "lastModified": 1750118843,
+        "narHash": "sha256-X99QY/sorztynxCibMlZe3JpLS8hiVOYhj1ac82BwC4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "dfd3d3a31962e584f914c605e943ae152d4bafba",
+        "rev": "d34728d4fc2f66326d211142b38d87337513cea3",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750022650,
-        "narHash": "sha256-Dllcid/yOQYlsvy+Fne3JvGq85CAHpKkiLfh9wSMPrM=",
+        "lastModified": 1750105753,
+        "narHash": "sha256-reWddMyGkxjackE4VSZ2NjOQlAdfiofhCEWFHapblNI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7176d51a343c642d4cc6c4ac3f547b54850b0e82",
+        "rev": "ab0a3682cc40da89029dcb3f467b46ae3b8c0fd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`d34728d4`](https://github.com/lovesegfault/vim-config/commit/d34728d4fc2f66326d211142b38d87337513cea3) | `` chore(flake/nixvim): 7176d51a -> ab0a3682 `` |