### PR TITLE
chore(flake/home-manager): `39b7903e` -> `7c355048`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750604619,
-        "narHash": "sha256-wNMm3ioA7q83UBDBQDew47bbjyvhOIcUcpjRFq3kHBY=",
+        "lastModified": 1750614446,
+        "narHash": "sha256-6WH0aRFay79r775RuTqUcnoZNm6A4uHxU1sbcNIk63s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "39b7903eaba5579046f7069b9d85d3ef4f2f972c",
+        "rev": "7c35504839f915abec86a96435b881ead7eb6a2b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7c355048`](https://github.com/nix-community/home-manager/commit/7c35504839f915abec86a96435b881ead7eb6a2b) | `` tests/neovim: fix expected config ``                              |
| [`a8e99a96`](https://github.com/nix-community/home-manager/commit/a8e99a960808fa69a2cea937ba604207552fe28a) | `` tests/nix-init: fix expected config ``                            |
| [`37353185`](https://github.com/nix-community/home-manager/commit/373531850c003c968b04c2a621f3cd8d123608fa) | `` tests/uv: fix expected config ``                                  |
| [`fd41fc5f`](https://github.com/nix-community/home-manager/commit/fd41fc5fbf077295e3bc66cac9c0903f4d1c4ec4) | `` tests/numbat: fix expected config ``                              |
| [`c8c30aa3`](https://github.com/nix-community/home-manager/commit/c8c30aa316fed11716b2b363e93a278664bb3c8e) | `` tests/meli: fix expected config ``                                |
| [`3d045a92`](https://github.com/nix-community/home-manager/commit/3d045a92d648a3603c3f94b1ca773299d2272e27) | `` tests/i3status-rust: fix expected config ``                       |
| [`c32df52a`](https://github.com/nix-community/home-manager/commit/c32df52a2f09187aaeda4e9e2c3862f729097ca2) | `` tests/himalaya: fix expected config ``                            |
| [`07e72705`](https://github.com/nix-community/home-manager/commit/07e72705a189d3ca0192a4c0364987c6a2dec8a1) | `` tests/niriswitcher: fix expected config ``                        |
| [`65db5b85`](https://github.com/nix-community/home-manager/commit/65db5b85d0f69ee1cbc2751d5337db92f983feee) | `` tests/spotify-player: fix expected config ``                      |
| [`597d672e`](https://github.com/nix-community/home-manager/commit/597d672e69bc12b451b045867700f4d911a42232) | `` tests/neovide: fix expected config ``                             |
| [`a2231992`](https://github.com/nix-community/home-manager/commit/a2231992dd4714c7ec2fb894ce641d4afefd115d) | `` tests/helix: fix expected config ``                               |
| [`975908d3`](https://github.com/nix-community/home-manager/commit/975908d3109728f602296a9262b6594e2d7105a6) | `` tests/clipcat: fix expected config ``                             |
| [`19530b8d`](https://github.com/nix-community/home-manager/commit/19530b8d3c568a1fb78c70e0f4263c8a6582cb2c) | `` network-manager-applet: maintainer midirhee12 -> midischwarz12 `` |
| [`2d9c66ee`](https://github.com/nix-community/home-manager/commit/2d9c66ee6d8bb3fe3bb3a607101d320749cb118f) | `` flake.lock: Update ``                                             |