### PR TITLE
chore(flake/stylix): `85d84607` -> `606944b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751637346,
-        "narHash": "sha256-zPYpnp3mlGmymhoGRK0VVNBv/4FCmQ3CDIQuegLbXlg=",
+        "lastModified": 1751656637,
+        "narHash": "sha256-x1uJ6wQ7C+N/Zx9liQzjyVOEwGf5tcKogSoGgxASZOg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "85d84607b2d4a28178f2ec0238ac5eed8e39cd71",
+        "rev": "606944b16862d43934fec3311f9cb9f478b7f99b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`606944b1`](https://github.com/nix-community/stylix/commit/606944b16862d43934fec3311f9cb9f478b7f99b) | `` rofi: fix mkTarget usage (#1593) ``                               |
| [`6b2898a6`](https://github.com/nix-community/stylix/commit/6b2898a6b7d6fc1956d808d285a1b4ceaf0ca56e) | `` mako: add testbed (#1192) ``                                      |
| [`dea0337e`](https://github.com/nix-community/stylix/commit/dea0337e0bffeeeb941ca6caffb44e966b13a97b) | `` stylix: restrict access to config while using mkTarget (#1368) `` |