### PR TITLE
chore(flake/home-manager): `20cf285e` -> `f49e872f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753709185,
-        "narHash": "sha256-fU0XPSNudRJHvbeMK2qWBXEbfd77t7r+e9V2L9ON5kI=",
+        "lastModified": 1753732062,
+        "narHash": "sha256-vojVM0SgFP8crFh1LDDXkzaI9/er/1cuRfbNPhfBHyc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "20cf285e9f8e5e3968abca80081c03ea96e7ea73",
+        "rev": "f49e872f55e36e67ebcb906ff65f86c7a1538f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`f49e872f`](https://github.com/nix-community/home-manager/commit/f49e872f55e36e67ebcb906ff65f86c7a1538f7c) | `` zsh: lib better docstrings ``                            |
| [`a1b7e7f5`](https://github.com/nix-community/home-manager/commit/a1b7e7f510b93a48406adc894eed6d0811147d11) | `` tests/antidote: remove deprecated relative path usage `` |
| [`471eeaa9`](https://github.com/nix-community/home-manager/commit/471eeaa9753a186338da134243584a44ccfde099) | `` zsh: add khaneliman maintainer ``                        |
| [`08f16235`](https://github.com/nix-community/home-manager/commit/08f162350c5d0062dfc1dd0b628448099bbc8317) | `` news: add news entry for zsh path refactor ``            |
| [`e52c6c3d`](https://github.com/nix-community/home-manager/commit/e52c6c3da3f9b16e085ef32a75237169c95364bf) | `` zsh: env var assertion for dotdir ``                     |
| [`40af7ba0`](https://github.com/nix-community/home-manager/commit/40af7ba06ba959a191ac1297f5f4e6c2786a1e39) | `` zsh: relative path deprecation warning ``                |
| [`9ff467fb`](https://github.com/nix-community/home-manager/commit/9ff467fbe7d42972068cfcfc9167838e7c66aabc) | `` tests/zsh: add more path test cases ``                   |
| [`938ecd79`](https://github.com/nix-community/home-manager/commit/938ecd797f17b5baa408f7a0af01747a81e4bed6) | `` zsh: fix lib function for env var path parsing ``        |