### PR TITLE
chore(flake/agenix): `4835b1dc` -> `531beac6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747575206,
-        "narHash": "sha256-NwmAFuDUO/PFcgaGGr4j3ozG9Pe5hZ/ogitWhY+D81k=",
+        "lastModified": 1750173260,
+        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "4835b1dc898959d8547a871ef484930675cb47f1",
+        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                    |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`531beac6`](https://github.com/ryantm/agenix/commit/531beac616433bac6f9e2a19feb8e99a22a66baf) | `` Improve `age.identityPaths must be set` error (#335) `` |