### PR TITLE
chore(flake/stylix): `744431e1` -> `af85565a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753490930,
-        "narHash": "sha256-noQ6sJ1twQvvGH34d13iM0uh95Syx+kb3nw45wTalIM=",
+        "lastModified": 1753553562,
+        "narHash": "sha256-CpTwdsrPU3UFy95Btg56RcVMgNpnw3C0DYTznE5aRq4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "744431e17676177c18c4c52e8781ba6e91db30d6",
+        "rev": "af85565aba0f4749cb18b118a7333a0745920950",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`af85565a`](https://github.com/nix-community/stylix/commit/af85565aba0f4749cb18b118a7333a0745920950) | `` treewide: replace lib.listToAttrs with builtins.listToAttrs (#1760) `` |
| [`3a7b869c`](https://github.com/nix-community/stylix/commit/3a7b869cd61c0db5ca369d39632d64a6e45a41f2) | `` fuzzel: fix icons not being set correctly ``                           |
| [`07482556`](https://github.com/nix-community/stylix/commit/07482556dc38c0d9f28ffdc3d25009ce9dbbdd22) | `` fuzzel: add MrSom3body as a maintainer ``                              |
| [`ab417a28`](https://github.com/nix-community/stylix/commit/ab417a287ff4f095212f9c4e520c6db8079e8e5a) | `` ci: add more top-level labels to provide better overview ``            |
| [`04f130b0`](https://github.com/nix-community/stylix/commit/04f130b035cbcfe11209fce02cb64d275aa66907) | `` ci: lexicographically sort labels to avoid ambiguous order ``          |
| [`a6d99d74`](https://github.com/nix-community/stylix/commit/a6d99d742dd0feb97e5cb712f3f1fd5e3a19563f) | `` ci: consistently format singleton list ``                              |