### PR TITLE
chore(flake/home-manager): `50adf8fc` -> `cfe397c8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753761827,
-        "narHash": "sha256-mrVNT+aF4yR8P8Fx570W2vz+LzukSlf68Yr2YhUJHjo=",
+        "lastModified": 1753803071,
+        "narHash": "sha256-O8l1+c8L6NE+kW4MJvJMLKKz6cElV/FOcomr+qTZjZs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "50adf8fcaa97c9d64309f2d507ed8be54ea23110",
+        "rev": "cfe397c8c091a06a5a0a4e683e6fca2e57a8312f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`cfe397c8`](https://github.com/nix-community/home-manager/commit/cfe397c8c091a06a5a0a4e683e6fca2e57a8312f) | `` arrpc: assert linux ``                                            |
| [`0f9fae16`](https://github.com/nix-community/home-manager/commit/0f9fae161dba7c828de66d1111dfd82909cbd6f8) | `` tests/arrpc: add service module test coverage ``                  |
| [`1ed730a9`](https://github.com/nix-community/home-manager/commit/1ed730a9771eba6b9426e58b8d29baa7084cba89) | `` ci: manage reviewers doesn't re-add manually removed reviewers `` |
| [`2c8306e5`](https://github.com/nix-community/home-manager/commit/2c8306e506718d4c7596ba0b2a595a8e623fc009) | `` ci: manage reviewers add dry run option ``                        |