### PR TITLE
chore(flake/home-manager): `0de18bd5` -> `1d7abbd5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754225444,
-        "narHash": "sha256-mv01SQtqlhBMavc1dgNjgqJw4WfZxy+w3xBgwJU3YmU=",
+        "lastModified": 1754263839,
+        "narHash": "sha256-ck7lILfCNuunsLvExPI4Pw9OOCJksxXwozum24W8b+8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0de18bd5c6681280d7ae017fa34ffd91bdcf0557",
+        "rev": "1d7abbd5454db97e0af51416f4960b3fb64a4773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`1d7abbd5`](https://github.com/nix-community/home-manager/commit/1d7abbd5454db97e0af51416f4960b3fb64a4773) | `` htop: add field `M_VIRT` and `TTY` as alias ``  |
| [`a26e907c`](https://github.com/nix-community/home-manager/commit/a26e907ca1cd4ccba1295f0ea2957c04cb244fdf) | `` htop: sort fields by its id ``                  |
| [`d4c53262`](https://github.com/nix-community/home-manager/commit/d4c53262ca0a6bf449b65fa0529d76dbc1b0a4c3) | `` htop: add more platform-independence fields `` |
| [`c89fdd32`](https://github.com/nix-community/home-manager/commit/c89fdd3291f4bd98feaf0e158ad91c9136013c69) | `` htop: add more fields ``                        |
| [`5954bb38`](https://github.com/nix-community/home-manager/commit/5954bb383edce727ced7549bc4b79b2fcdc32843) | `` Add translation using Weblate (Faroese) ``      |