### PR TITLE
chore(flake/stylix): `1d7a7814` -> `7b9a528d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752012890,
-        "narHash": "sha256-ozqfSCB8vDqV+W4VF0+lwen50YWhFCNxp1ruCm/6bP8=",
+        "lastModified": 1752073281,
+        "narHash": "sha256-SreB7pgUb8nOTDA9K2GFKiIam6MN2oJ5du/KVgvsRaU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1d7a78147d5f2f6c97beb41b7815ab9cd213ef81",
+        "rev": "7b9a528d6ce61feef42ef3ede42792438e59e205",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`7b9a528d`](https://github.com/nix-community/stylix/commit/7b9a528d6ce61feef42ef3ede42792438e59e205) | `` treewide: replace builtins.toString with toString (#1657) `` |
| [`82a1f36f`](https://github.com/nix-community/stylix/commit/82a1f36f80a0bdc9875c8b868ea6fe930b09887c) | `` ci: fix 'has: port to stable' labeling (#1621) ``            |