### PR TITLE
chore(flake/home-manager): `f117b383` -> `af8a8841`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751729568,
-        "narHash": "sha256-ay7O1jjalUxkL23QWLv9C2s8rdVGs3hUOPZClIbUHKs=",
+        "lastModified": 1751751054,
+        "narHash": "sha256-qUEejOOj1jc+y5anxDgay+NqVgLHVeY0So5PEDzlV18=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f117b383dd591fd579bce5ee7bac07a3fdc1d050",
+        "rev": "af8a884164bb50ad34c09719bdbdb2a1b01b917c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`af8a8841`](https://github.com/nix-community/home-manager/commit/af8a884164bb50ad34c09719bdbdb2a1b01b917c) | `` kubeswitch: add module ``     |
| [`92db5be8`](https://github.com/nix-community/home-manager/commit/92db5be8e17c5150c46a2ca8f55a85d20df75643) | `` maintainers: add m0nsterrr `` |
| [`5a49fe44`](https://github.com/nix-community/home-manager/commit/5a49fe448e81ee05ab48ed3189109b322237ddbf) | `` opencode: init (#7320) ``     |