### PR TITLE
chore(flake/home-manager): `ea24675e` -> `f2795aa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752348734,
-        "narHash": "sha256-w3s5y+9Nn0oKUk6yS77YG1iRSizNStxqhEsgIlJKRtw=",
+        "lastModified": 1752361671,
+        "narHash": "sha256-AliH6gxw6l9OFZCUuXgxmH+UvTKPeyHzBu4lnvQ8Ick=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ea24675e4f4f4c494ccb04f6645db2a394d348ee",
+        "rev": "f2795aa053ef11f958fba49aef15a5c4d9734c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`f2795aa0`](https://github.com/nix-community/home-manager/commit/f2795aa053ef11f958fba49aef15a5c4d9734c02) | `` ci: tag-maintainers further refactoring (#7446) `` |