### PR TITLE
chore(flake/nixos-hardware): `cc66fddc` -> `a872d985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1753122741,
-        "narHash": "sha256-nFxE8lk9JvGelxClCmwuJYftbHqwnc01dRN4DVLUroM=",
+        "lastModified": 1754229794,
+        "narHash": "sha256-yOl7REX6O/1mh+tpscJPKgjK6nmXSMOB1xhmDNAMUZM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "cc66fddc6cb04ab479a1bb062f4d4da27c936a22",
+        "rev": "a872d985392ee5b19d8409bfcc3f106de2070070",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`d99ca4e5`](https://github.com/NixOS/nixos-hardware/commit/d99ca4e5f4d5dbbe3c8107e2fd2c778edeb37851) | `` framework-amd-ai-300-series: bump kernel to latest for suspend support `` |