### PR TITLE
chore(flake/stylix): `af85565a` -> `a6cf7759`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753553562,
-        "narHash": "sha256-CpTwdsrPU3UFy95Btg56RcVMgNpnw3C0DYTznE5aRq4=",
+        "lastModified": 1753641602,
+        "narHash": "sha256-lt+bUL+Mx9FAKW2qTuPMQge/WDhW821gCkhIBrDbrXk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "af85565aba0f4749cb18b118a7333a0745920950",
+        "rev": "a6cf77599790af5a21d7043a6b65767e410d633f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`a6cf7759`](https://github.com/nix-community/stylix/commit/a6cf77599790af5a21d7043a6b65767e410d633f) | `` yazi: allow to set boldness of directory (#1696) ``     |
| [`e6d25946`](https://github.com/nix-community/stylix/commit/e6d25946f370f50a1f7b48c9081845fae6804ae9) | `` zellij: add testbed (#1773) ``                          |
| [`4606c3e1`](https://github.com/nix-community/stylix/commit/4606c3e1b59d8c93b2368b4e5352fcee7992c0e0) | `` helix: add testbed (#1772) ``                           |
| [`e8fe026f`](https://github.com/nix-community/stylix/commit/e8fe026f0441eae821e8b27f4ea51f82b23d2a2a) | `` ashell: add testbed (#1768) ``                          |
| [`2f1ae3b8`](https://github.com/nix-community/stylix/commit/2f1ae3b872539bf0f77c45687c3d009b135531d2) | `` stylix/testbed: add sendNotifications option (#1770) `` |
| [`cb01ed11`](https://github.com/nix-community/stylix/commit/cb01ed115251cda10ec0b0621d4ba8e7fd5bda05) | `` blender: add support for version 4.5 (#1766) ``         |
| [`b5af13b1`](https://github.com/nix-community/stylix/commit/b5af13b1db6001c6239fbb5b28f5252d67a7d80d) | `` doc: overhaul GitHub PR template ``                     |
| [`00309532`](https://github.com/nix-community/stylix/commit/00309532fc20d86334321a8a5802acf46484e110) | `` doc: add backport checkbox to GitHub PR template ``     |