### PR TITLE
chore(flake/home-manager): `0f21ed51` -> `78fc50f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751296747,
-        "narHash": "sha256-/nHOfmB0C972nYX0xVF0zWmbt8ooA9TCczfeKHNvwqI=",
+        "lastModified": 1751309344,
+        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f21ed5182a158d2f84e9136f6bf8539fd9a6890",
+        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`78fc50f1`](https://github.com/nix-community/home-manager/commit/78fc50f1cf8e57a974ff4bfe654563fce43d6289) | `` direnv: fix nushell cell-path handling (#7339) ``               |
| [`ee2189cb`](https://github.com/nix-community/home-manager/commit/ee2189cb2f6c9e2b9c734a839faa20ed2ba8b577) | `` gh: insert empty helper when using credential helper (#7347) `` |