### PR TITLE
chore(flake/home-manager): `e96a8a32` -> `29d717aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751411489,
-        "narHash": "sha256-x+AJyQ5+4EPDU3NnQ1OPP/KuoG0C6UrbgptEW6PSLQ8=",
+        "lastModified": 1751429037,
+        "narHash": "sha256-+dpzC9DQCtiCNDIBVpKNuWzsIQD/rNR+EuBKBCmadKE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e96a8a325cf23538a7f58b9335b4c4c0b393bacf",
+        "rev": "29d717aab5189b3383d965928823ddac8a95e8f3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`29d717aa`](https://github.com/nix-community/home-manager/commit/29d717aab5189b3383d965928823ddac8a95e8f3) | `` ci: tests fetch nixpkgs from flake.lock rev ``              |
| [`212f4a4f`](https://github.com/nix-community/home-manager/commit/212f4a4fb20449d51bbc403e3d140778aab4d18a) | `` ci: update-maintainers fetch nixpkgs from flake.lock rev `` |
| [`121b430d`](https://github.com/nix-community/home-manager/commit/121b430df7b5c5eeb9d37dff2a3ba1883a9e51e1) | `` maintainers: fix incorrect entries (#7360) ``               |