### PR TITLE
chore(flake/stylix): `f6c5aaa4` -> `d683e35f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752422998,
-        "narHash": "sha256-c4o/PeudMsxXaJ0G8B75eFyhH7XvcFv21kvgn3jDjlQ=",
+        "lastModified": 1752449117,
+        "narHash": "sha256-Cn24ySH/LN/Q/SsDhpOX4cTMYZa1JMOLNeNsoYqcZpY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f6c5aaa4f8b70ec0bf995be43311c38be3131776",
+        "rev": "d683e35fa5ec8bbfd45d52e4b53c7b91f7b38d06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`d683e35f`](https://github.com/nix-community/stylix/commit/d683e35fa5ec8bbfd45d52e4b53c7b91f7b38d06) | `` stylix: use lib.warn instead of builtins.warn (#1676) ``            |
| [`218d4424`](https://github.com/nix-community/stylix/commit/218d4424b0634f8e9e3af92df7ca807bda529255) | `` treewide: remove redundant stylix.image Nix store copies (#1659) `` |