### PR TITLE
chore(flake/nixos-hardware): `98236410` -> `8b1f8940`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1750837715,
-        "narHash": "sha256-2m1ceZjbmgrJCZ2PuQZaK4in3gcg3o6rZ7WK6dr5vAA=",
+        "lastModified": 1751379130,
+        "narHash": "sha256-TObxiGbuX/4FbOnzDRvznfMUjIgS+d71+BetT35EOB8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "98236410ea0fe204d0447149537a924fb71a6d4f",
+        "rev": "8b1f894089789eb39eacf0d6891d1e17cc3a84ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d4b60312`](https://github.com/NixOS/nixos-hardware/commit/d4b603125e98ce2da1340e0a67bc430d7384b344) | `` Updated nvidia offload mode to include amd drivers `` |
| [`42dedc05`](https://github.com/NixOS/nixos-hardware/commit/42dedc05793c842ab7afbfd0cf5a8ee4007d7ea5) | `` apple/t2: kernel 6.14 -> 6.15; sync patches ``        |
| [`dcbb69f9`](https://github.com/NixOS/nixos-hardware/commit/dcbb69f9bc071826aeb05e95014cb607b88f0c9b) | `` feat: update Surface stable kernel to 6.15.3 ``       |