### PR TITLE
chore(flake/home-manager): `72cc1e31` -> `e4b032ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753617834,
-        "narHash": "sha256-WEVfKrdIdu5CpppJ0Va3vzP0DKlS+ZTLbBjugMO2Drg=",
+        "lastModified": 1753675338,
+        "narHash": "sha256-KDS9sr7dddH97lUXa7oxfRqphBlCA6JxZO4m/Z4W06I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72cc1e3134a35005006f06640724319caa424737",
+        "rev": "e4b032ba5113664f0b8b23d956e59ce8e0bc349d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`e4b032ba`](https://github.com/nix-community/home-manager/commit/e4b032ba5113664f0b8b23d956e59ce8e0bc349d) | `` ci: re-enable home manager install and uninstall tests on darwin `` |
| [`a07400a2`](https://github.com/nix-community/home-manager/commit/a07400a2e53a59e1b06ef5b76f0062bcaf3500fc) | `` ci: don't duplicate test runs on github ``                          |
| [`800f16a9`](https://github.com/nix-community/home-manager/commit/800f16a9c53c279cdd1cdf847bdff5e99438eeb0) | `` tests: forward only test chunks to buildbot ``                      |
| [`7a02711a`](https://github.com/nix-community/home-manager/commit/7a02711a610d921f53e3a5b6a38fe3e71adc51cd) | `` tests: integration tests only run on linux ``                       |
| [`9fa2ad30`](https://github.com/nix-community/home-manager/commit/9fa2ad30c5df6dfa3bfed5ba057dc530b309c0bb) | `` buildbot-nix.toml: add file ``                                      |
| [`234f10ec`](https://github.com/nix-community/home-manager/commit/234f10ec6d97a45b401f23caa2de46954b2164bd) | `` tests/flake: add buildbot output ``                                 |
| [`e45ff565`](https://github.com/nix-community/home-manager/commit/e45ff5651ceecfb5b0a2cb37b11a73a7f713235f) | `` ci: split tests into chunks ``                                      |