### PR TITLE
chore(flake/stylix): `4ead8043` -> `4bc15ef1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751296480,
-        "narHash": "sha256-PMuzVs9khM7cYrjUCXQeV2OP6WVtbsmdZwa4Cc21y0o=",
+        "lastModified": 1751379237,
+        "narHash": "sha256-jDoLz04rgXS0jYLT017RARjcC7PoZoJ6NzH6ypi2kKM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4ead8043f70cc3b951e704a1f6e40c8a10230e61",
+        "rev": "4bc15ef13c970981e37506491e18d1158af9a70c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4bc15ef1`](https://github.com/nix-community/stylix/commit/4bc15ef13c970981e37506491e18d1158af9a70c) | `` blender: use mkTarget (#1509) ``                         |
| [`73b7d0f3`](https://github.com/nix-community/stylix/commit/73b7d0f30039b6e51a02a1cc29215565107ed6c7) | `` stylix: guard home-manager-integration config (#1494) `` |