### PR TITLE
chore(flake/stylix): `fbe1dab7` -> `ceda12a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1748408240,
-        "narHash": "sha256-9M2b1rMyMzJK0eusea0x3lyh3mu5nMeEDSc4RZkGm+g=",
+        "lastModified": 1752979451,
+        "narHash": "sha256-0CQM+FkYy0fOO/sMGhOoNL80ftsAzYCg9VhIrodqusM=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "6c711ab1a9db6f51e2f6887cc3345530b33e152e",
+        "rev": "27cf1e66e50abc622fb76a3019012dc07c678fac",
         "type": "github"
       },
       "original": {
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753296482,
-        "narHash": "sha256-VPLaHVhU6/CwnMHTjhf6945qyrXEcpjxKfpWqQXtnxI=",
+        "lastModified": 1753372006,
+        "narHash": "sha256-eyIYqerHPYHl2Eq802wJSOwMwZ3tdvJ4D+vckDe2mD8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fbe1dab7783a3d579dc57be8ceee148104e0930b",
+        "rev": "ceda12a6da2181e424d8ed7e68ed291745f06f49",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`62c9ec3e`](https://github.com/nix-community/stylix/commit/62c9ec3e0eebe2d8e9b49c9976cf1f5138c85ab2) | `` treewide: expand testbed interactions with Flake Parts tree ``            |
| [`79fab36b`](https://github.com/nix-community/stylix/commit/79fab36b0f92cfca17c74871558a48640cf0eac1) | `` treewide: replace custom testbed test files with Flake Parts tree ``      |
| [`1adb93fc`](https://github.com/nix-community/stylix/commit/1adb93fcbcfb1ffeef23cdf0ab4f7d17e7af0a6e) | `` flake: add Flake Parts tree into testbed environment ``                   |
| [`e334b301`](https://github.com/nix-community/stylix/commit/e334b3019e72212289729c753873ad2a897370ca) | `` ci: check: add wimpysworld/nothing-but-nix Action for larger Nix store `` |
| [`06d89e95`](https://github.com/nix-community/stylix/commit/06d89e95bab748316c8dfddb95d542d9a6ec36f4) | `` helix: add `osipog` as maintainer ``                                      |
| [`bb2d949c`](https://github.com/nix-community/stylix/commit/bb2d949cd14a40b649b205f9e6043155663fea9e) | `` flake: bump `base16-helix` to latest version ``                           |