### PR TITLE
chore(flake/nix-fast-build): `8f9623ef` -> `64b4f816`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1750933613,
-        "narHash": "sha256-UtBpLFPpQfKrnzxsESKroXzRB2rHdXEifVrtRUYHWng=",
+        "lastModified": 1751414949,
+        "narHash": "sha256-vLGqlaHsvgvA1ozdcMtCGentlDru5UkvPt6f8uJ1gYI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "8f9623efceac21f432fdd83abbd3ab979ea8a39a",
+        "rev": "64b4f81619f1691dba8d886458911d553632b8bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`64b4f816`](https://github.com/Mic92/nix-fast-build/commit/64b4f81619f1691dba8d886458911d553632b8bb) | `` chore(deps): lock file maintenance (#188) ``                |
| [`13ec7952`](https://github.com/Mic92/nix-fast-build/commit/13ec7952e4ef73321eea997646b536658c72831e) | `` chore(deps): update flake-parts digest to 7782624 (#189) `` |