### PR TITLE
chore(flake/home-manager): `426b405d` -> `1fa73bb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751513147,
-        "narHash": "sha256-idSXM3Y0KNf/WDDqGfthiOSQMwZYwis1JZhTkdWrr6A=",
+        "lastModified": 1751549056,
+        "narHash": "sha256-miKaJ4SFNxhZ/WVDADae2jNd9zka5bV9hKmXspAzvxo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "426b405d979d893832549b95f23c13537c65d244",
+        "rev": "1fa73bb2cc39e250eb01e511ae6ac83bfbf9f38c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`1fa73bb2`](https://github.com/nix-community/home-manager/commit/1fa73bb2cc39e250eb01e511ae6ac83bfbf9f38c) | `` fix(service/gpg-agent): allow SSH ForwardAgent compatibility (#7355) `` |
| [`b182e64c`](https://github.com/nix-community/home-manager/commit/b182e64c01aa4e61a007691525a3ea498a9aee63) | `` zed-editor: survive if previous files are not JSON5 (#7351) ``          |