### PR TITLE
chore(flake/stylix): `bf0ef81c` -> `2a1ad278`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -696,11 +696,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751914048,
-        "narHash": "sha256-xHO3xlw35tCC0f3pN3osPNjgwwwAgusTuZk5iC8oDiE=",
+        "lastModified": 1751988434,
+        "narHash": "sha256-zNpPDEuhTPIB9uiZ980XT0zFQXay54ET9KFoQoek9RY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "bf0ef81c8fcc30c32db9dab32d379f8d9db835e4",
+        "rev": "2a1ad27868f5ec62230b9ecc756ce4e9d3355547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`2a1ad278`](https://github.com/nix-community/stylix/commit/2a1ad27868f5ec62230b9ecc756ce4e9d3355547) | `` ci: public flake instead of root flake (#1629) ``              |
| [`a0e891bf`](https://github.com/nix-community/stylix/commit/a0e891bfbeba5e8bfb391ffcee6589c5436e1151) | `` {i3,sway}: export bar configuration through options (#1502) `` |