### PR TITLE
chore(flake/treefmt-nix): `a05be418` -> `ac8e6f32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -956,11 +956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "lastModified": 1750931469,
+        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`ac8e6f32`](https://github.com/numtide/treefmt-nix/commit/ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1) | `` feat: add autocorrect, a formatter for CJK spacing and punctuation (#372) `` |