### PR TITLE
chore(flake/stylix): `606944b1` -> `50ed5ddd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751656637,
-        "narHash": "sha256-x1uJ6wQ7C+N/Zx9liQzjyVOEwGf5tcKogSoGgxASZOg=",
+        "lastModified": 1751769163,
+        "narHash": "sha256-5/fDueotC2qqa5r+1UbOO1p6g1FUhVVb5cR5TwweF4c=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "606944b16862d43934fec3311f9cb9f478b7f99b",
+        "rev": "50ed5ddd1072a6b10e6368cc338d759ffa02df9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                   |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`50ed5ddd`](https://github.com/nix-community/stylix/commit/50ed5ddd1072a6b10e6368cc338d759ffa02df9b) | `` {neovim, vim}: add testbeds (#1571) `` |
| [`1bd6d031`](https://github.com/nix-community/stylix/commit/1bd6d031acacf64cef2b45a570d114f16c4b9ae6) | `` rio: use mkTarget (#1599) ``           |
| [`aca5e11a`](https://github.com/nix-community/stylix/commit/aca5e11a1fc8cf5b9aa73ba64433c64e06f328ff) | `` rio: add testbed (#1600) ``            |