### PR TITLE
chore(flake/darwin): `1dd19f19` -> `425c929e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750618568,
-        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
+        "lastModified": 1751270151,
+        "narHash": "sha256-xL7UKUPnJwqmlQKiqeVX+LDbLKIP8fcBcc55ocnhy64=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
+        "rev": "425c929e209a05f8790ce83106942e94258adbc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                    |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`7f9694a4`](https://github.com/nix-darwin/nix-darwin/commit/7f9694a4be6c55322474a0a00723bcfcf8f21c0d) | `` github-runner/service.nix: fix missing argument in workDir assertion `` |