### PR TITLE
chore(flake/nix-index-database): `9c932ae6` -> `85686025`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -562,11 +562,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751170039,
-        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
+        "lastModified": 1751774635,
+        "narHash": "sha256-DuOznGdgMxeSlPpUu6Wkq0ZD5e2Cfv9XRZeZlHWMd1s=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
+        "rev": "85686025ba6d18df31cc651a91d5adef63378978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`85686025`](https://github.com/nix-community/nix-index-database/commit/85686025ba6d18df31cc651a91d5adef63378978) | `` update generated.nix to release 2025-07-06-034719 `` |
| [`d3de5a18`](https://github.com/nix-community/nix-index-database/commit/d3de5a18d3c1efa9ea05deeda071ff06c8fe39dc) | `` flake.lock: Update ``                                |