### PR TITLE
chore(flake/agenix): `531beac6` -> `6d194f75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750173260,
-        "narHash": "sha256-9P1FziAwl5+3edkfFcr5HeGtQUtrSdk/MksX39GieoA=",
+        "lastModified": 1754323089,
+        "narHash": "sha256-qpmyMBMyksBbyXkc9kSIkY2zIuPRixQZDorec216FfM=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "531beac616433bac6f9e2a19feb8e99a22a66baf",
+        "rev": "6d194f7522b9ed8aadb0856f1316f6d660ceb42a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                  |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`da00e1cb`](https://github.com/ryantm/agenix/commit/da00e1cb898fc8f089e91a37b75a37a3398cc7e2) | `` Add more description on why armor may be useful ``                    |
| [`d1eefa4d`](https://github.com/ryantm/agenix/commit/d1eefa4de1e66cdf2f340cefd0781b375694f987) | `` Add wait for file write before assertion ``                           |
| [`783bf0da`](https://github.com/ryantm/agenix/commit/783bf0daf6c3b13e927849039247f213dcf401f8) | `` Remove path config to use default secret path in test ``              |
| [`d48f920c`](https://github.com/ryantm/agenix/commit/d48f920cde5e9336bc307f3d514d2e220b836604) | `` Run nix fmt on secrets.nix ``                                         |
| [`01217f8b`](https://github.com/ryantm/agenix/commit/01217f8b39e52ac7a7c5de569b7e176a4b59bca1) | `` Update docs to include example of armored output ``                   |
| [`92af581e`](https://github.com/ryantm/agenix/commit/92af581e8b9bdcab0a213d7d17fb198d546538ca) | `` Add integration test for armored secret ``                            |
| [`8f606575`](https://github.com/ryantm/agenix/commit/8f6065756acce9c8eb0f7547d43a3728ac7e2871) | `` Add armored example ``                                                |
| [`e945c673`](https://github.com/ryantm/agenix/commit/e945c673b8b40ed8dec944a21c3936706647cc4a) | `` Try adding an option to output with armor ``                          |
| [`d80d1feb`](https://github.com/ryantm/agenix/commit/d80d1febd35ccf73455148a73bbc406d52dffc57) | `` fix: take userborn into consideration ``                              |
| [`caab0435`](https://github.com/ryantm/agenix/commit/caab0435e181becfd66c24e5ea5ae56ac837afbe) | `` feat: works with sysuser ``                                           |
| [`25b74caf`](https://github.com/ryantm/agenix/commit/25b74cafe80f5a1a23d732dc6ca1a8d10a9c91bc) | `` Escape literalExpression at all/properly ``                           |
| [`11b35f0a`](https://github.com/ryantm/agenix/commit/11b35f0a108fd1197b60637cf8b181a26460c846) | `` doc: clarify lack of support when using nondefault implementations `` |