### PR TITLE
chore(flake/home-manager): `cfe397c8` -> `b108e6b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753803071,
-        "narHash": "sha256-O8l1+c8L6NE+kW4MJvJMLKKz6cElV/FOcomr+qTZjZs=",
+        "lastModified": 1753818448,
+        "narHash": "sha256-Z9WzU2+S3z4QZ/LGcivBY4cf2aG0VYiRmgeAsdegXY0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cfe397c8c091a06a5a0a4e683e6fca2e57a8312f",
+        "rev": "b108e6b7f75d2767a1a559345689e7bedfe7dd11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b108e6b7`](https://github.com/nix-community/home-manager/commit/b108e6b7f75d2767a1a559345689e7bedfe7dd11) | `` editorconfig: fix insert_final_newline unset for json files `` |
| [`1a8b119e`](https://github.com/nix-community/home-manager/commit/1a8b119e60158711ac53962f7a6ad478796f449a) | `` tests/caffeine: add test coverage ``                           |
| [`cec4c1be`](https://github.com/nix-community/home-manager/commit/cec4c1be7eaae2ad3ec780b3c7cd26dbe8c3ce20) | `` tests/ssh-agent: add test coverage ``                          |
| [`85a52871`](https://github.com/nix-community/home-manager/commit/85a5287116c6c09ce01ff006a3f14ba7a9d3c21b) | `` tests/gnome-keyring: add test coverage ``                      |
| [`2f588d27`](https://github.com/nix-community/home-manager/commit/2f588d275ebd8243be6c29e7bf3ec7409baa0aa7) | `` hyprsunset: add program to home packages ``                    |
| [`f4e8bc1a`](https://github.com/nix-community/home-manager/commit/f4e8bc1ab6d3e2a178b86141d39f8b847dc52a1b) | `` hyprsunset: refactor implementation ``                         |
| [`fa184c54`](https://github.com/nix-community/home-manager/commit/fa184c5460b1099ad7dafeba0ae980a998a12d8d) | `` hyprsunset: Add tests for transitons option ``                 |
| [`7c01358f`](https://github.com/nix-community/home-manager/commit/7c01358ff6f555330addf5f606d39fb97c70f8e3) | `` hyprsunset: Add tests for hyprsunset.conf file ``              |
| [`6ff07a01`](https://github.com/nix-community/home-manager/commit/6ff07a01a811f3866e8fab0e30e48392e5741865) | `` hyprsunset: deprecate transitions option ``                    |
| [`8aaf3b53`](https://github.com/nix-community/home-manager/commit/8aaf3b53192e62abfd28eddf79f9a9de9d7834f5) | `` hyprsunset: Update module to use hyprsunset.conf ``            |
| [`03fdb312`](https://github.com/nix-community/home-manager/commit/03fdb31290d1a4a8d23f52206283450d304c3841) | `` treewide: add missing package options (#7575) ``               |
| [`25deca89`](https://github.com/nix-community/home-manager/commit/25deca893974aae98c9be151fb47d6284c053470) | `` Translate using Weblate (Finnish) ``                           |
| [`1fa11c8e`](https://github.com/nix-community/home-manager/commit/1fa11c8e830b919b85d9d975567aad12cba69e8c) | `` Translate using Weblate (Turkish) ``                           |
| [`1364772b`](https://github.com/nix-community/home-manager/commit/1364772b57c0dd751dfa3d9baf6c0978c52e0adc) | `` Translate using Weblate (Japanese) ``                          |