### PR TITLE
chore(flake/nixos-hardware): `d1bfa8f6` -> `cc66fddc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1752666637,
-        "narHash": "sha256-P8J72psdc/rWliIvp8jUpoQ6qRDlVzgSDDlgkaXQ0Fw=",
+        "lastModified": 1753122741,
+        "narHash": "sha256-nFxE8lk9JvGelxClCmwuJYftbHqwnc01dRN4DVLUroM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d1bfa8f6ccfb5c383e1eba609c1eb67ca24ed153",
+        "rev": "cc66fddc6cb04ab479a1bb062f4d4da27c936a22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8ea54c02`](https://github.com/NixOS/nixos-hardware/commit/8ea54c025e9ef7e4929234bdd12c22a52709dcbb) | `` surface: linux 6.15.3 -> 6.15.6 ``             |
| [`94100810`](https://github.com/NixOS/nixos-hardware/commit/94100810798c046d1e9f17e370da8bf8734eb8f4) | `` init: NUC 5i5RYB ``                            |
| [`41f2cad3`](https://github.com/NixOS/nixos-hardware/commit/41f2cad3f96c1fb163fde49c27f22e1faabced9a) | `` Add flip_done timeout workaround for 14IMH9 `` |
| [`1828627b`](https://github.com/NixOS/nixos-hardware/commit/1828627b087329e5324be0909892ec7337d55f14) | `` asus: fix charge-upto script ``                |