### PR TITLE
chore(flake/stylix): `24499b00` -> `f826d321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752947709,
-        "narHash": "sha256-dtyj+wJs/t8hf1Xd2RMS5Zu7RjwZfAZJ1R4qsQ9vSrM=",
+        "lastModified": 1752965417,
+        "narHash": "sha256-FDec+RoFgSrk3YPedcjNiBK+acaHO4Vt0YDTMdKdw1w=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "24499b0049881959bd4e159b6fe4e96e4c03db25",
+        "rev": "f826d3214b8a9be3f158d5cc7514c4130674324b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`f826d321`](https://github.com/nix-community/stylix/commit/f826d3214b8a9be3f158d5cc7514c4130674324b) | `` stylix: add generated all-maintainers file (#1654) `` |
| [`e4cc192b`](https://github.com/nix-community/stylix/commit/e4cc192b263f17fb58e616301e29b1498e72f390) | `` ci: use cachix/install-nix-action (#1725) ``          |