### PR TITLE
chore(flake/nixos-hardware): `8b1f8940` -> `f49bb3b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1751379130,
-        "narHash": "sha256-TObxiGbuX/4FbOnzDRvznfMUjIgS+d71+BetT35EOB8=",
+        "lastModified": 1751393906,
+        "narHash": "sha256-I1x6K61ZcdFlqc07weRBy3erCAB0lVkX10i0c9eXjDI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8b1f894089789eb39eacf0d6891d1e17cc3a84ab",
+        "rev": "f49bb3b4107a0917ee144337bb02d311033ee1ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`e8bd6a44`](https://github.com/NixOS/nixos-hardware/commit/e8bd6a44ac0d6041996531b96ed190d0de9f8598) | `` disable treefmt on riscv64 ``                                |
| [`72cdb224`](https://github.com/NixOS/nixos-hardware/commit/72cdb2246305abf2bd3cbc88d2c72ea6040fcef3) | `` add script to update nar hashes in tests ``                  |
| [`1ead2d05`](https://github.com/NixOS/nixos-hardware/commit/1ead2d05dd46c21b721a28ae1ce963849e1f3423) | `` bump nixos-stable/nixos-unstable ``                          |
| [`bd65595c`](https://github.com/NixOS/nixos-hardware/commit/bd65595c6d689c407d7f15f3b5a8f681c91101b5) | `` Add .git-blame-ignore-revs file for auto-rebasing ``         |
| [`b2c7dee5`](https://github.com/NixOS/nixos-hardware/commit/b2c7dee5c6aa93cf1029bbe38e32d4799042cc9e) | `` ci: support for merge queues ``                              |
| [`a7600cef`](https://github.com/NixOS/nixos-hardware/commit/a7600cef40e350c6f3fcb6eefb6f0d6b09c7d05e) | `` move treefmt to tests flake ``                               |
| [`fe49c326`](https://github.com/NixOS/nixos-hardware/commit/fe49c326d572e4a92f8d2aa6f5f0c6b39245cd37) | `` chore: add formatting job to GitHub Actions ``               |
| [`c3f13f26`](https://github.com/NixOS/nixos-hardware/commit/c3f13f261032b6c393bd4fc2c25990783937b4d9) | `` Remove GitHub action requirement ``                          |
| [`9ac3df2a`](https://github.com/NixOS/nixos-hardware/commit/9ac3df2a020ea6c6efb9f30c42aa2a031a5e9241) | `` Remove GitHub action ``                                      |
| [`2b0ced06`](https://github.com/NixOS/nixos-hardware/commit/2b0ced06c1543883636ec5dea30b48b13a28c9f5) | `` chore: add formatting job to GitHub Actions ``               |
| [`51e51e60`](https://github.com/NixOS/nixos-hardware/commit/51e51e601448705c0d2f92ef90ec7b680123077c) | `` chore: format repo using treefmt-nix and nixfmt-rfc-style `` |