### PR TITLE
chore(flake/darwin): `04a34128` -> `1dd19f19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750572051,
-        "narHash": "sha256-01NcVvfAco+eiIbOHZFrtMEoCTEDMqNoN4YZyvRWQn4=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "04a34128012730be97af192f6e112d25204c97e9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                               |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`f2457a22`](https://github.com/nix-darwin/nix-darwin/commit/f2457a22c8cce48c2f8ede0935037c4d2cf8de39) | `` systems.defaults.alf: deprecate ``                                 |
| [`caa59bf5`](https://github.com/nix-darwin/nix-darwin/commit/caa59bf50a430d2ba18ff4d428c267561b686072) | `` networking.applicationFirewall: init ``                            |
| [`30845bee`](https://github.com/nix-darwin/nix-darwin/commit/30845beee0448bea77a7b8770ea9e6d17ca205d8) | `` nix.nixPath: Do not use environment.darwinConfig if set to null `` |