### PR TITLE
chore(flake/home-manager): `b8b7e5ec` -> `3976e050`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752256062,
-        "narHash": "sha256-2s0PrY3vIFusm4UrqPnskY6SgdVolEDAz9wHcCSadcw=",
+        "lastModified": 1752265577,
+        "narHash": "sha256-YhnBM3oknReSFTAuc2SMwekwjl9nDd5PUhcar4DsefM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b8b7e5ec3570eb003d55f4947dd39af15c3ca98d",
+        "rev": "3976e0507edc9a5f332cb2be93fa20e646d22374",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`3976e050`](https://github.com/nix-community/home-manager/commit/3976e0507edc9a5f332cb2be93fa20e646d22374) | `` test/wpaperd: add test for empty settings ``    |
| [`a3f4b998`](https://github.com/nix-community/home-manager/commit/a3f4b998ecaa9cf87f1a6244a49e5ed96a81f03e) | `` wpaperd: handle empty settings properly ``      |
| [`6d8ed2b4`](https://github.com/nix-community/home-manager/commit/6d8ed2b4fc2aaba8c87f44b1cf4931e22b683583) | `` ci: tag-maintainer workflow refactor (#7436) `` |
| [`03bf1bd8`](https://github.com/nix-community/home-manager/commit/03bf1bd8d6bad7521ce1c69dbe9b953156ca1148) | `` gtk2: fix missing force option (#7437) ``       |