### PR TITLE
chore(flake/darwin): `2f140d6a` -> `0d71cbf8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749873626,
-        "narHash": "sha256-1Mc/D/1RwwmDKY59f4IpDBgcQttxffm+4o0m67lQ8hc=",
+        "lastModified": 1750325256,
+        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "2f140d6ac8840c6089163fb43ba95220c230f22b",
+        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                        |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`82566dd2`](https://github.com/nix-darwin/nix-darwin/commit/82566dd25414241193275f49a645680b23a4c107) | `` programs/ssh: remove `with lib;` ``                         |
| [`a991859d`](https://github.com/nix-darwin/nix-darwin/commit/a991859d1f404e89875e744517fc79bb79f8e0ff) | `` nixos/ssh: undeprecate knownHosts.«name».hostNames ``       |
| [`9d5b27bc`](https://github.com/nix-darwin/nix-darwin/commit/9d5b27bc93a3c845f4e834182c1112b34ead7ffe) | `` modules/programs/ssh: knownHosts -> extraKnownHosts ``      |
| [`2d257c09`](https://github.com/nix-darwin/nix-darwin/commit/2d257c09a1bdcaadf1574e0c6f2f284ee457602d) | `` programs.ssh.knownHosts: update example to be an attrset `` |
| [`04b04f4b`](https://github.com/nix-darwin/nix-darwin/commit/04b04f4b9dcf037ac3feda91d617c3f44b603007) | `` programs/ssh: move to match path in NixOS ``                |