### PR TITLE
chore(flake/stylix): `2b231cdc` -> `8c1421ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750362693,
-        "narHash": "sha256-KFfm5lWvUaUAVQcjQ6cRAGNbi4TfJDc7fId/79Psd5U=",
+        "lastModified": 1750369088,
+        "narHash": "sha256-njtrVYrl+4I3ikgAoKLyQ+5MZ1BKwazAiEpLq2efwrE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2b231cdc9b0537f57be8260463d7e96fe22138ed",
+        "rev": "8c1421ae02475a874f2a09cc4a7ad6de63fbc9e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`8c1421ae`](https://github.com/nix-community/stylix/commit/8c1421ae02475a874f2a09cc4a7ad6de63fbc9e8) | `` stylix: honour recent docs to doc renames (#1493) `` |