### PR TITLE
chore(flake/home-manager): `0cdfcdbb` -> `1fde6fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753181343,
-        "narHash": "sha256-CLQfNtUqirNVSYoW/kYbvL4PeeNasmZonaPnjO3+1YQ=",
+        "lastModified": 1753294394,
+        "narHash": "sha256-1Dfgq09lHZ8AdYB2Deu/mYP1pMNpob8CgqT5Mzo44eI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0cdfcdbb525b77b951c889b6131047bc374f48fe",
+        "rev": "1fde6fb1be6cd5dc513dc1c287d69e4eb2de973e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1fde6fb1`](https://github.com/nix-community/home-manager/commit/1fde6fb1be6cd5dc513dc1c287d69e4eb2de973e) | `` yofi: add module (#7528) ``                                |
| [`fe38a5e0`](https://github.com/nix-community/home-manager/commit/fe38a5e02870debe6084203bca56d750e5d67ce8) | `` pueue: enable darwin configuration (#7519) ``              |
| [`3641df95`](https://github.com/nix-community/home-manager/commit/3641df95becab34d2d7a221218091c2cea2d9c2e) | `` Translate using Weblate (Basque) ``                        |
| [`b8d1a792`](https://github.com/nix-community/home-manager/commit/b8d1a79235798d6397db93bc891350901117cf54) | `` Translate using Weblate (Swedish) ``                       |
| [`e9c599e4`](https://github.com/nix-community/home-manager/commit/e9c599e40c8d0d754980f51e580d00ebef3f2fea) | `` yarn: add module (#7526) ``                                |
| [`b4752b0e`](https://github.com/nix-community/home-manager/commit/b4752b0eda6302b92a6d5dd554c83f188bc3ae6d) | `` treewide: format with latest stable formatter ``           |
| [`56ee5d06`](https://github.com/nix-community/home-manager/commit/56ee5d06701cc9a0a0721a4d33216233ed46c34a) | `` flake: use nixfmt stable release ``                        |
| [`6cf61d10`](https://github.com/nix-community/home-manager/commit/6cf61d10e8308f4c5f6eedded9de26a8c1b7234c) | `` tests/darwinScrublist: add opencode ``                     |
| [`3260a705`](https://github.com/nix-community/home-manager/commit/3260a705861f5174be28e63633663f5f05f59043) | `` flake.lock: Update ``                                      |
| [`62975b8e`](https://github.com/nix-community/home-manager/commit/62975b8e23c4e39599b3303f6e76faa280a02c63) | `` hyprsunset: assert hyprland package is not null (#7518) `` |