### PR TITLE
chore(flake/stylix): `a6cf7759` -> `fc24382f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753641602,
-        "narHash": "sha256-lt+bUL+Mx9FAKW2qTuPMQge/WDhW821gCkhIBrDbrXk=",
+        "lastModified": 1753698383,
+        "narHash": "sha256-uR2ZKp1/yjQz0xTu7U/hhiBVp28/o/o+uOqIJIqOAW8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a6cf77599790af5a21d7043a6b65767e410d633f",
+        "rev": "fc24382fabe1d4413c9a898ecbc6508c4ebb503b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                            |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`fc24382f`](https://github.com/nix-community/stylix/commit/fc24382fabe1d4413c9a898ecbc6508c4ebb503b) | `` fnott: add testbed (#1783) ``   |
| [`4faa7be9`](https://github.com/nix-community/stylix/commit/4faa7be903dc4c4c2b09e977e21d71fb83216ece) | `` nushell: add testbed (#1785) `` |
| [`e280f272`](https://github.com/nix-community/stylix/commit/e280f272a5f60a5f44c9665449635354e9ebe2ac) | `` fish: add testbeds (#1782) ``   |
| [`d65c5d83`](https://github.com/nix-community/stylix/commit/d65c5d83009da0f9f10de52f53cdcaadbcb11953) | `` dunst: add testbed (#1781) ``   |