### PR TITLE
chore(flake/lovesegfault-vim-config): `3e37fbde` -> `33d146a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754006920,
-        "narHash": "sha256-AB/blFlOptyi7nNDi0oy+jdlcVJDo03KRKbA8N6z09Y=",
+        "lastModified": 1754093368,
+        "narHash": "sha256-uLxl2aJ8NCI98UwxvWlSjflH714B5nFhXTlyWbSx3Y8=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "3e37fbde681effc0efacd01056be811e35756dca",
+        "rev": "33d146a908869b9863b2af98aa458fecaa9e3aa7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`33d146a9`](https://github.com/lovesegfault/vim-config/commit/33d146a908869b9863b2af98aa458fecaa9e3aa7) | `` chore(flake/flake-parts): 644e0fc4 -> 67df8c62 `` |
| [`0f346757`](https://github.com/lovesegfault/vim-config/commit/0f34675733e0323f47142b56e17e36da2e89b1ca) | `` chore(flake/treefmt-nix): 6b9214ff -> 58bd4da4 `` |