### PR TITLE
chore(flake/home-manager): `1e548375` -> `f7a45b08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752467539,
-        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
+        "lastModified": 1752592931,
+        "narHash": "sha256-cAGqSjubxOu+tPB/SbsIAlo/VrW2Hz6yOKw2HGmtzmI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "rev": "f7a45b08319233b9b93ba60bbfccb41df75a7ac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`f7a45b08`](https://github.com/nix-community/home-manager/commit/f7a45b08319233b9b93ba60bbfccb41df75a7ac1) | `` nix: use-sandbox -> sandbox (#7475) ``                |
| [`4cc9cc67`](https://github.com/nix-community/home-manager/commit/4cc9cc67ebd2847f5ed332a226e9109c97336ecf) | `` wayfire: fix broken configuration.ini test (#7478) `` |