### PR TITLE
chore(flake/home-manager): `83f97881` -> `7d9e3c35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751589297,
-        "narHash": "sha256-3q35cq6BPuwIRL3IoVKYPc72r3OleeuRyf4YAPjEqzA=",
+        "lastModified": 1751638848,
+        "narHash": "sha256-7HiC6w4ROEbMmKtj5pilnLOJej9HkkfU9wEd5QSTyNo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "83f978812c37511ef2ffaf75ffa72160483f738a",
+        "rev": "7d9e3c35f0d46f82bac791d76260f15f53d83529",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`7d9e3c35`](https://github.com/nix-community/home-manager/commit/7d9e3c35f0d46f82bac791d76260f15f53d83529) | `` all-maintainers: regenerate with latest changes ``                |
| [`412c545b`](https://github.com/nix-community/home-manager/commit/412c545bb6df640c795177b02f79831087132267) | `` extract-maintainers-meta: simplify ``                             |
| [`f6d11046`](https://github.com/nix-community/home-manager/commit/f6d11046657ea7e22a70be602f1b05ea61684056) | `` extract-maintainers-meta: include non module system files ``      |
| [`b8bb556c`](https://github.com/nix-community/home-manager/commit/b8bb556ce5abe5bbc10acb7508ef273b053f647d) | `` maintainers: remove duplicate HM entries ``                       |
| [`18e1f7fb`](https://github.com/nix-community/home-manager/commit/18e1f7fbce644f9fe44cf38faad137f2d0bfa1af) | `` ci: validate maintainers also checks for duplicate maintainers `` |
| [`31242bdf`](https://github.com/nix-community/home-manager/commit/31242bdf8f5fff430a23bc167dd8e0fb2fce4c35) | `` polybar: fix meta.maintainer position ``                          |