### PR TITLE
chore(flake/home-manager): `e2fe7256` -> `a35f6b60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753365873,
-        "narHash": "sha256-+Swd3wJppukESlWkbdopl9ZThjNVIFARVlb/eA2xjUA=",
+        "lastModified": 1753387274,
+        "narHash": "sha256-Y1hAI9h+9DLBbgKvZBsHaeptFIcRw4iC6ySPmzyqmlM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e2fe7256c4ebbb35bfd1b4c6f52b57a3845ab1d0",
+        "rev": "a35f6b60430ff0c7803bd2a727df84c87569c167",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`a35f6b60`](https://github.com/nix-community/home-manager/commit/a35f6b60430ff0c7803bd2a727df84c87569c167) | `` trippy: add forceUserConfig option (#7536) ``                              |
| [`64796151`](https://github.com/nix-community/home-manager/commit/64796151f79e6f3834bfc55f07c5487708bb5b3f) | `` opencode: add JSON schema reference to config.json output ``               |
| [`1df662dd`](https://github.com/nix-community/home-manager/commit/1df662dde0b46f0480c259f9bb92577afc48ae2b) | `` opencode: add empty-settings test ``                                       |
| [`08edcbe9`](https://github.com/nix-community/home-manager/commit/08edcbe9dfd4a3098f5d097b13d7ce693ba2ad16) | `` opencode: add support for global custom instructions via `rules` option `` |
| [`0a98177b`](https://github.com/nix-community/home-manager/commit/0a98177bb8a5b81d69d1a2bfb490e47875875b01) | `` maintainers: remove karaolidis keys (#7537) ``                             |