### PR TITLE
chore(flake/lovesegfault-vim-config): `e4fdedf7` -> `26bfb73f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753834188,
-        "narHash": "sha256-uq7kLK3Zp0OpEBK0p84yD58Dmgn9RDXBkzTeWFw/ZgM=",
+        "lastModified": 1753912212,
+        "narHash": "sha256-ymL+9UdBFlRMyLSDI7weUBEnSUM2C8BfbuwI8MN+U48=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "e4fdedf7b0fd57494a7035e9862af7c9304e63d6",
+        "rev": "26bfb73ff1473a31f2413b8aba9700925b3f997e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                       |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`26bfb73f`](https://github.com/lovesegfault/vim-config/commit/26bfb73ff1473a31f2413b8aba9700925b3f997e) | `` fix: only enable wl-copy/xclip on linux ``                                 |
| [`a419f30a`](https://github.com/lovesegfault/vim-config/commit/a419f30a5c463d8bfe2ec5ce104f272c9a3bfd61) | `` chore(flake/nixpkgs): 7fd36ee8 -> dc963787 ``                              |
| [`87912af9`](https://github.com/lovesegfault/vim-config/commit/87912af9fb61849ba90c31ccf7aaed30679b7de3) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 18 to 19 `` |