### PR TITLE
chore(flake/stylix): `a92b0ac9` -> `8c854fe3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752629792,
-        "narHash": "sha256-M/RmEyb0M5f/FseO4eXAqB2gd6U68eHzoZ7l0Dno+Ew=",
+        "lastModified": 1752673382,
+        "narHash": "sha256-GxyHdgZqn6LJVsN9H6kTwMAu703wVaoequXP7f14NJk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a92b0ac9da273fa484136283d4ef54ca19eacc4f",
+        "rev": "8c854fe383fda20e8befefc31ecf248988a40bcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`8c854fe3`](https://github.com/nix-community/stylix/commit/8c854fe383fda20e8befefc31ecf248988a40bcc) | `` stylix: allow choosing testbed desktop (#1222) ``                        |
| [`436ad797`](https://github.com/nix-community/stylix/commit/436ad797df3fea6daab8b47a1ba10c7ae2505625) | `` zellij: update theme based on built-in Catppuccin Mocha theme (#1704) `` |