### PR TITLE
chore(flake/disko): `d5ad4485` -> `545aba02`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752718651,
-        "narHash": "sha256-PkaR0qmyP9q/MDN3uYa+RLeBA0PjvEQiM0rTDDBXkL8=",
+        "lastModified": 1753140376,
+        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d5ad4485e6f2edcc06751df65c5e16572877db88",
+        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`545aba02`](https://github.com/nix-community/disko/commit/545aba02960caa78a31bd9a8709a0ad4b6320a5c) | `` build(deps): bump DeterminateSystems/update-flake-lock from 26 to 27 `` |
| [`3db2f047`](https://github.com/nix-community/disko/commit/3db2f0476516b2758fe8f1559f70c937b9d9b16b) | `` allow subtype definitions to be broken up ``                            |