### PR TITLE
chore(flake/home-manager): `bf893ad4` -> `1a4d8ffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752402455,
-        "narHash": "sha256-mCHfZhQKdTj2JhCFcqfOfa3uKZbwUkPQbd0/zPnhOE8=",
+        "lastModified": 1752449767,
+        "narHash": "sha256-P8mQIrgIImASTlNkHPfKwGTmyZgku8EUt6cF52s3N/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf893ad4cbf46610dd1b620c974f824e266cd1df",
+        "rev": "1a4d8ffd320c2393b72e7ebc5b647122d5703056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`1a4d8ffd`](https://github.com/nix-community/home-manager/commit/1a4d8ffd320c2393b72e7ebc5b647122d5703056) | `` gurk-rs: fix missing s in home.packages (#7467) `` |
| [`7969ed8b`](https://github.com/nix-community/home-manager/commit/7969ed8baac8363b32775c5f55e132668bab8123) | `` gurk-rs: add module (#7466) ``                     |