### PR TITLE
chore(flake/home-manager): `df122690` -> `7c455533`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751429452,
-        "narHash": "sha256-4s5vRtaqdNhVBnbOWOzBNKrRa0ShQTLoEPjJp3joeNI=",
+        "lastModified": 1751469941,
+        "narHash": "sha256-ZIUkH4Djh1NUFQ0GnWCsw9HZBDcVgjvJASiTplMXEzc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "df12269039dcf752600b1bcc176bacf2786ec384",
+        "rev": "7c455533409411b4053bb6d7db71eb35e0544254",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`7c455533`](https://github.com/nix-community/home-manager/commit/7c455533409411b4053bb6d7db71eb35e0544254) | `` mpvpaper: fix eval if no settings are defined (#7370) `` |
| [`3d243d4a`](https://github.com/nix-community/home-manager/commit/3d243d4a16cafe855df585b3030aa99261a27a86) | `` ci: fix which branch to show on pr (#7368) ``            |
| [`77027882`](https://github.com/nix-community/home-manager/commit/77027882a7f637f84f7c221406b75f1463f5a321) | `` ci: prefix flake update prs (#7366) ``                   |
| [`4bd46345`](https://github.com/nix-community/home-manager/commit/4bd4634525150766b96facdb8a35bb991de67956) | `` ci: fix update-flake branch inputs (#7345) ``            |
| [`6c53df3b`](https://github.com/nix-community/home-manager/commit/6c53df3b9c809e3b4b30d515e18bfa4c6f079254) | `` flake.lock: Update (#7363) ``                            |