### PR TITLE
chore(flake/home-manager): `b4486ff4` -> `fd9e55f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751816429,
-        "narHash": "sha256-F9xzryA4OfrGTQS1N8SimJQzoD8qDMj/e2lTFE9V288=",
+        "lastModified": 1751824240,
+        "narHash": "sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt+ca0QkmHYZxMzI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b4486ff44addd453a64fd8c176ab2fd7ad3f6eb3",
+        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`fd9e55f5`](https://github.com/nix-community/home-manager/commit/fd9e55f5fac45a26f6169310afca64d56b681935) | `` tests/firefox: add bookmark policy to profile bookmarks test ``                       |
| [`753ea0b3`](https://github.com/nix-community/home-manager/commit/753ea0b3240ae3d64923dc77e33aa5c1be06b62f) | `` librewolf: allow bookmark configuration ``                                            |
| [`dbac1fbc`](https://github.com/nix-community/home-manager/commit/dbac1fbcd675c7e7149a35309269c37aef6223ee) | `` mkFirefoxModule: set `NoDefaultBookmarks` when a profile has bookmarks are enabled `` |
| [`9d21f998`](https://github.com/nix-community/home-manager/commit/9d21f9985e279bb5d35dbf03a25644ed6e954d8c) | `` i3-sway/lib: modifier accepts any string (#7398) ``                                   |