### PR TITLE
chore(flake/stylix): `a950a3f5` -> `f6c5aaa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752419080,
-        "narHash": "sha256-XzdeXeHc99OPMAm6IAU95UYdSfI1xImrmVCxSc3/fcU=",
+        "lastModified": 1752422998,
+        "narHash": "sha256-c4o/PeudMsxXaJ0G8B75eFyhH7XvcFv21kvgn3jDjlQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a950a3f529e1952a7ddf2af138b90a99edf41fe5",
+        "rev": "f6c5aaa4f8b70ec0bf995be43311c38be3131776",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`f6c5aaa4`](https://github.com/nix-community/stylix/commit/f6c5aaa4f8b70ec0bf995be43311c38be3131776) | `` stylix: add missing trailing period in mkEnableTargetWith's description (#1681) `` |
| [`2947a837`](https://github.com/nix-community/stylix/commit/2947a83755d206553fb88116058f5322f3bc2d0e) | `` gtksourceview: don't overlay all of gnome2 (#1680) ``                              |