### PR TITLE
chore(flake/home-manager): `460f1e9a` -> `bc9f3c84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752767945,
-        "narHash": "sha256-C7l88gwS48gjLxGqsJvQkVvvi7e99CdsdEVKiZTKEj8=",
+        "lastModified": 1752781640,
+        "narHash": "sha256-bDgECs6Gls+KeIba8ft7jmxM3Hsbc2+DseiI4zrra2o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "460f1e9af95b081fb7e2022485b6c22b92085936",
+        "rev": "bc9f3c8413a3aaa01ed959c371c1f9e57515965b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`bc9f3c84`](https://github.com/nix-community/home-manager/commit/bc9f3c8413a3aaa01ed959c371c1f9e57515965b) | `` direnv: misc cleanup ``                           |
| [`8320333a`](https://github.com/nix-community/home-manager/commit/8320333a4547422afb68b6df7ac7edfa2733038b) | `` tests/direnv: refactor tests ``                   |
| [`63994b71`](https://github.com/nix-community/home-manager/commit/63994b71d223b48007dbec0089bbfd62d9cd4e1d) | `` direnv: fix silent clobbering global config ``    |
| [`e595fe1d`](https://github.com/nix-community/home-manager/commit/e595fe1df49d75e971b33f311e365f032089f450) | `` flake.lock: Update (#7450) ``                     |
| [`2d55a529`](https://github.com/nix-community/home-manager/commit/2d55a52963d8a3856792e2fd6604f307176026bc) | `` radio-cli: add module (#7488) ``                  |
| [`50adf434`](https://github.com/nix-community/home-manager/commit/50adf43449743dfc0e4e82ab533112ef110bcfb0) | `` nushell: fix `get -i` deprecation (#7490) ``      |
| [`8eb2f2a2`](https://github.com/nix-community/home-manager/commit/8eb2f2a26ae540cc89300eed97c61fa264c2ff7f) | `` treewide: Remove unwanted dependencies (#7487) `` |