### PR TITLE
chore(flake/stylix): `fc24382f` -> `57d036d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753698383,
-        "narHash": "sha256-uR2ZKp1/yjQz0xTu7U/hhiBVp28/o/o+uOqIJIqOAW8=",
+        "lastModified": 1753731630,
+        "narHash": "sha256-8pyTksY2aYtLGmqP8u3xhs4ZfttsfzZXAQZXHKecLDo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fc24382fabe1d4413c9a898ecbc6508c4ebb503b",
+        "rev": "57d036d92283fddc6ae080459e72e767144a1cda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`57d036d9`](https://github.com/nix-community/stylix/commit/57d036d92283fddc6ae080459e72e767144a1cda) | `` doc: commit_convention: overhaul and formalize unspoken rules (#1717) `` |
| [`683d6269`](https://github.com/nix-community/stylix/commit/683d626986cf87548c66bfe27c5588a071ad636f) | `` fuzzel: add testbed (#1784) ``                                           |