### PR TITLE
chore(flake/home-manager): `bd82507e` -> `7035020a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753943136,
-        "narHash": "sha256-eiEE5SabVcIlGSTRcRyBjmJMaYAV95SJnjy8YSsVeW4=",
+        "lastModified": 1753983724,
+        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd82507edd860c453471c46957cbbe3c9fd01b5c",
+        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`7035020a`](https://github.com/nix-community/home-manager/commit/7035020a507ed616e2b20c61491ae3eaa8e5462c) | `` anki: set valid language default ``            |
| [`e2238e60`](https://github.com/nix-community/home-manager/commit/e2238e60736a2dd86f5bcf6fafee72429a9cd6ff) | `` anki: remove trailing whitespace ``            |
| [`4e97102b`](https://github.com/nix-community/home-manager/commit/4e97102bd44899c514411aa8e604ecc33a9da356) | `` nh: add options for specific flakes (#7566) `` |