### PR TITLE
chore(flake/stylix): `cf71ad5a` -> `b4e1daad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753836228,
-        "narHash": "sha256-cWdFqyNEqGbB6S5neG8MnrOaEXtPQRSlx0pm9NRehzs=",
+        "lastModified": 1753884760,
+        "narHash": "sha256-U/dCdXlfnEg2MPqxYsOlnUUVP2O/0Y/nSD329dcA+xo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "cf71ad5aae3555d9ccc3ae0b522a88e8973c500d",
+        "rev": "b4e1daad3bcd434cf09a42fd0014c5d239c7ceed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`b4e1daad`](https://github.com/nix-community/stylix/commit/b4e1daad3bcd434cf09a42fd0014c5d239c7ceed) | `` ci: request subsystem maintainers review (#1053) ``                    |
| [`4bfd32c8`](https://github.com/nix-community/stylix/commit/4bfd32c8f93ef95be2f41a00e438f0bb2de1c4ac) | `` ci: backport: fix "has: port to stable" condition (#1795) ``           |
| [`8017dec8`](https://github.com/nix-community/stylix/commit/8017dec82d5eb7664393da364fac0b05190cdbc6) | `` stylix/testbed: make path escaping test actually contain a space ``    |
| [`3499e3ec`](https://github.com/nix-community/stylix/commit/3499e3ec704b00d2155e1be72bb8f34081e471e4) | `` treewide: properly quote stylix.image when used as a shell argument `` |
| [`e0db8fc1`](https://github.com/nix-community/stylix/commit/e0db8fc17af557765885a514c3752f332586a6af) | `` gnome/hm: use mkTarget (#1650) ``                                      |