### PR TITLE
chore(flake/lovesegfault-vim-config): `32b25fa9` -> `016c55b8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752624581,
-        "narHash": "sha256-Ba7RzpjTED82VSSe8uH5LqAw/1haiM/5eoXLoVGxv8U=",
+        "lastModified": 1752883657,
+        "narHash": "sha256-vSNv57fvra9rDvpsIskjDPWxOtqpj8WduBVe5XAtnZI=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "32b25fa9a20e34388b4f5a153555007e7f960c7f",
+        "rev": "016c55b8abadb2984726594f345b6daa6c6a5a19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`016c55b8`](https://github.com/lovesegfault/vim-config/commit/016c55b8abadb2984726594f345b6daa6c6a5a19) | `` chore(flake/nixpkgs): 62e0f05e -> 6e987485 `` |