### PR TITLE
chore(flake/home-manager): `c5d7e957` -> `a0b1afdb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754365350,
-        "narHash": "sha256-NLWIkn1qM0wxtZu/2NXRaujWJ4Y1PSZlc7h0y6pOzOQ=",
+        "lastModified": 1754421590,
+        "narHash": "sha256-TrlzGR5l/OltcTnBtihUxoKqv+JNEKWmUamDVWICtX0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5d7e957397ecb7d48b99c928611c6e780db1b56",
+        "rev": "a0b1afdb5efbf59f4b6e934d090cf8d150517890",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`a0b1afdb`](https://github.com/nix-community/home-manager/commit/a0b1afdb5efbf59f4b6e934d090cf8d150517890) | `` news: add new module entries ``                              |
| [`b7ee8dee`](https://github.com/nix-community/home-manager/commit/b7ee8deefca4f88be521077b2f6975618c7e0ab6) | `` programs/nix-search-tv: init ``                              |
| [`28caf471`](https://github.com/nix-community/home-manager/commit/28caf471a643f951e60b4b71d367b990ff6bbbf1) | `` Add self as maintainer ``                                    |
| [`74b4edc2`](https://github.com/nix-community/home-manager/commit/74b4edc2d28cff9b225ef12ebae9ce14948ba8d8) | `` fontconfig: add options for font rendering ``                |
| [`672381a3`](https://github.com/nix-community/home-manager/commit/672381a34e2bc7c872f6943d46293f0044c6cf87) | `` fontconfig: add maintainer bmrips ``                         |
| [`6d1fddb1`](https://github.com/nix-community/home-manager/commit/6d1fddb13b0663ffd7464c2d39379972502ef126) | `` gcc: init module (#7614) ``                                  |
| [`0cda19d4`](https://github.com/nix-community/home-manager/commit/0cda19d4209bb28db8fcaa54df4621eb97c36b5d) | `` grep: init module (#7613) ``                                 |
| [`36ad7d25`](https://github.com/nix-community/home-manager/commit/36ad7d25fbc60b820d3a06dbf4cf6200948f7fc4) | `` zsh: option to define autoloadable site-functions (#7611) `` |