### PR TITLE
chore(flake/agenix): `856df6f6` -> `9edb1787`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754337839,
-        "narHash": "sha256-fEc2/4YsJwtnLU7HCFMRckb0u9UNnDZmwGhXT5U5NTw=",
+        "lastModified": 1754433428,
+        "narHash": "sha256-NA/FT2hVhKDftbHSwVnoRTFhes62+7dxZbxj5Gxvghs=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "856df6f6922845abd4fd958ce21febc07ca2fa45",
+        "rev": "9edb1787864c4f59ae5074ad498b6272b3ec308d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------- |
| [`bc3b1316`](https://github.com/ryantm/agenix/commit/bc3b1316421a7edac0f515354a0ae52dbb94aebd) | `` hashed password file ``      |
| [`0814fdc0`](https://github.com/ryantm/agenix/commit/0814fdc0dea23e6c2656109e66d69e056f466358) | `` format nix with rfc style `` |