### PR TITLE
chore(flake/home-manager): `88913c98` -> `13461dec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754495836,
-        "narHash": "sha256-ON5VEr70cAUR0YOHuVgLlgq9HarBqfbWsxknlmHnM+o=",
+        "lastModified": 1754503522,
+        "narHash": "sha256-V0iiDcYvNeMOP2FyfgC4H8Esx+JodXEl80lD4hFD4SI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "88913c98fe674e10302bbdb71b4e173f527b69c2",
+        "rev": "13461dec40bf03d9196ff79d1abe48408268cc35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`13461dec`](https://github.com/nix-community/home-manager/commit/13461dec40bf03d9196ff79d1abe48408268cc35) | `` git-credential-keepassxc: fix eval ``             |
| [`2a299689`](https://github.com/nix-community/home-manager/commit/2a29968912815e825a8cae73e2535a94424a9d1b) | `` git-credential-keepassxc: init module ``          |
| [`53bf4fab`](https://github.com/nix-community/home-manager/commit/53bf4fab3013c9c200593a45c95469dba12c5315) | `` docs: add tests command documentation ``          |
| [`bf2dc7eb`](https://github.com/nix-community/home-manager/commit/bf2dc7ebd8e3fd10f24cfe0a8acfd3d2676666c7) | `` tests: add tests package to search / run tests `` |