### PR TITLE
chore(flake/home-manager): `86402a17` -> `d07e9cce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750713626,
-        "narHash": "sha256-uM+hqdMxp+H53d8R7EHn2yY+nLNGgg59pdipIgCZ5yY=",
+        "lastModified": 1750730235,
+        "narHash": "sha256-rZErlxiV7ssvI8t7sPrKU+fRigNc2KvoKZG3gtUtK50=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86402a17b6c67b07c5536354da5d56c14196de46",
+        "rev": "d07e9cceb4994ed64a22b9b36f8b76923e87ac38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`d07e9cce`](https://github.com/nix-community/home-manager/commit/d07e9cceb4994ed64a22b9b36f8b76923e87ac38) | `` docs: add note about importing modules (#7315) ``         |
| [`c9d8158b`](https://github.com/nix-community/home-manager/commit/c9d8158bc56923013fa9a4346ba3e273f3b956b3) | `` tests/aerospace: test launchd agent ``                    |
| [`d33444e6`](https://github.com/nix-community/home-manager/commit/d33444e63a88f70feccd99971c442dc9d84faff1) | `` aerospace: Add launchd agent and enhance configuration `` |