### PR TITLE
chore(flake/tinted-schemes): `c279b1ef` -> `7ef9b314`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1753742647,
-        "narHash": "sha256-NvTte5U88zkBfzhbEZ/xZfRQG5Xn3T0eGO59et/tVx4=",
+        "lastModified": 1753976271,
+        "narHash": "sha256-TrVL5MmmuUi2ahfbYUpHWgZIK93WgbzecXmgOTQGSXE=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "c279b1efcd28f05109236fa66b6e153bda3148ff",
+        "rev": "7ef9b3144e0ccd3f8d80aeaccc49ef62c501fafe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                      |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`7ef9b314`](https://github.com/tinted-theming/schemes/commit/7ef9b3144e0ccd3f8d80aeaccc49ef62c501fafe) | `` base16/charcoal: added the charcoal colorscheme. (#67) `` |