### PR TITLE
chore(flake/home-manager): `206ed3c7` -> `d81cb050`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752093218,
-        "narHash": "sha256-+3rXu8ewcNDi65/2mKkdSGrivQs5zEZVp5aYszXC0d0=",
+        "lastModified": 1752175395,
+        "narHash": "sha256-VECsFTbfspSuKnMlptHC9L3y5lLilepcVLBq7WPNSX0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "206ed3c71418b52e176f16f58805c96e84555320",
+        "rev": "d81cb050f5530fc84aa0ddb421d50722ee662600",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`d81cb050`](https://github.com/nix-community/home-manager/commit/d81cb050f5530fc84aa0ddb421d50722ee662600) | `` hyprshell: add module (#7409) `` |
| [`50330593`](https://github.com/nix-community/home-manager/commit/50330593f33d0b873e0b6b05294164d093c0992a) | `` flake.lock: Update (#7419) ``    |