### PR TITLE
chore(flake/stylix): `ea60526c` -> `37673b1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753117651,
-        "narHash": "sha256-7gWBlUOe2c0nYGyoVDa9hw15pI3DXDR0KK+nYh9KOpU=",
+        "lastModified": 1753237059,
+        "narHash": "sha256-4ZmwEYiS0vdhJSkNCLyoYRZuxRYT/8JGpL4WDRvrX14=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ea60526c8c2a1c5df2743a9495814dc0b319ef3b",
+        "rev": "37673b1de0703a637f3a8abe8da8a097d076a377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`37673b1d`](https://github.com/nix-community/stylix/commit/37673b1de0703a637f3a8abe8da8a097d076a377) | `` zen-browser: fix select tags not being readable (#1738) `` |
| [`6e8c6906`](https://github.com/nix-community/stylix/commit/6e8c6906c15cb235eb164db9766a9ba1f51f94d4) | `` i3: remove readOnly from exportedBar (#1737) ``            |