### PR TITLE
chore(flake/home-manager): `e4b032ba` -> `a7b7c6f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753675338,
-        "narHash": "sha256-KDS9sr7dddH97lUXa7oxfRqphBlCA6JxZO4m/Z4W06I=",
+        "lastModified": 1753693456,
+        "narHash": "sha256-5i5+9pPq80C37a/xqepLRYMHNw8CSh1S7o0ps+kkl3k=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e4b032ba5113664f0b8b23d956e59ce8e0bc349d",
+        "rev": "a7b7c6f520b51f3577bd6b7a7493d2cdbcb22ec6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`a7b7c6f5`](https://github.com/nix-community/home-manager/commit/a7b7c6f520b51f3577bd6b7a7493d2cdbcb22ec6) | `` docs: add upgrade guide for NixOS version transitions `` |
| [`3156a1c4`](https://github.com/nix-community/home-manager/commit/3156a1c4196e03e66ce16220d4f2e58cb19718cb) | `` docs: minor manual style fix ``                          |