### PR TITLE
chore(flake/home-manager): `25f003f8` -> `a5b56720`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751485527,
-        "narHash": "sha256-E2AtD5UUeU50xco4gmgsCOs7tnBNsVi7+CdCZ4yQUrA=",
+        "lastModified": 1751500614,
+        "narHash": "sha256-mYiYNsTJkbQouC5YHOTgqVpjpELoNf9f4z5ZeY4NfPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "25f003f8a9eae31a11938d53cb23e0b4a3c08d3a",
+        "rev": "a5b56720841121d2189c011e445c4be4c943bab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`a5b56720`](https://github.com/nix-community/home-manager/commit/a5b56720841121d2189c011e445c4be4c943bab5) | `` kitty: add config change signal on darwin (#7375) `` |
| [`89af52d9`](https://github.com/nix-community/home-manager/commit/89af52d9a893af013f5f4c1d2d56912106827153) | `` tests/firefox: add extension user.js test ``         |
| [`1b25908d`](https://github.com/nix-community/home-manager/commit/1b25908d1dc6832c3cced1aba29b6ff932b6a0bd) | `` firefox: fix user.js extensions.settings creation `` |