### PR TITLE
chore(flake/home-manager): `392ddb64` -> `ea24675e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752286566,
-        "narHash": "sha256-A4nftqiNz2bNihz0bKY94Hq/6ydR6UQOcGioeL7iymY=",
+        "lastModified": 1752348734,
+        "narHash": "sha256-w3s5y+9Nn0oKUk6yS77YG1iRSizNStxqhEsgIlJKRtw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "392ddb642abec771d63688c49fa7bcbb9d2a5717",
+        "rev": "ea24675e4f4f4c494ccb04f6645db2a394d348ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`ea24675e`](https://github.com/nix-community/home-manager/commit/ea24675e4f4f4c494ccb04f6645db2a394d348ee) | `` lib: Improve KDL generator (#7429) ``            |
| [`ae62fd8a`](https://github.com/nix-community/home-manager/commit/ae62fd8ad8347e6bb5b615057f39f33d595a1c47) | `` tests/zsh: add zprof test ``                     |
| [`196487c5`](https://github.com/nix-community/home-manager/commit/196487c54f58f237fade6b85dfd57f097c8b5581) | `` zsh: group plugins in a separate directory ``    |
| [`26b987cf`](https://github.com/nix-community/home-manager/commit/26b987cf8840e74b89bf3fe42d48fdf84af108b3) | `` zsh: move deprecated options to separate file `` |
| [`80a07bc6`](https://github.com/nix-community/home-manager/commit/80a07bc6f7f062d78c7dbc91ae8863eca0cabb2a) | `` zsh: move history to separate file ``            |
| [`3d95ab3c`](https://github.com/nix-community/home-manager/commit/3d95ab3cdca4e931b062e4dff39dea5563cbc2e3) | `` zsh: move zprof to separate file ``              |
| [`9b76feaf`](https://github.com/nix-community/home-manager/commit/9b76feafd02c84935ca3dea671057ca28b08131f) | `` zsh: move oh-my-zsh to separate file ``          |