### PR TITLE
chore(flake/home-manager): `710771af` -> `72cc1e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753595562,
-        "narHash": "sha256-Ci88mAdtiP5RQkYmVhRUq69iYPMM7/lS9/mw+FnC7DE=",
+        "lastModified": 1753617834,
+        "narHash": "sha256-WEVfKrdIdu5CpppJ0Va3vzP0DKlS+ZTLbBjugMO2Drg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "710771af3d1c8c3f86a9e5d562616973ed5f3f21",
+        "rev": "72cc1e3134a35005006f06640724319caa424737",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`72cc1e31`](https://github.com/nix-community/home-manager/commit/72cc1e3134a35005006f06640724319caa424737) | `` tests/hyprlock: update tests with upstream changes ``  |
| [`0daef6fb`](https://github.com/nix-community/home-manager/commit/0daef6fbe0d71cd81967d9595a60c515a31ad034) | `` hyprlock: update example config ``                     |
| [`e8867156`](https://github.com/nix-community/home-manager/commit/e88671567b5020c41fa1880ef08428f91448548b) | `` zsh: only apply plugins when zsh is enabled (#7555) `` |