### PR TITLE
chore(flake/home-manager): `af8a8841` -> `8b0180dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751751054,
-        "narHash": "sha256-qUEejOOj1jc+y5anxDgay+NqVgLHVeY0So5PEDzlV18=",
+        "lastModified": 1751760902,
+        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "af8a884164bb50ad34c09719bdbdb2a1b01b917c",
+        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`8b0180dd`](https://github.com/nix-community/home-manager/commit/8b0180dde1d6f4cf632e046309e8f963924dfbd0) | `` maintainers: update all-maintainers.nix (#7392) `` |