### PR TITLE
chore(flake/home-manager): `e0402627` -> `13a83d1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753055793,
-        "narHash": "sha256-hJIMlQDfUUb44VTH4F+21HGJsrNaWoBqDDnAH22kkd4=",
+        "lastModified": 1753056897,
+        "narHash": "sha256-AVVMBFcuOXqIgmShvRv9TED3fkiZhQ0ZvlhsPoFfkNE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0402627096f236943a6691fbe037b55dabef4d1",
+        "rev": "13a83d1b6545b7f0e8f7689bad62e7a3b1d63771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`13a83d1b`](https://github.com/nix-community/home-manager/commit/13a83d1b6545b7f0e8f7689bad62e7a3b1d63771) | `` zed-editor: support tasks (#7493) ``                         |
| [`7834432c`](https://github.com/nix-community/home-manager/commit/7834432ca540b4179959b4864c40ed29f2720732) | `` thunderbird: support declaration of address books (#7443) `` |