### PR TITLE
chore(flake/home-manager): `e102920c` -> `e6e2f43a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754085240,
-        "narHash": "sha256-kVHCrTWEe8B1thAhFag1bk4QPY0ZP45V9vPbrwPHoNo=",
+        "lastModified": 1754174776,
+        "narHash": "sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW+lDMMZNF43PQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e102920c1becb114645c6f92fe14edc0b05cc229",
+        "rev": "e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`e6e2f43a`](https://github.com/nix-community/home-manager/commit/e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445) | `` televison: add PopeRigby as maintainer ``                      |
| [`98aed449`](https://github.com/nix-community/home-manager/commit/98aed449ba2ec9f9c4bc265da37a7666e3ad04bd) | `` television: update channel location ``                         |
| [`d492e3c3`](https://github.com/nix-community/home-manager/commit/d492e3c3811ebd0e67bad5145c618b108cf84a4f) | `` nixos: improve description of enableLegacyProfileManagement `` |
| [`187e0af2`](https://github.com/nix-community/home-manager/commit/187e0af20adf97f799992bf2821a123b7c4dfb3b) | `` nh: remove .nix suffix check for flake paths (#7600) ``        |