### PR TITLE
chore(flake/stylix): `45749a79` -> `a92b0ac9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752598315,
-        "narHash": "sha256-pSm1BqcA6wido27VeNAi86SjpurpL84+ciAXQmrtSzk=",
+        "lastModified": 1752629792,
+        "narHash": "sha256-M/RmEyb0M5f/FseO4eXAqB2gd6U68eHzoZ7l0Dno+Ew=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "45749a791efd692c04dee4702b86a31535ed30d2",
+        "rev": "a92b0ac9da273fa484136283d4ef54ca19eacc4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`a92b0ac9`](https://github.com/nix-community/stylix/commit/a92b0ac9da273fa484136283d4ef54ca19eacc4f) | `` ci: bump DeterminateSystems/nix-installer-action from 18 to 19 `` |