### PR TITLE
chore(flake/home-manager): `520fc4b5` -> `05b8c950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750650909,
-        "narHash": "sha256-HRNJuqo15PRKezyBjhNf2Tjj05EcSJ8q6xJyDDbmDXE=",
+        "lastModified": 1750690749,
+        "narHash": "sha256-x6fRPeqdgDKVTCyvbp4J8Q5UQ3DV3oWYSoyM444N8cY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "520fc4b50af1b365014c3748c126d3f52edb2f3b",
+        "rev": "05b8c9506452349d8be854ac46e5a7630fa7917d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`05b8c950`](https://github.com/nix-community/home-manager/commit/05b8c9506452349d8be854ac46e5a7630fa7917d) | `` ci: home-manager switch test aginst codebase ``                |
| [`4a8f993c`](https://github.com/nix-community/home-manager/commit/4a8f993c45fcd2edf75d64ee4532cb9aca41566c) | `` home-manager: fix broken path reference ``                     |
| [`4c9e99e8`](https://github.com/nix-community/home-manager/commit/4c9e99e8e8e36bcdfa9cdb102e45e4dc95aa5c5b) | `` ci: disable home-manager install tests on darwin ``            |
| [`41a5f0a9`](https://github.com/nix-community/home-manager/commit/41a5f0a98a4970f27ff23914927aec33da949f2a) | `` tests/nix-gc: reorganize darwin and linux ``                   |
| [`7a64c023`](https://github.com/nix-community/home-manager/commit/7a64c0234077290079e5457691afb6cb543d45a0) | `` tests/imapnotify: reorganize darwin and linux ``               |
| [`5618e7a7`](https://github.com/nix-community/home-manager/commit/5618e7a748706dbe4f23ef11ec303070af7b5ea0) | `` tests/home-manager-auto-expire: reorganize darwin and linux `` |
| [`d2b2c72a`](https://github.com/nix-community/home-manager/commit/d2b2c72add6796fe95a9eb95690286cb0ab5fab3) | `` tests/espanso: reorganize darwin and linux ``                  |
| [`c283a23e`](https://github.com/nix-community/home-manager/commit/c283a23ef6c23366837a754ba3c30d45826424c1) | `` tests/emacs: reorganize darwin and linux ``                    |
| [`e9bde769`](https://github.com/nix-community/home-manager/commit/e9bde7692e7a0b6c87ea36200c3d196759959c31) | `` tests/git-sync: reorganize darwin and linux ``                 |
| [`2c4f8cb7`](https://github.com/nix-community/home-manager/commit/2c4f8cb7d6c1958d1afbd30276a3389947be4e59) | `` tests/yubikey-agent: reorganize darwin and linux ``            |
| [`bbad45b7`](https://github.com/nix-community/home-manager/commit/bbad45b7ea7152f540faa531bafaf98a73b00463) | `` tests/jellyfin-mpv-shim: fix tests ``                          |
| [`06c1392c`](https://github.com/nix-community/home-manager/commit/06c1392ca886553e9df1c7a927e5972261cf98f8) | `` tests: implement auto importing for modules ``                 |
| [`4fca600c`](https://github.com/nix-community/home-manager/commit/4fca600cb1db1d10bed39f67702c443f119117c1) | `` treewide: implement auto importing for modules ``              |
| [`fefeb0e9`](https://github.com/nix-community/home-manager/commit/fefeb0e928d1ec528f54e73892a7c069425d5041) | `` tests/redshift-gammastep: check file exists first ``           |