### PR TITLE
chore(flake/lovesegfault-vim-config): `a0a9a026` -> `f0f78780`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751069189,
-        "narHash": "sha256-a+GJG6hq97ydkuJhl5z1MJ5wTWFavDckPcXqQER0uBQ=",
+        "lastModified": 1751155780,
+        "narHash": "sha256-HJ/6kLMrkppSwdp3TBs9uzTqiNt+FwjHmwWr2vKjJI4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "a0a9a026f862fe045cee9999ec119d583dec70bf",
+        "rev": "f0f78780f6884160707c6a626ece9beb4f4e19a6",
         "type": "github"
       },
       "original": {
@@ -637,11 +637,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1751053139,
-        "narHash": "sha256-FMcWdec8fAXs7kiOQBsD+vA/RzjqoDz3zoYgPDQpZlA=",
+        "lastModified": 1751144320,
+        "narHash": "sha256-KJsKiGfkfXFB23V26NQ1p+UPsexI6NKtivnrwSlWWdQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c39f5f39c32e0a8fe91bff1cda847de7a0269411",
+        "rev": "ceb52aece5d571b37096945c2815604195a04eb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`f0f78780`](https://github.com/lovesegfault/vim-config/commit/f0f78780f6884160707c6a626ece9beb4f4e19a6) | `` chore(flake/nixpkgs): 4b1164c3 -> 30e2e285 `` |
| [`58cd07c1`](https://github.com/lovesegfault/vim-config/commit/58cd07c10729d1e1ed873f26c383d278a57f415b) | `` chore(flake/nixvim): c39f5f39 -> ceb52aec ``  |