### PR TITLE
chore(flake/darwin): `ff139e81` -> `04a34128`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750558694,
-        "narHash": "sha256-BVFZLpbQ3YJHp+IVAudMZJpdL+QrhF1RNmLJZp1nWSw=",
+        "lastModified": 1750572051,
+        "narHash": "sha256-01NcVvfAco+eiIbOHZFrtMEoCTEDMqNoN4YZyvRWQn4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ff139e81835fc150c4615f25eae215e904a717d2",
+        "rev": "04a34128012730be97af192f6e112d25204c97e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                       |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`e2361f44`](https://github.com/nix-darwin/nix-darwin/commit/e2361f44961f8a9cc7bf3c00e5c2d472b7a7b93c) | `` homebrew: allow setting greedy for all casks by default `` |