### PR TITLE
chore(flake/stylix): `7b9a528d` -> `480649bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752073281,
-        "narHash": "sha256-SreB7pgUb8nOTDA9K2GFKiIam6MN2oJ5du/KVgvsRaU=",
+        "lastModified": 1752083519,
+        "narHash": "sha256-NbLWT1fOfyoNdt5ZH65h0JnGzF8uSZPsjdo5PmW2AHI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7b9a528d6ce61feef42ef3ede42792438e59e205",
+        "rev": "480649bbdf8ef423c84a7152ceadf22839a5acbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`480649bb`](https://github.com/nix-community/stylix/commit/480649bbdf8ef423c84a7152ceadf22839a5acbb) | `` mako: fix testbed name (#1653) ``                                   |
| [`9028a74f`](https://github.com/nix-community/stylix/commit/9028a74f88d5ed31f4cff3483f3c143346ce43ea) | `` stylix: use isFunction (#1652) ``                                   |
| [`4eadb250`](https://github.com/nix-community/stylix/commit/4eadb2503b80f0251ff2c48856f9450474a70688) | `` stylix: guard against config.stylix.*.enable in mkTarget (#1640) `` |