### PR TITLE
chore(flake/lovesegfault-vim-config): `33d146a9` -> `85a033e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754093368,
-        "narHash": "sha256-uLxl2aJ8NCI98UwxvWlSjflH714B5nFhXTlyWbSx3Y8=",
+        "lastModified": 1754093572,
+        "narHash": "sha256-YoWbPHtrMelCHXT0Y47pZ/zj/Fmhl1WHiBAfVKcfd+k=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "33d146a908869b9863b2af98aa458fecaa9e3aa7",
+        "rev": "85a033e0146fcbaeccc1f1535276388a3d375bee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`85a033e0`](https://github.com/lovesegfault/vim-config/commit/85a033e0146fcbaeccc1f1535276388a3d375bee) | `` chore(flake/nixpkgs): dc963787 -> 94def634 `` |