### PR TITLE
chore(flake/lovesegfault-vim-config): `f35b588a` -> `36a66aa2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750896556,
-        "narHash": "sha256-8pnnO74IQmuRhDHxoat5VwF3duC0ewTbfyNKmVx4eDI=",
+        "lastModified": 1750982822,
+        "narHash": "sha256-IFr9hcFldRvjsnAjYbShE0stEBA7Ab4xd8rO9OhBfWk=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "f35b588a1b63898f839bf2834752dea8e34a6dc4",
+        "rev": "36a66aa268db51724db5531387645f0a7a98931c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`36a66aa2`](https://github.com/lovesegfault/vim-config/commit/36a66aa268db51724db5531387645f0a7a98931c) | `` chore(flake/treefmt-nix): a05be418 -> ac8e6f32 `` |