### PR TITLE
chore(flake/home-manager): `873c5b2d` -> `86402a17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750704637,
-        "narHash": "sha256-PHhDLtkEBkH+ee27YCsMziijpbypsRGDTuOuz6mG7iE=",
+        "lastModified": 1750713626,
+        "narHash": "sha256-uM+hqdMxp+H53d8R7EHn2yY+nLNGgg59pdipIgCZ5yY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "873c5b2dc5c9387bf67e59a12abc4de12a4b8697",
+        "rev": "86402a17b6c67b07c5536354da5d56c14196de46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`86402a17`](https://github.com/nix-community/home-manager/commit/86402a17b6c67b07c5536354da5d56c14196de46) | `` treewide: flatten single file modules `` |
| [`bda9deb7`](https://github.com/nix-community/home-manager/commit/bda9deb791b29454d49f8f5c35198e2b23f7751a) | `` modules: allow root level nix files ``   |
| [`f5098b07`](https://github.com/nix-community/home-manager/commit/f5098b074051d1ae0e919adf434a60fc3f23347b) | `` programs/hyprpanel: init (#7303) ``      |