### PR TITLE
chore(flake/home-manager): `57d1027e` -> `36c57c6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751676893,
-        "narHash": "sha256-kXlkCJcws234u4gLjtl07/U+8FV8/TBYoR14gXVRv0g=",
+        "lastModified": 1751693185,
+        "narHash": "sha256-+LKghTO5wWBcR/MJAeoSarWR7c7dO6GyA8+jM8DHV08=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "57d1027e1eaf1220342248ff18d34f42b0beea7b",
+        "rev": "36c57c6a1d03a5efbf5e23c04dbe21259d25f992",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`36c57c6a`](https://github.com/nix-community/home-manager/commit/36c57c6a1d03a5efbf5e23c04dbe21259d25f992) | `` lib/deprecations: add ignore parameter to remapAttrsRecursive `` |
| [`650a38eb`](https://github.com/nix-community/home-manager/commit/650a38ebe819d439ece41b5a1c510b3244896265) | `` ashell: support yaml and toml config ``                          |
| [`f62e9a81`](https://github.com/nix-community/home-manager/commit/f62e9a8114bc181ae160c9a1d7ce8205fa5619b0) | `` lib/strings: add extra string matching predicates ``             |
| [`19f0ba9c`](https://github.com/nix-community/home-manager/commit/19f0ba9c52f30c1a26e816a05bddf6b4aa9e327d) | `` lib/deprecations: add remapAttrsRecursive ``                     |
| [`a4fc77c6`](https://github.com/nix-community/home-manager/commit/a4fc77c63d41b74f156f25fb34be905527865028) | `` ashell: new ashell 0.5.0 config standards ``                     |
| [`e8da7372`](https://github.com/nix-community/home-manager/commit/e8da7372fd1f0da3fe3874af3aa9ddd78662d8ae) | `` anki: add module (#7274) ``                                      |