### PR TITLE
chore(flake/home-manager): `28639e64` -> `402333d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751569544,
-        "narHash": "sha256-iWjzNHaSU+pm4TS/vzkzgBdbTwkyHy8Jc6PlcrgdgyU=",
+        "lastModified": 1751580393,
+        "narHash": "sha256-oRipTA4/JGeDGI31GNNVGFx0uhuR7h/R9SvkR4K8Axc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "28639e6470ef597fe9f5efc4c6594306859d62ed",
+        "rev": "402333d5ec2f9eed0f2584555936361f39d2f93e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`402333d5`](https://github.com/nix-community/home-manager/commit/402333d5ec2f9eed0f2584555936361f39d2f93e) | `` ci: concurrency protect tag flow ``                     |
| [`03c3576f`](https://github.com/nix-community/home-manager/commit/03c3576f8b7e3d2154fba3f450e2bfd942024e1e) | `` ci: remove unneeded reviewers ``                        |
| [`7582cbfa`](https://github.com/nix-community/home-manager/commit/7582cbfabce2ff1626083f1c73a2e3c74ee4cf40) | `` ci: check for new maintainers on updates ``             |
| [`7044c3ec`](https://github.com/nix-community/home-manager/commit/7044c3eced5319148c09fe9612659765b9297d4a) | `` ci: tag-maintainers fix fetching maintainers (#7380) `` |
| [`09ef413c`](https://github.com/nix-community/home-manager/commit/09ef413c804bde7afc259c67b2dcb4cc999913f6) | `` all-maintainers: update ``                              |
| [`d03fa2d8`](https://github.com/nix-community/home-manager/commit/d03fa2d84c6c7def463f9ff90d6a36d5873de0fc) | `` ci: generate-all-maintainers use nix eval update ``     |
| [`b46c6937`](https://github.com/nix-community/home-manager/commit/b46c6937970a3dc3141136134f8244b5a928a7f6) | `` lib: add extract-maintainers-meta ``                    |