### PR TITLE
chore(flake/nixos-hardware): `f49bb3b4` -> `497ae135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -577,11 +577,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1751393906,
-        "narHash": "sha256-I1x6K61ZcdFlqc07weRBy3erCAB0lVkX10i0c9eXjDI=",
+        "lastModified": 1751432711,
+        "narHash": "sha256-136MeWtckSHTN9Z2WRNRdZ8oRP3vyx3L8UxeBYE+J9w=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f49bb3b4107a0917ee144337bb02d311033ee1ba",
+        "rev": "497ae1357f1ac97f1aea31a4cb74ad0d534ef41f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`3b622ae6`](https://github.com/NixOS/nixos-hardware/commit/3b622ae6e613bf0b59bd142394ee86ed62cd2a60) | `` Add System76 Thelio Mega module ``             |
| [`a724614b`](https://github.com/NixOS/nixos-hardware/commit/a724614b86a2a67f7dbb3873942dcd0561106102) | `` xiaomi/redmibook/15-pro-2021: fix flake.nix `` |