### PR TITLE
chore(flake/home-manager): `a0b1afdb` -> `c23168ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754421590,
-        "narHash": "sha256-TrlzGR5l/OltcTnBtihUxoKqv+JNEKWmUamDVWICtX0=",
+        "lastModified": 1754436133,
+        "narHash": "sha256-UpcWgMSNE8sz6oMWNqzQK8NzX+rz3pXrUQ66fWCqKGA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0b1afdb5efbf59f4b6e934d090cf8d150517890",
+        "rev": "c23168acf558fc24adc8240533c4fbf9591f183e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`c23168ac`](https://github.com/nix-community/home-manager/commit/c23168acf558fc24adc8240533c4fbf9591f183e) | `` vscode: specify full path `` |
| [`9b59dcee`](https://github.com/nix-community/home-manager/commit/9b59dcee0b0190de497bfc177687265b665c6c1d) | `` vscode: quote path ``        |