### PR TITLE
chore(flake/home-manager): `d81cb050` -> `fab659b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752175395,
-        "narHash": "sha256-VECsFTbfspSuKnMlptHC9L3y5lLilepcVLBq7WPNSX0=",
+        "lastModified": 1752202894,
+        "narHash": "sha256-knafgng4gCjZIUMyAEWjxxdols6n/swkYnbWr+oF+1w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d81cb050f5530fc84aa0ddb421d50722ee662600",
+        "rev": "fab659b346c0d4252208434c3c4b3983a4b38fec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`fab659b3`](https://github.com/nix-community/home-manager/commit/fab659b346c0d4252208434c3c4b3983a4b38fec) | `` trippy: add module (#7426) ``                           |
| [`3978bcd6`](https://github.com/nix-community/home-manager/commit/3978bcd6961847385121db30c58dbd444d4a73df) | `` thunderbird: configure SMTP and GPG for aliases ``      |
| [`d52abd5b`](https://github.com/nix-community/home-manager/commit/d52abd5b525e2f4ccc57b07db9759d1a147472fd) | `` email: allow more extensive configuration of aliases `` |
| [`729c5e54`](https://github.com/nix-community/home-manager/commit/729c5e5465a0585b2c492a40d9308ec3ad78a296) | `` docker-cli: add module (#7411) ``                       |
| [`d52da303`](https://github.com/nix-community/home-manager/commit/d52da303efeb39d67fdedd08f7d8fc8efd5f4332) | `` firefox: add extension permissions (#7402) ``           |
| [`fb12dbbc`](https://github.com/nix-community/home-manager/commit/fb12dbbce39ca29919e2b45913ce244c54d009de) | `` lutris: make module x86_64-linux only (#7425) ``        |