### PR TITLE
chore(flake/home-manager): `d07e9cce` -> `951f0b30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750730235,
-        "narHash": "sha256-rZErlxiV7ssvI8t7sPrKU+fRigNc2KvoKZG3gtUtK50=",
+        "lastModified": 1750794896,
+        "narHash": "sha256-5+vTNCuyH1FmXw6oC3Snn1IphjRQb6COR/R0EBgMSHE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d07e9cceb4994ed64a22b9b36f8b76923e87ac38",
+        "rev": "951f0b30c535a46817aa5ef4c66ddc4445f3e324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`951f0b30`](https://github.com/nix-community/home-manager/commit/951f0b30c535a46817aa5ef4c66ddc4445f3e324) | `` ci: schedule release flake lock updates (#7325) ``      |
| [`d400c361`](https://github.com/nix-community/home-manager/commit/d400c361660526a199e1e56cc22f073c09c71d35) | `` tests/flake.lock: remove (#7324) ``                     |
| [`a4bac2b9`](https://github.com/nix-community/home-manager/commit/a4bac2b9ba2f9bd68032880da8ae6b44fbc46047) | `` helix: fix configuration file creation logic (#7319) `` |