### PR TITLE
chore(flake/home-manager): `e4bf85da` -> `847711c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753132348,
-        "narHash": "sha256-0i3jU9AHuNXb0wYGzImnVwaw+miE0yW13qfjC0F+fIE=",
+        "lastModified": 1753180535,
+        "narHash": "sha256-KEtlzMs2O7FDvciFtjk9W4hyau013Pj9qZNK9a0PxEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4bf85da687027cfc4a8853ca11b6b86ce41d732",
+        "rev": "847711c7ffa9944b0c5c39a8342ac8eb6a9f9abc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`847711c7`](https://github.com/nix-community/home-manager/commit/847711c7ffa9944b0c5c39a8342ac8eb6a9f9abc) | `` ci: bump DeterminateSystems/update-flake-lock from 26 to 27 `` |
| [`83674177`](https://github.com/nix-community/home-manager/commit/836741779f18dc111af1609f9749a5236e1e8f33) | `` ci: apply dependabot on release-25.05 ``                       |
| [`d1db9055`](https://github.com/nix-community/home-manager/commit/d1db9055ea3934e36a82332f6237b789b1d859ab) | `` iamb: use correct config directory on macOS ``                 |
| [`04b710c1`](https://github.com/nix-community/home-manager/commit/04b710c1f0c522b7b2f47600bec60d790becdbdb) | `` maintainers: update all-maintainers.nix ``                     |
| [`de448dcb`](https://github.com/nix-community/home-manager/commit/de448dcb577570f2a11f243299b6536537e05bbe) | `` home-manager: avoid profile management during activation ``    |