### PR TITLE
chore(flake/home-manager): `d732b648` -> `0630790b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753848447,
-        "narHash": "sha256-fsld/crW9XRodFUG1GK8Lt0ERv6ARl9Wj3Xb0x96J4w=",
+        "lastModified": 1753888434,
+        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d732b648e5a7e3b89439ee25895e4eb24b7e5452",
+        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`0630790b`](https://github.com/nix-community/home-manager/commit/0630790b31d4547d79ff247bc3ba1adda3a017d9) | `` tests: include test names in passthru `` |
| [`53524d8b`](https://github.com/nix-community/home-manager/commit/53524d8b274a4710ff9e2bf3468764937217ed8e) | `` tests: chunk size 250 -> 50 ``           |