### PR TITLE
chore(flake/stylix): `9242b3ec` -> `c32c82e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753009241,
-        "narHash": "sha256-puhWbjjrOtOlYYV0R2J99V905vUjF+NqyK5N+kiVZXg=",
+        "lastModified": 1753055255,
+        "narHash": "sha256-t7jZUPQSqlNA3wdIhmZuz7CPAMXCo6CsoAGyrR++jXA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9242b3ec8e0d253f32614778ed4996af7aaf9438",
+        "rev": "c32c82e460b9022c4c20cf51014db1665e866ffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`c32c82e4`](https://github.com/nix-community/stylix/commit/c32c82e460b9022c4c20cf51014db1665e866ffb) | `` zen-browser: init (#1694) ``                                     |
| [`62bd6e52`](https://github.com/nix-community/stylix/commit/62bd6e52a541f5f717671812fd3556cb5bec40cf) | `` i3: use mkTarget (#1655) ``                                      |
| [`4af7cbde`](https://github.com/nix-community/stylix/commit/4af7cbde9cdae25e5ecc4a95693b9e0e30ace8b6) | `` qt: guard nixosConfig instead of isLinux and osConfig (#1722) `` |