### PR TITLE
chore(flake/darwin): `425c929e` -> `e04a3882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751270151,
-        "narHash": "sha256-xL7UKUPnJwqmlQKiqeVX+LDbLKIP8fcBcc55ocnhy64=",
+        "lastModified": 1751313918,
+        "narHash": "sha256-HsJM3XLa43WpG+665aGEh8iS8AfEwOIQWk3Mke3e7nk=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "425c929e209a05f8790ce83106942e94258adbc8",
+        "rev": "e04a388232d9a6ba56967ce5b53a8a6f713cdfcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`a79b28f2`](https://github.com/nix-darwin/nix-darwin/commit/a79b28f2fa4d7113a21e4175b34ddfd0bb92df08) | `` readme: update flake guide ``      |
| [`b866fbb2`](https://github.com/nix-darwin/nix-darwin/commit/b866fbb28ba37482d4151315b38a9070761fb0c3) | `` readme: bump nix stable version `` |