### PR TITLE
chore(flake/lovesegfault-vim-config): `19972366` -> `2eebeaf7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752192446,
-        "narHash": "sha256-VKRvd8iTprpLi6dRAbR/u0YsbbtYB8GuLgNOooFp1Uk=",
+        "lastModified": 1752278914,
+        "narHash": "sha256-cgpe12GoRpsrQyOayIQ8qTK22bDIe2B5lib/MBeGkik=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "199723666020b34361e9e01048d385972136f13b",
+        "rev": "2eebeaf72236a47a86ca049a2ac231c3e105f038",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752158208,
-        "narHash": "sha256-XbXYLUtaB/wHvZYefvaDPbo4eYj27kbtowHfww9bqLw=",
+        "lastModified": 1752262661,
+        "narHash": "sha256-jPDiaHsKZeFH+zoxRIW0t1T/R+S8cYM3/9YUfMMjUEA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b728cf43d97814df43f5d9bd9dafac9072ccd9e8",
+        "rev": "658980fb247e2f10fa692bae372ac21389a67c6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`2eebeaf7`](https://github.com/lovesegfault/vim-config/commit/2eebeaf72236a47a86ca049a2ac231c3e105f038) | `` chore(flake/nixvim): b728cf43 -> 658980fb `` |