### PR TITLE
chore(flake/home-manager): `b108e6b7` -> `ab148052`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753818448,
-        "narHash": "sha256-Z9WzU2+S3z4QZ/LGcivBY4cf2aG0VYiRmgeAsdegXY0=",
+        "lastModified": 1753829416,
+        "narHash": "sha256-Shx91k6pLdX8wK6LchsHRXWAWODvy6fHAbUqOmye43A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b108e6b7f75d2767a1a559345689e7bedfe7dd11",
+        "rev": "ab14805267c132c5e9ac66129ca5361abd592a3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ab148052`](https://github.com/nix-community/home-manager/commit/ab14805267c132c5e9ac66129ca5361abd592a3a) | `` darwinScrublist: add superfile ``                                         |
| [`fc55d9a4`](https://github.com/nix-community/home-manager/commit/fc55d9a42b178a62edb15a1d11b7085274a922a2) | `` flake.lock: Update ``                                                     |
| [`4bf12467`](https://github.com/nix-community/home-manager/commit/4bf124678be14242e916f4dec2596158900780d4) | `` hyprland: Add `"output"` to `importantPrefixes` option default (#7507) `` |
| [`909d3939`](https://github.com/nix-community/home-manager/commit/909d39391efa9a1f74f7386cb6919b2722e06310) | `` PULL_REQUEST_TEMPLATE: nixfmt-rfc-style -> nixfmt (#7580) ``              |