### PR TITLE
chore(flake/home-manager): `8b0180dd` -> `b4486ff4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751760902,
-        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
+        "lastModified": 1751816429,
+        "narHash": "sha256-F9xzryA4OfrGTQS1N8SimJQzoD8qDMj/e2lTFE9V288=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
+        "rev": "b4486ff44addd453a64fd8c176ab2fd7ad3f6eb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`b4486ff4`](https://github.com/nix-community/home-manager/commit/b4486ff44addd453a64fd8c176ab2fd7ad3f6eb3) | `` mkFirefoxModule: add extension settings example to policies (#7397) ``      |
| [`153e680c`](https://github.com/nix-community/home-manager/commit/153e680c4263fbd8fa416ef5b8ef13397e02fd2f) | `` firefox: add release option (#6784) ``                                      |
| [`502d9b7d`](https://github.com/nix-community/home-manager/commit/502d9b7d30a1f5940ecdb786b4f71ebf57b1ac13) | `` codex: starting with v0.2.0 codex uses a TOML configuration file (#7388) `` |
| [`cc740783`](https://github.com/nix-community/home-manager/commit/cc7407839d09cef4838c9980ee3a390c28085951) | `` flake.lock: Update (#7395) ``                                               |