### PR TITLE
chore(flake/home-manager): `3976e050` -> `392ddb64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752265577,
-        "narHash": "sha256-YhnBM3oknReSFTAuc2SMwekwjl9nDd5PUhcar4DsefM=",
+        "lastModified": 1752286566,
+        "narHash": "sha256-A4nftqiNz2bNihz0bKY94Hq/6ydR6UQOcGioeL7iymY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3976e0507edc9a5f332cb2be93fa20e646d22374",
+        "rev": "392ddb642abec771d63688c49fa7bcbb9d2a5717",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`392ddb64`](https://github.com/nix-community/home-manager/commit/392ddb642abec771d63688c49fa7bcbb9d2a5717) | `` home-manager: add flake support for repl command (#7439) ``                 |
| [`7c6f7377`](https://github.com/nix-community/home-manager/commit/7c6f7377ccca88c45a28875e7755c38b604c5ff3) | `` vscode: enable defining `mcp.json` separate from `settings.json` (#7441) `` |