### PR TITLE
chore(flake/treefmt-nix): `861c262a` -> `1298185c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754481157,
-        "narHash": "sha256-jw437PMQtx652SpATpvHnnIRrtvwMMz2pNwZKn8QeOg=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "861c262ae97d60a3e5be305349a56779763a98ab",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1298185c`](https://github.com/numtide/treefmt-nix/commit/1298185c05a56bff66383a20be0b41a307f52228) | `` feat: add dockerfmt formatter (#395) ``                     |
| [`bf87ce8f`](https://github.com/numtide/treefmt-nix/commit/bf87ce8fa33f7f94e3a9e4801d833791d1798511) | `` chore: update nixpkgs (#396) ``                             |
| [`7828e728`](https://github.com/numtide/treefmt-nix/commit/7828e728df154b000fdef00a6a41a2256b5adbd3) | `` feat(module): add self-describing meta attributes (#399) `` |