### PR TITLE
chore(flake/stylix): `3a09d3f5` -> `4ead8043`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751145558,
-        "narHash": "sha256-OPlbpH64jzIspYqvJB96tnN9V9HBlAxROS5ijQwtN70=",
+        "lastModified": 1751296480,
+        "narHash": "sha256-PMuzVs9khM7cYrjUCXQeV2OP6WVtbsmdZwa4Cc21y0o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3a09d3f5cb940fa4142a2f3415b508a8be92b721",
+        "rev": "4ead8043f70cc3b951e704a1f6e40c8a10230e61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                             |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`4ead8043`](https://github.com/nix-community/stylix/commit/4ead8043f70cc3b951e704a1f6e40c8a10230e61) | `` zed: fix homepage URL (#1561) ``                                                 |
| [`a0082d08`](https://github.com/nix-community/stylix/commit/a0082d087eabaf710977f22b06984329145b526c) | `` nixos-icons: modify `nix-snowflake-colours.svg` to match color scheme (#1522) `` |