### PR TITLE
chore(flake/nixpkgs): `94def634` -> `5b09dc45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753939845,
-        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                   |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`bdb6f413`](https://github.com/NixOS/nixpkgs/commit/bdb6f413b8501782feb2ede572c1c58bc1e31155) | `` androidStudioPackages.canary: 2025.1.3.2 -> 2025.1.3.3 ``                                              |
| [`195282b4`](https://github.com/NixOS/nixpkgs/commit/195282b4d06fa5fcd486a08bbe317e01354d8c81) | `` dnsmonster: update changelog URL ``                                                                    |
| [`b16813ba`](https://github.com/NixOS/nixpkgs/commit/b16813baa89e3bf87c62d459e6c8b2c3da57a369) | `` root: 6.36.00 -> 6.36.02 (#424032) ``                                                                  |
| [`a2622366`](https://github.com/NixOS/nixpkgs/commit/a26223668fd0830249592ed6cacad4c89cbf4f19) | `` qownnotes: 25.7.8 -> 25.7.9 ``                                                                         |
| [`b56e34b5`](https://github.com/NixOS/nixpkgs/commit/b56e34b54022a864ede429d7f78c6662d7f29b36) | `` awsume: migrate to by-name ``                                                                          |
| [`09325145`](https://github.com/NixOS/nixpkgs/commit/09325145c0e1cbd93b778b904cf0bf419821cb05) | `` olive-editor: migrate to by-name ``                                                                    |
| [`53479e04`](https://github.com/NixOS/nixpkgs/commit/53479e04c4adffeb4fb09870f2515ff488c9df2d) | `` plater: migrate to by-name ``                                                                          |
| [`feff4890`](https://github.com/NixOS/nixpkgs/commit/feff4890ba70556f81384c96b475f9655e989047) | `` gotty: 1.5.0 -> 1.5.1 ``                                                                               |
| [`e960e6e1`](https://github.com/NixOS/nixpkgs/commit/e960e6e1dc689e2b5fe9e3ee824fc12860d9f27c) | `` inspircd: 4.7.0 -> 4.8.0 ``                                                                            |
| [`0515216c`](https://github.com/NixOS/nixpkgs/commit/0515216cefe35b8ed9b68cd65afad66d66b5faea) | `` nixos/inspircd: sync with upstream systemd.service file ``                                             |
| [`0f560425`](https://github.com/NixOS/nixpkgs/commit/0f56042556eef90c0ffcde1a36974d2a7085bd98) | `` inspircd: 3.18.0 -> 4.7.0 ``                                                                           |
| [`8dfd1d60`](https://github.com/NixOS/nixpkgs/commit/8dfd1d60bdf8ac4a9a59fd95edf76a2e15542853) | `` cdncheck: 1.1.29 -> 1.1.30 ``                                                                          |
| [`bbc8067b`](https://github.com/NixOS/nixpkgs/commit/bbc8067bcf93029fe1a9bb4cee7c66c8749a9957) | `` fallout2-ce: fix patch hash ``                                                                         |
| [`f3245b67`](https://github.com/NixOS/nixpkgs/commit/f3245b67d085b83a796c5c107dfa500b48906ac1) | `` wahay: init at 0.2 ``                                                                                  |
| [`e9aa1c19`](https://github.com/NixOS/nixpkgs/commit/e9aa1c19b02838571a37040f000ffb5fb287ffe3) | `` hashcat: fix build on aarch64 ``                                                                       |
| [`31ad4265`](https://github.com/NixOS/nixpkgs/commit/31ad4265427c14d4c1bfb5960338d57435d28ce8) | `` tpnote: 1.25.12 -> 1.25.14 ``                                                                          |
| [`3c25cbb0`](https://github.com/NixOS/nixpkgs/commit/3c25cbb0aa935917d0a07f9a73025e9cbe5f7d77) | `` cargo-public-api: 0.49.0 -> 0.50.1 ``                                                                  |
| [`0d4ab9b0`](https://github.com/NixOS/nixpkgs/commit/0d4ab9b08cc4697aa0cf06af245ab6d17f9231a9) | `` screen: disable tests on loongarch64 ``                                                                |
| [`fb2d4f22`](https://github.com/NixOS/nixpkgs/commit/fb2d4f22502a9a35038b34d84012c1c66f253fb9) | `` zwave-js-ui: 10.10.0 -> 11.0.1 ``                                                                      |
| [`68255dbd`](https://github.com/NixOS/nixpkgs/commit/68255dbddfa7c6c6985da563b7ead4a00a442b85) | `` hypercore: 11.11.0 -> 11.11.2 ``                                                                       |
| [`3f4350d4`](https://github.com/NixOS/nixpkgs/commit/3f4350d4afa0eef5d5b4cb3cfbc8e463fee2752a) | `` python3Packages.fastcore: 1.8.6 -> 1.8.7 ``                                                            |
| [`1d5d07c2`](https://github.com/NixOS/nixpkgs/commit/1d5d07c2310be18f6c74955bc5fec7bc97894198) | `` extrakto: remove unnecessary deps for darwin ``                                                        |
| [`c1ceba0a`](https://github.com/NixOS/nixpkgs/commit/c1ceba0ad8397c0e9d36065a3fcc23318ff68c68) | `` tailwindcss-language-server: 0.14.25 -> 0.14.26 ``                                                     |
| [`a41daaf9`](https://github.com/NixOS/nixpkgs/commit/a41daaf983d201473bdd7e4d59068e8edef2aa46) | `` steamPackages.steam-fhsenv-without-steam: drop broken alias ``                                         |
| [`d4db6929`](https://github.com/NixOS/nixpkgs/commit/d4db692989c7c638d33ef79a94ab68513c30887f) | `` simplex-chat-desktop: 6.4.0 -> 6.4.2 ``                                                                |
| [`97ec8915`](https://github.com/NixOS/nixpkgs/commit/97ec891580b7e038b8982f36bf1c201a84b9565e) | `` cura-appimage: 5.10.1 -> 5.10.2 ``                                                                     |
| [`987c0190`](https://github.com/NixOS/nixpkgs/commit/987c0190501172382a731f10ab27e4c0794a5078) | `` harper: 0.53.0 -> 0.54.0 ``                                                                            |
| [`164133be`](https://github.com/NixOS/nixpkgs/commit/164133be7edf4364a21a4fc99295018314e6ff7a) | `` vscode-extensions.ndonfris.fish-lsp: 0.1.10 -> 0.1.11 ``                                               |
| [`c3ab7634`](https://github.com/NixOS/nixpkgs/commit/c3ab7634ed3e1db54ea2e6cb564025d3ec77bf04) | `` cpeditor: move to by-name ``                                                                           |
| [`24d206dd`](https://github.com/NixOS/nixpkgs/commit/24d206dd242744735fe96b77ffc83ebcc9ff0e06) | `` cpeditor: use finalAttrs ``                                                                            |
| [`26f9efe2`](https://github.com/NixOS/nixpkgs/commit/26f9efe2c5ca7c70479db795bfba577c367a85a6) | `` eslint: 9.31.0 -> 9.32.0 ``                                                                            |
| [`41698ced`](https://github.com/NixOS/nixpkgs/commit/41698ced6cef1907110a641a8d14bda6b446f9f0) | `` moonlight: 1.3.24 -> 1.3.25 ``                                                                         |
| [`88d59b1f`](https://github.com/NixOS/nixpkgs/commit/88d59b1f28fde2098b231cdd8f88ad5c52d0219e) | `` cpeditor: remove with lib ``                                                                           |
| [`4696381f`](https://github.com/NixOS/nixpkgs/commit/4696381f5f0939176c3ceaf9aabbff82b46a22ab) | `` ccpeditor: use callPackage ``                                                                          |
| [`2e130ff1`](https://github.com/NixOS/nixpkgs/commit/2e130ff1a1eb91cca84564fccb680414616a417f) | `` ludusavi: use finalAttrs ``                                                                            |
| [`4553f7d9`](https://github.com/NixOS/nixpkgs/commit/4553f7d9cbdb52624c28f1dbcc067bcf57734421) | `` python3Packages.pynetdicom: 3.0.3 -> 3.0.4 ``                                                          |
| [`59de3a51`](https://github.com/NixOS/nixpkgs/commit/59de3a510756ea9b370da077e347509ee70a197b) | `` keyspersecond: build with gradle_8, remove gradle_7 ``                                                 |
| [`723ce939`](https://github.com/NixOS/nixpkgs/commit/723ce9394b443fc4ce83d6d5a54aee528c5bb328) | `` Revert "coin3d: 4.0.3 -> 4.0.4" ``                                                                     |
| [`fd9c7557`](https://github.com/NixOS/nixpkgs/commit/fd9c7557a9016d6efe021761b0362503c3a942df) | `` open-policy-agent: disable flaky test ``                                                               |
| [`05238330`](https://github.com/NixOS/nixpkgs/commit/05238330bc089c285ab6316d7f4d2057dfe6afcd) | `` vscode: remove rec ``                                                                                  |
| [`efd87a99`](https://github.com/NixOS/nixpkgs/commit/efd87a9914af70c971cc0e4ad937e5d7d44138c4) | `` vscode: remove misleading description ``                                                               |
| [`b318c694`](https://github.com/NixOS/nixpkgs/commit/b318c694c9a01b5c0ee78d135e3c8811d5979a15) | `` rendercv: init at 2.2 ``                                                                               |
| [`b57e54cc`](https://github.com/NixOS/nixpkgs/commit/b57e54cc886d168ae3425cba5f3fd078810b998c) | `` codex: 0.4.0 -> 0.11.0 ``                                                                              |
| [`08c53a27`](https://github.com/NixOS/nixpkgs/commit/08c53a27b4b40659cd63f7fdfb9e9f544c939823) | `` clock-rs: 0.1.215 -> 0.1.216 ``                                                                        |
| [`acad8eaa`](https://github.com/NixOS/nixpkgs/commit/acad8eaa083f51dd7620ce0422bc90c760c85db7) | `` gost: 3.1.0 -> 3.2.0 ``                                                                                |
| [`24e7bdb2`](https://github.com/NixOS/nixpkgs/commit/24e7bdb2cb046027c13ceecd909891bdd9de997d) | `` libretro.beetle-pce-fast: 0-unstable-2025-07-18 -> 0-unstable-2025-08-01 ``                            |
| [`591935a0`](https://github.com/NixOS/nixpkgs/commit/591935a0ec5fd18c70f32433b0f8834014c50121) | `` platformio-core: add missing dependencies and adjust path environment variable ``                      |
| [`5f66907e`](https://github.com/NixOS/nixpkgs/commit/5f66907eba03167cbfc0bbc793eaba53cbb7ddb7) | `` home-assistant-custom-lovelace-modules.atomic-calendar.revive: fix update script ``                    |
| [`e982553e`](https://github.com/NixOS/nixpkgs/commit/e982553eefc4be1cfe365d55ce0f5bea38330918) | `` evcc: 0.206.0 -> 0.207.0 ``                                                                            |
| [`ba61e9e3`](https://github.com/NixOS/nixpkgs/commit/ba61e9e331d7e026844d24bbd2316dcbff3197e4) | `` wttrbar: provide changelog ``                                                                          |
| [`9c1fa0c2`](https://github.com/NixOS/nixpkgs/commit/9c1fa0c2c888fd67cf81b37d5cc2a9d79fcb2e42) | `` wttrbar: use tag instead of rev for fetchFromGitHub ``                                                 |
| [`ed989156`](https://github.com/NixOS/nixpkgs/commit/ed9891566015036b07966de01110d8cab03606a9) | `` wttrbar: use finalAttrs pattern ``                                                                     |
| [`ce7f9692`](https://github.com/NixOS/nixpkgs/commit/ce7f9692fa33564e0ee7fb2b183ee64a9f531b07) | `` wttrbar: Add OpenSSL dependency ``                                                                     |
| [`0bee0a8d`](https://github.com/NixOS/nixpkgs/commit/0bee0a8d0ade7a72ee6bfbabf1a64a4e4333bd54) | `` element-desktop: 1.11.106 -> 1.11.108 ``                                                               |
| [`a9ecbd54`](https://github.com/NixOS/nixpkgs/commit/a9ecbd5418b1c672d833bbd6f8b93fea59c3a275) | `` element-web-unwrapped: 1.11.106 -> 1.11.108 ``                                                         |
| [`6bd10b37`](https://github.com/NixOS/nixpkgs/commit/6bd10b373007b0fe97dadcf88a06061cc92edd86) | `` diffoscope: fix build on Darwin ``                                                                     |
| [`8e41855f`](https://github.com/NixOS/nixpkgs/commit/8e41855fcdea5a4c9e6915fc39cc4c93126b7b74) | `` gp-saml-gui: migrate to by-name ``                                                                     |
| [`b47ee350`](https://github.com/NixOS/nixpkgs/commit/b47ee350af73c7a1c6148eca78973446bdc3f9ec) | `` python3Packages.rendercv-fonts: init at 0.4.0 ``                                                       |
| [`8c6099ba`](https://github.com/NixOS/nixpkgs/commit/8c6099ba657952fe89779b6b54579147a05b9bd1) | `` gobject-introspection: fix inappropriate targetPlatform usage ``                                       |
| [`3a005897`](https://github.com/NixOS/nixpkgs/commit/3a00589790aaa14d54841aea29982db7c99d4e2e) | `` clorinde: 1.0.0 -> 1.0.1 ``                                                                            |
| [`37c8670e`](https://github.com/NixOS/nixpkgs/commit/37c8670ed90543737cc93035b8efd9c819da635f) | `` linux_xanmod_latest: 6.15.8 -> 6.15.9 ``                                                               |
| [`f00e0073`](https://github.com/NixOS/nixpkgs/commit/f00e007371886b534f6e4aecb01ba9ebe899fe21) | `` linux_xanmod: 6.12.40 -> 6.12.41 ``                                                                    |
| [`9a32aeff`](https://github.com/NixOS/nixpkgs/commit/9a32aeffd8dac5b4b913481a5898ad778db5ae34) | `` newelle: 0.9.8 -> 1.0.0 ``                                                                             |
| [`bcc64ded`](https://github.com/NixOS/nixpkgs/commit/bcc64dedcea0e8b9d62bd3780d25d88e811079d9) | `` hashcat: 6.2.6 -> 7.0.0 ``                                                                             |
| [`e488a90d`](https://github.com/NixOS/nixpkgs/commit/e488a90d3550ed536c7ac9080b9373396b916a10) | `` docling: 2.38.1 -> 2.42.0 ``                                                                           |
| [`059951b6`](https://github.com/NixOS/nixpkgs/commit/059951b66b216fdd9eecb0f2d147211323afc9b4) | `` python3Packages.docling-ibm-models: 3.8.1 -> 3.9.0 ``                                                  |
| [`4a7f35b2`](https://github.com/NixOS/nixpkgs/commit/4a7f35b27c3506f9f34c65502753fe03a78330b6) | `` vscode-extensions.saoudrizwan.claude-dev: 3.20.1 -> 3.20.5 ``                                          |
| [`a0b0d0c9`](https://github.com/NixOS/nixpkgs/commit/a0b0d0c98ff1b77838a630f82f00e3c92821e53f) | `` python3Packages.docling-parse: patch unit test due to groundtruth data not including text direction `` |
| [`0da74c61`](https://github.com/NixOS/nixpkgs/commit/0da74c61ee63e8f9ad4c074f3414a50921eea9fa) | `` python3Packages.docling-core: 2.38.1 -> 2.44.1 ``                                                      |
| [`4ee2f8d7`](https://github.com/NixOS/nixpkgs/commit/4ee2f8d79799edd1161f540b6363e823168b4782) | `` lazygit: 0.53.0 -> 0.54.0 ``                                                                           |
| [`b4516016`](https://github.com/NixOS/nixpkgs/commit/b4516016077f1cf6b319a8b537794be100d6a3c2) | `` steampipePackages.steampipe-plugin-aws: 1.19.0 -> 1.21.0 ``                                            |
| [`b6effd29`](https://github.com/NixOS/nixpkgs/commit/b6effd29c0ff000127f82bd2b7af3f7f55a0bf45) | `` nebula: fix potential cert expiration during tests ``                                                  |
| [`63806079`](https://github.com/NixOS/nixpkgs/commit/63806079c3e45f7073f3b381861395dbc04f1f68) | `` python3Packages.pyosohotwaterapi: 1.2.0 -> 1.2.4 ``                                                    |
| [`524a4612`](https://github.com/NixOS/nixpkgs/commit/524a461212e47ccccc897c5127ead12f649110c6) | `` python3Packages.posthog: 6.3.1 -> 6.3.3 ``                                                             |
| [`bd210dd1`](https://github.com/NixOS/nixpkgs/commit/bd210dd16af288350175f92bbadc4a29f213ac83) | `` overcommit: 0.64.0 -> 0.67.1 ``                                                                        |
| [`55d806ce`](https://github.com/NixOS/nixpkgs/commit/55d806ceed0b75c6bfa520020d0300e7b00c7d83) | `` autosuspend: 7.2.0 -> 8.0.0 ``                                                                         |
| [`37c9267f`](https://github.com/NixOS/nixpkgs/commit/37c9267f3e77ccafb3d7f247c6c57ab9c2b9d35d) | `` rosa: 1.2.54 -> 1.2.55 ``                                                                              |
| [`2d7b12e3`](https://github.com/NixOS/nixpkgs/commit/2d7b12e32f6a2267a040dc4728661f34977f88f4) | `` crosvm: 0-unstable-2025-07-24 -> 0-unstable-2025-08-01 ``                                              |
| [`047423e2`](https://github.com/NixOS/nixpkgs/commit/047423e2f99414d9fb701f64a714b150908d2071) | `` groovy: 4.0.27 -> 4.0.28 ``                                                                            |
| [`d4123ff1`](https://github.com/NixOS/nixpkgs/commit/d4123ff1437c6006a07f51e323694db032f24bd9) | `` opencode: 0.3.110 -> 0.3.112 ``                                                                        |
| [`0eb1203a`](https://github.com/NixOS/nixpkgs/commit/0eb1203a178bc98fdf4385b6d58dea9904b12fea) | `` opencode: fix missing `tree-sitter-htesyypn.node` module runtime error ``                              |
| [`8821112d`](https://github.com/NixOS/nixpkgs/commit/8821112d5628cac5ce0b55dad0752740fe88cad6) | `` dua: 2.30.1 -> 2.31.0 ``                                                                               |
| [`58a6f271`](https://github.com/NixOS/nixpkgs/commit/58a6f2718c852dda0a9c2216ab7d47bfdf004598) | `` postman: 11.50.5 -> 11.56.4 ``                                                                         |
| [`8a16039d`](https://github.com/NixOS/nixpkgs/commit/8a16039df8180dfb79141783f6648dc31a791784) | `` pineapple-pictures: 1.1.0 -> 1.1.1 ``                                                                  |
| [`1cbeff3b`](https://github.com/NixOS/nixpkgs/commit/1cbeff3b97285ed2b08332ff6aaa523e0d90c365) | `` libretro.stella: 0-unstable-2025-06-26 -> 0-unstable-2025-07-28 ``                                     |
| [`23de8e09`](https://github.com/NixOS/nixpkgs/commit/23de8e0965006fe225c5c840617ed64dc83928ce) | `` pnpm: 10.13.1 -> 10.14.0 ``                                                                            |
| [`314ad593`](https://github.com/NixOS/nixpkgs/commit/314ad593a1abd8d663e6d8ea078885e06437dd54) | `` dnsmonster: 1.0.0 -> 1.0.2 ``                                                                          |
| [`f1eee168`](https://github.com/NixOS/nixpkgs/commit/f1eee16801316d89df15350471e8410560b0c7f8) | `` polarity: latest-unstable-2025-07-15 -> latest-unstable-2025-07-30 ``                                  |
| [`00332eb9`](https://github.com/NixOS/nixpkgs/commit/00332eb9abcb4136af31daba7924730a42574de7) | `` plasma-plugin-blurredwallpaper: 3.3.1 -> 3.4.0 ``                                                      |
| [`ec5d6368`](https://github.com/NixOS/nixpkgs/commit/ec5d6368e35d6e0904f933a33d586eccca9055ee) | `` hyprcursor: 0.1.12 -> 0.1.13 ``                                                                        |
| [`e95c6286`](https://github.com/NixOS/nixpkgs/commit/e95c6286dffd93c33a6cff427307683a476df831) | `` kdePackages.krohnkite: 0.9.9.1 -> 0.9.9.2 ``                                                           |
| [`980fe63e`](https://github.com/NixOS/nixpkgs/commit/980fe63e5c9319440655b9b1c8159dca918f03bb) | `` igir: 4.1.1 -> 4.1.2 ``                                                                                |
| [`ce825d28`](https://github.com/NixOS/nixpkgs/commit/ce825d2854f93dce89ed2d19c8da32c13e21746e) | `` bento: 1.9.0 -> 1.9.1 ``                                                                               |
| [`430bc4f4`](https://github.com/NixOS/nixpkgs/commit/430bc4f40ba595179fb109fd64ee179e9ac38899) | `` pinta: 3.0.2 -> 3.0.3 ``                                                                               |
| [`a82ec34b`](https://github.com/NixOS/nixpkgs/commit/a82ec34b6462ffcd149193c065402253ff726a28) | `` bookstack: 25.05.2 -> 25.07 ``                                                                         |
| [`ebe1353e`](https://github.com/NixOS/nixpkgs/commit/ebe1353e36ccc1d0c4f79e6f16f38dd2d7f16a02) | `` simdutf: 7.3.3 -> 7.3.4 ``                                                                             |
| [`fb732681`](https://github.com/NixOS/nixpkgs/commit/fb732681fd8896550faaf5ccfe98855305773e8b) | `` olympus-unwrapped: 25.07.23.01 -> 25.07.26.04 ``                                                       |
| [`5d8ad491`](https://github.com/NixOS/nixpkgs/commit/5d8ad491d5e2171514e559124deff4db93aa0177) | ``  marytts: use Gradle 8 ``                                                                              |
| [`f1deb8b4`](https://github.com/NixOS/nixpkgs/commit/f1deb8b4ac88efed89ae5027bb5e8c57063268fa) | `` webkitgtk_6_0: 2.48.3 → 2.48.5 ``                                                                      |
| [`2e89b61a`](https://github.com/NixOS/nixpkgs/commit/2e89b61a4cb755ee224d22411258709bba1b0d4d) | `` zed-editor: 0.197.3 -> 0.197.5 ``                                                                      |
| [`a32fcdbf`](https://github.com/NixOS/nixpkgs/commit/a32fcdbf550b060da1be146f9383b37897755aec) | `` vscode-runner: 1.8.0 -> 1.8.1 ``                                                                       |
| [`5ca1168b`](https://github.com/NixOS/nixpkgs/commit/5ca1168b17ef2f14633d1c0db56fe35f0c6d2397) | `` home-assistant-custom-components.solis-sensor: 3.12.0 -> 3.13.0 (#430249) ``                           |