### PR TITLE
chore(flake/stylix): `03699ed2` -> `24499b00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752750082,
-        "narHash": "sha256-NoVAqy+Wj4tgkvrYB8zWncl8Z6Hb80aX3t/TYGdsfaM=",
+        "lastModified": 1752947709,
+        "narHash": "sha256-dtyj+wJs/t8hf1Xd2RMS5Zu7RjwZfAZJ1R4qsQ9vSrM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "03699ed214f6e8195bc7199d6ae3aeccf9732b08",
+        "rev": "24499b0049881959bd4e159b6fe4e96e4c03db25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`24499b00`](https://github.com/nix-community/stylix/commit/24499b0049881959bd4e159b6fe4e96e4c03db25) | `` stylix: conditionally load external modules in testbeds (#1698) ``                 |
| [`2e2e96f6`](https://github.com/nix-community/stylix/commit/2e2e96f6b0720c9e974093b6521b8848ddd5706c) | `` treewide: remove blank lines around 'let', 'in', and function arguments (#1700) `` |