### PR TITLE
chore(flake/home-manager): `36c57c6a` -> `f117b383`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751693185,
-        "narHash": "sha256-+LKghTO5wWBcR/MJAeoSarWR7c7dO6GyA8+jM8DHV08=",
+        "lastModified": 1751729568,
+        "narHash": "sha256-ay7O1jjalUxkL23QWLv9C2s8rdVGs3hUOPZClIbUHKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "36c57c6a1d03a5efbf5e23c04dbe21259d25f992",
+        "rev": "f117b383dd591fd579bce5ee7bac07a3fdc1d050",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`f117b383`](https://github.com/nix-community/home-manager/commit/f117b383dd591fd579bce5ee7bac07a3fdc1d050) | `` numbat: Allow specifying a path for initFile ``                                  |
| [`26d405da`](https://github.com/nix-community/home-manager/commit/26d405da4179c7dafc0a84e611edfa2f5ddf7faa) | `` numbat: Add initFile option ``                                                   |
| [`d75a5474`](https://github.com/nix-community/home-manager/commit/d75a547415f08a52a1e8fc84a1bef9e48bba4c5c) | `` programs.msmtp: merge extraConfig and extraAccount into configContent (#7385) `` |