### PR TITLE
chore(flake/lovesegfault-vim-config): `2be60666` -> `3e37fbde`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753920542,
-        "narHash": "sha256-fiRL/pHt1MOChreJf4tyb4V2DsiKw/AmixCTTAWzewc=",
+        "lastModified": 1754006920,
+        "narHash": "sha256-AB/blFlOptyi7nNDi0oy+jdlcVJDo03KRKbA8N6z09Y=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "2be60666d0c98a60376f57a00de53ba740996996",
+        "rev": "3e37fbde681effc0efacd01056be811e35756dca",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1753878247,
-        "narHash": "sha256-nxwVcC0ptpXenOWAyXTkYysbWAJPBIu2Mgp4XiFOfm4=",
+        "lastModified": 1753977315,
+        "narHash": "sha256-AM3CZh+Emk/cr5Gf6RUf2xzkWdRB+yewP1YWoRxUbYQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1729fe160872c9e53bd6977d92f53ef131606d4e",
+        "rev": "a16c89c175277309fd3dd065fb5bc4eab450ae07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`3e37fbde`](https://github.com/lovesegfault/vim-config/commit/3e37fbde681effc0efacd01056be811e35756dca) | `` chore(flake/nixvim): 1729fe16 -> a16c89c1 `` |