### PR TITLE
chore(flake/home-manager): `a5b56720` -> `426b405d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751500614,
-        "narHash": "sha256-mYiYNsTJkbQouC5YHOTgqVpjpELoNf9f4z5ZeY4NfPg=",
+        "lastModified": 1751513147,
+        "narHash": "sha256-idSXM3Y0KNf/WDDqGfthiOSQMwZYwis1JZhTkdWrr6A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a5b56720841121d2189c011e445c4be4c943bab5",
+        "rev": "426b405d979d893832549b95f23c13537c65d244",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`426b405d`](https://github.com/nix-community/home-manager/commit/426b405d979d893832549b95f23c13537c65d244) | `` ci: add validation workflow for maintainers list `` |
| [`66de606f`](https://github.com/nix-community/home-manager/commit/66de606f48f789b0a407d842714de8dd01893dc5) | `` ci: update all-maintainers on merge ``              |