### PR TITLE
chore(flake/home-manager): `7c355048` -> `520fc4b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750614446,
-        "narHash": "sha256-6WH0aRFay79r775RuTqUcnoZNm6A4uHxU1sbcNIk63s=",
+        "lastModified": 1750650909,
+        "narHash": "sha256-HRNJuqo15PRKezyBjhNf2Tjj05EcSJ8q6xJyDDbmDXE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c35504839f915abec86a96435b881ead7eb6a2b",
+        "rev": "520fc4b50af1b365014c3748c126d3f52edb2f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`520fc4b5`](https://github.com/nix-community/home-manager/commit/520fc4b50af1b365014c3748c126d3f52edb2f3b) | `` k9s: fix config files not generated correctly & improve options (#7262) `` |
| [`6fa01d52`](https://github.com/nix-community/home-manager/commit/6fa01d524bc5b0e77e6702dd37cf453247438480) | `` labwc: do not manage file when in default value(#7240) ``                  |
| [`2fbd694f`](https://github.com/nix-community/home-manager/commit/2fbd694fec4a53d0358ab9b1f5f0483fbb876286) | `` labwc: Fix pipemenu(#7236) and icon in menu generation ``                  |
| [`3bd64613`](https://github.com/nix-community/home-manager/commit/3bd646138a9c71f244a9293dde6f59ae1c6875ab) | `` nushell: Make sure the plugins are not garbage-collected (#7295) ``        |