### PR TITLE
chore(flake/home-manager): `bc9f3c84` -> `7c78e592`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752781640,
-        "narHash": "sha256-bDgECs6Gls+KeIba8ft7jmxM3Hsbc2+DseiI4zrra2o=",
+        "lastModified": 1752783339,
+        "narHash": "sha256-RXxejsGIWtJ5rJKLAm8Kh159euZHPMi7CtbOoHLsm2c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bc9f3c8413a3aaa01ed959c371c1f9e57515965b",
+        "rev": "7c78e592a895f2f1921f0024848fe193e2f8518e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7c78e592`](https://github.com/nix-community/home-manager/commit/7c78e592a895f2f1921f0024848fe193e2f8518e) | `` maintainers: remove duplicate nixpkgs maintainers `` |
| [`defabc11`](https://github.com/nix-community/home-manager/commit/defabc11abd602bed3af5fe4111d023f638ccfc3) | `` ci: move validate maintainers logic to lib ``        |