### PR TITLE
chore(flake/home-manager): `76d0c31f` -> `f6deff17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751146119,
-        "narHash": "sha256-gvjG95TCnUVJkvQvLMlnC4NqiqFyBdJk3o8/RwuHeaU=",
+        "lastModified": 1751239699,
+        "narHash": "sha256-zA1uUdAq3c26fHm26xMWMuF5COhI18EzaH7az/P2OWM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "76d0c31fce2aa0c71409de953e2f9113acd5b656",
+        "rev": "f6deff178cc4d6049d30785dbfc831e6c6e3a219",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`f6deff17`](https://github.com/nix-community/home-manager/commit/f6deff178cc4d6049d30785dbfc831e6c6e3a219) | `` quickshell: add module (#7316) ``                                            |
| [`cab8104e`](https://github.com/nix-community/home-manager/commit/cab8104e9236fab1eb9a702165454ffed353c20f) | `` home-manager: add repl subcommand (#5600) ``                                 |
| [`3faf4a15`](https://github.com/nix-community/home-manager/commit/3faf4a15072006f684dcce8ca95d198aeaf2c2f4) | `` syncthing: add guiAddress to configuration (#7281) ``                        |
| [`a4f9ab00`](https://github.com/nix-community/home-manager/commit/a4f9ab000564187663c79e2dd68c74bae98012e7) | `` sway: add `wayland.windowManager.sway.systemd.dbusImplementation` (#7271) `` |
| [`522c681a`](https://github.com/nix-community/home-manager/commit/522c681ac22bf3b4d2cfc5f74e71401da82001cc) | `` flake.lock: Update (#7326) ``                                                |
| [`2b3bb17e`](https://github.com/nix-community/home-manager/commit/2b3bb17e871b22250e7ee5dbf422b8c40c5d5c79) | `` oh-my-posh: fix nushell with v26.0.0 (#7342) ``                              |