### PR TITLE
chore(flake/home-manager): `f754e377` -> `0f355844`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750256996,
-        "narHash": "sha256-xPH4tgE7yIeBtOn54B6iDzMGXrf7mWvODML+DCN+H8I=",
+        "lastModified": 1750275572,
+        "narHash": "sha256-upC/GIlsIgtdtWRGd1obzdXWYQptNkfzZeyAFWgsgf0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f754e377dc2da5d34dfea6a5215c21741eaf8930",
+        "rev": "0f355844e54e4c70906b1ef5cc35a0047d666c04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`0f355844`](https://github.com/nix-community/home-manager/commit/0f355844e54e4c70906b1ef5cc35a0047d666c04) | `` tests/firefox: fix bookmarks test (#7292) `` |
| [`85e68c6a`](https://github.com/nix-community/home-manager/commit/85e68c6a388ef1dfc799aaa01f00758c58e87d89) | `` tests/neovim: stub meta.teams ``             |
| [`70c289b5`](https://github.com/nix-community/home-manager/commit/70c289b54dec227d8b42fc33fd3e8bd5b7c032f9) | `` i3status-rust: farlion -> workflow ``        |
| [`df9fddf7`](https://github.com/nix-community/home-manager/commit/df9fddf70ce619cee027c904a2f796de8ad2720d) | `` flake.lock: Update ``                        |