### PR TITLE
chore(flake/home-manager): `78fc50f1` -> `96354906`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751309344,
-        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
+        "lastModified": 1751336185,
+        "narHash": "sha256-ptnVr2x+sl7cZcTuGx/0BOE2qCAIYHTcgfA+/h60ml0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
+        "rev": "96354906f58464605ff81d2f6c2ea23211cbf051",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`96354906`](https://github.com/nix-community/home-manager/commit/96354906f58464605ff81d2f6c2ea23211cbf051) | `` files: show better error when file would be clobbered (#7348) `` |
| [`40741217`](https://github.com/nix-community/home-manager/commit/40741217965a63be07dcfcf51865d6f65ef88e71) | `` nh: update maintainers ``                                        |
| [`e8a3e2c1`](https://github.com/nix-community/home-manager/commit/e8a3e2c1e06c1dd488292929f7263ccfa765c7d8) | `` nh: fix clean option behaviour for Darwin ``                     |