### PR TITLE
chore(flake/stylix): `0ba0ffe9` -> `03699ed2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752684057,
-        "narHash": "sha256-QRuM25aYp3n2cf59gEJE0VcIoGRX2ps8gp2mzorKodw=",
+        "lastModified": 1752750082,
+        "narHash": "sha256-NoVAqy+Wj4tgkvrYB8zWncl8Z6Hb80aX3t/TYGdsfaM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0ba0ffe94cbe20ae739c2aa8cae04cbf900bf56b",
+        "rev": "03699ed214f6e8195bc7199d6ae3aeccf9732b08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`03699ed2`](https://github.com/nix-community/stylix/commit/03699ed214f6e8195bc7199d6ae3aeccf9732b08) | `` stylix/testbed: respect xserver rename for gnome (#1714) `` |
| [`52804c7c`](https://github.com/nix-community/stylix/commit/52804c7c81fbe34e435113e253c002f788c096bf) | `` waybar: add testbed (#1712) ``                              |