### PR TITLE
chore(flake/disko): `8fd2d6c7` -> `83c4da29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750680230,
-        "narHash": "sha256-kD88T/NqmcgfOBFAwphN30ccaUdj6K6+LG0XdM2w2LA=",
+        "lastModified": 1750903843,
+        "narHash": "sha256-Ng9+f0H5/dW+mq/XOKvB9uwvGbsuiiO6HrPdAcVglCs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8fd2d6c75009ac75f9a6fb18c33a239806778d01",
+        "rev": "83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`83c4da29`](https://github.com/nix-community/disko/commit/83c4da299c1d7d300f8c6fd3a72ac46cb0d59aae) | `` flake.lock: Update `` |