### PR TITLE
chore(flake/stylix): `3c73dee2` -> `85d84607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751602277,
-        "narHash": "sha256-mlJeMDyj+B9QYNw/f9YdlBzvq6mcQ3dx5qjfepzV70I=",
+        "lastModified": 1751637346,
+        "narHash": "sha256-zPYpnp3mlGmymhoGRK0VVNBv/4FCmQ3CDIQuegLbXlg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3c73dee2dbdf242a16a6e929f3e574dd0694d85a",
+        "rev": "85d84607b2d4a28178f2ec0238ac5eed8e39cd71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`85d84607`](https://github.com/nix-community/stylix/commit/85d84607b2d4a28178f2ec0238ac5eed8e39cd71) | `` flake: sort pre-commit hooks and formatters (#1586) ``                 |
| [`732c666b`](https://github.com/nix-community/stylix/commit/732c666ba54a724bb90d76a1b6f1417bc4823235) | `` ci: fix dependabot backport label (#1585) ``                           |
| [`127fe6cc`](https://github.com/nix-community/stylix/commit/127fe6cc3de1ab0bc2f38eba7469d7a53e306eb1) | `` ci: bump DeterminateSystems/update-flake-lock from 25 to 26 (#1583) `` |
| [`2fee88f2`](https://github.com/nix-community/stylix/commit/2fee88f2813ad9fbcefc20e5bd39af336cf5b9f3) | `` fuzzel: apply iconTheme (#1497) ``                                     |
| [`825d7911`](https://github.com/nix-community/stylix/commit/825d79112f7a7480a00784e2dcdd91ffadf2d263) | `` nixos-icons: pad hex color values with leading zeros (#1584) ``        |