### PR TITLE
chore(flake/home-manager): `29d717aa` -> `df122690`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751429037,
-        "narHash": "sha256-+dpzC9DQCtiCNDIBVpKNuWzsIQD/rNR+EuBKBCmadKE=",
+        "lastModified": 1751429452,
+        "narHash": "sha256-4s5vRtaqdNhVBnbOWOzBNKrRa0ShQTLoEPjJp3joeNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29d717aab5189b3383d965928823ddac8a95e8f3",
+        "rev": "df12269039dcf752600b1bcc176bacf2786ec384",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`df122690`](https://github.com/nix-community/home-manager/commit/df12269039dcf752600b1bcc176bacf2786ec384) | `` maintainers: update all-maintainers.nix (#7361) `` |