### PR TITLE
chore(flake/home-manager): `7035020a` -> `19f94a3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753983724,
-        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
+        "lastModified": 1754060289,
+        "narHash": "sha256-rWc9WUHtDCnHhnKEbiyLwBmvsXxHgBf56jvmmHPMUCk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
+        "rev": "19f94a3e0e6c8573ea58dac685e96c36e2526cfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`19f94a3e`](https://github.com/nix-community/home-manager/commit/19f94a3e0e6c8573ea58dac685e96c36e2526cfa) | `` sesh: Add preview window ``                        |
| [`712c6dad`](https://github.com/nix-community/home-manager/commit/712c6dad6cc41abd77c103dc76cda7c443b6c4b3) | `` sesh: fix kill-session field seperator ``          |
| [`614956c9`](https://github.com/nix-community/home-manager/commit/614956c9932b607a758d7910a5c133af44110309) | `` sesh: switch from `fzf-tmux -p` to `fzf --tmux` `` |
| [`899af421`](https://github.com/nix-community/home-manager/commit/899af4218c5a8dd6d6f98e55e21d0c7ccc6b13f7) | `` tmux: fix prefix and shortcut settings (#7549) ``  |
| [`08cf2543`](https://github.com/nix-community/home-manager/commit/08cf2543eac2a88435d7fe4553fd5322f80f587e) | `` Translate using Weblate (French) (#7596) ``        |