### PR TITLE
chore(flake/home-manager): `2b73c2fc` -> `710771af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753567913,
-        "narHash": "sha256-eYrqSRI1/mrnVGCGYO+zkKHUszwJQodq/qDHh+mzvkI=",
+        "lastModified": 1753595562,
+        "narHash": "sha256-Ci88mAdtiP5RQkYmVhRUq69iYPMM7/lS9/mw+FnC7DE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2b73c2fcca690b6eca4f520179e54ae760f25d4e",
+        "rev": "710771af3d1c8c3f86a9e5d562616973ed5f3f21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`710771af`](https://github.com/nix-community/home-manager/commit/710771af3d1c8c3f86a9e5d562616973ed5f3f21) | `` docs: add a poison module ``                              |
| [`6ce43381`](https://github.com/nix-community/home-manager/commit/6ce433818580edc2acbf7282455331c4a5b95aae) | `` nixos: increase laziness regarding shared modules ``      |
| [`ed1eeeee`](https://github.com/nix-community/home-manager/commit/ed1eeeeee6279c371fbc0e4b6d68bc0b39077a16) | `` xdg-terminal-exec: make sure the module is imported ``    |
| [`42924f0e`](https://github.com/nix-community/home-manager/commit/42924f0eff0f6694d9e374e9c08a75fabc3eb140) | `` xdg-terminal-exec: minor cleanup of option description `` |
| [`63dd0e94`](https://github.com/nix-community/home-manager/commit/63dd0e9409accc1df46b81199f423c0446397775) | `` opencode: minor cleanup of option description ``          |