### PR TITLE
chore(flake/stylix): `713f8dae` -> `3a09d3f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751105505,
-        "narHash": "sha256-SfM48R06e9omzDRNoU7vTRghxLmQPZ+fxoBoOkszL0k=",
+        "lastModified": 1751145558,
+        "narHash": "sha256-OPlbpH64jzIspYqvJB96tnN9V9HBlAxROS5ijQwtN70=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "713f8dae3127a0faeb1d343ed8da67677121ee29",
+        "rev": "3a09d3f5cb940fa4142a2f3415b508a8be92b721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3a09d3f5`](https://github.com/nix-community/stylix/commit/3a09d3f5cb940fa4142a2f3415b508a8be92b721) | `` rofi: fix attribute 'size' missing (#1553) ``         |
| [`8c4b2ebf`](https://github.com/nix-community/stylix/commit/8c4b2ebfb83010e5b345cba4afcbe499603f6861) | `` ci: commit as stylix-automation in updates (#1547) `` |