### PR TITLE
chore(flake/treefmt-nix): `58bd4da4` -> `861c262a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754061284,
-        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
+        "lastModified": 1754481157,
+        "narHash": "sha256-jw437PMQtx652SpATpvHnnIRrtvwMMz2pNwZKn8QeOg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
+        "rev": "861c262ae97d60a3e5be305349a56779763a98ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                    |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`962f3a9e`](https://github.com/numtide/treefmt-nix/commit/962f3a9e7665d592b3cb39924797377167472de1) | `` zizmor: add katexochen as maintainer `` |
| [`5fe6a8b9`](https://github.com/numtide/treefmt-nix/commit/5fe6a8b93f63d6586d7762468f3fddadf7985280) | `` zizmor: also lint github actions ``     |