### PR TITLE
chore(flake/lovesegfault-vim-config): `2eebeaf7` -> `c9f4de01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752278914,
-        "narHash": "sha256-cgpe12GoRpsrQyOayIQ8qTK22bDIe2B5lib/MBeGkik=",
+        "lastModified": 1752365364,
+        "narHash": "sha256-grzkBq0CTryhXL0/KocAJd2GucbN/DDNQsC+nQ1Lt+w=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "2eebeaf72236a47a86ca049a2ac231c3e105f038",
+        "rev": "c9f4de0151daa6adf4c25f82b3256cd05bb045a2",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752262661,
-        "narHash": "sha256-jPDiaHsKZeFH+zoxRIW0t1T/R+S8cYM3/9YUfMMjUEA=",
+        "lastModified": 1752358818,
+        "narHash": "sha256-Txnm5vJqZgaHpEM/9OANg1Ux4e9xHQ7iXfQ8EqtqM9s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "658980fb247e2f10fa692bae372ac21389a67c6c",
+        "rev": "4b068551d85cb4984fc60268a95097cf7af1ae48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`c9f4de01`](https://github.com/lovesegfault/vim-config/commit/c9f4de0151daa6adf4c25f82b3256cd05bb045a2) | `` chore(flake/nixvim): 658980fb -> 4b068551 `` |