### PR TITLE
chore(flake/agenix): `6d194f75` -> `856df6f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754323089,
-        "narHash": "sha256-qpmyMBMyksBbyXkc9kSIkY2zIuPRixQZDorec216FfM=",
+        "lastModified": 1754337839,
+        "narHash": "sha256-fEc2/4YsJwtnLU7HCFMRckb0u9UNnDZmwGhXT5U5NTw=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "6d194f7522b9ed8aadb0856f1316f6d660ceb42a",
+        "rev": "856df6f6922845abd4fd958ce21febc07ca2fa45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message            |
| ---------------------------------------------------------------------------------------------- | ------------------ |
| [`b30acb3d`](https://github.com/ryantm/agenix/commit/b30acb3d3ea2f431d06c82a7af421bd26dccb781) | `` bump nixpkgs `` |