### PR TITLE
chore(flake/lovesegfault-vim-config): `06a33c6e` -> `439ac4a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752451629,
-        "narHash": "sha256-jU0Mt41U7f4fcV0+t7hs8ho/NdOCSj8MEWKq0JRLo4E=",
+        "lastModified": 1752538019,
+        "narHash": "sha256-MzwXQBewy+o9u6SQK2ppbq6FT2BrPF/czLhNRY1kY+8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "06a33c6eb8224361c5a0747783bf59ef956e95ac",
+        "rev": "439ac4a3744380b9d635daf3e0c169491540aa7d",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1752447041,
-        "narHash": "sha256-n5DPC4+lI9/gM0cdogohOUjiz50jhZ5l+Xg5Ucrj76w=",
+        "lastModified": 1752496197,
+        "narHash": "sha256-yADANK6gJL+BJrL0f450RGCZlUixCuYSoEqdjmBE5nY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eeec7f7c31f84b33d3c52365b073e06c21104521",
+        "rev": "03fa28a65f23210934cb3a3c0454eb8870af748b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`439ac4a3`](https://github.com/lovesegfault/vim-config/commit/439ac4a3744380b9d635daf3e0c169491540aa7d) | `` chore(flake/nixvim): eeec7f7c -> 03fa28a6 `` |