### PR TITLE
chore(flake/home-manager): `479f8889` -> `e96a8a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751384836,
-        "narHash": "sha256-7xRbl/VLXxE5DzJmk1wdKWJmPx8rAfNC/a6mXtqp5cc=",
+        "lastModified": 1751411489,
+        "narHash": "sha256-x+AJyQ5+4EPDU3NnQ1OPP/KuoG0C6UrbgptEW6PSLQ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "479f8889675770881033878a1c114fbfc6de7a4d",
+        "rev": "e96a8a325cf23538a7f58b9335b4c4c0b393bacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e96a8a32`](https://github.com/nix-community/home-manager/commit/e96a8a325cf23538a7f58b9335b4c4c0b393bacf) | `` ci: conditional test step runs (#7358) ``                |
| [`5d2f3e3e`](https://github.com/nix-community/home-manager/commit/5d2f3e3e7fbb2cd8cab8b5f9e51526b1269645b9) | `` ci: fix update-maintainers reference location (#7357) `` |
| [`77bb9e03`](https://github.com/nix-community/home-manager/commit/77bb9e033b500a7111cee096555d510b715a3fb3) | `` ci: add update-maintainers.yml ``                        |
| [`11db5613`](https://github.com/nix-community/home-manager/commit/11db56137d1efbf663f614c7714c9224d4dd818d) | `` all-maintainers.nix: initial creation ``                 |
| [`44a2308d`](https://github.com/nix-community/home-manager/commit/44a2308db94b063c8dcb6505f61fdd225e571041) | `` scripts/generate-all-maintainers.py: add script ``       |