### PR TITLE
chore(flake/nixos-hardware): `61837d2a` -> `1552a9f4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1750083401,
-        "narHash": "sha256-ynqbgIYrg7P1fAKYqe8I/PMiLABBcNDYG9YaAP/d/C4=",
+        "lastModified": 1750431636,
+        "narHash": "sha256-vnzzBDbCGvInmfn2ijC4HsIY/3W1CWbwS/YQoFgdgPg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "61837d2a33ccc1582c5fabb7bf9130d39fee59ad",
+        "rev": "1552a9f4513f3f0ceedcf90320e48d3d47165712",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`1552a9f4`](https://github.com/NixOS/nixos-hardware/commit/1552a9f4513f3f0ceedcf90320e48d3d47165712) | `` add community meetings to CONTRIBUTING.md ``                              |
| [`e9a0908c`](https://github.com/NixOS/nixos-hardware/commit/e9a0908c620cfd828f477ce815d691cbf4bf86cd) | `` flake.nix: add more distinct common modules import support ``             |
| [`66b2b861`](https://github.com/NixOS/nixos-hardware/commit/66b2b86107252af9524305096d91368674850ed4) | `` add module names to README, add missing modulle declaration, fix typos `` |