### PR TITLE
chore(flake/home-manager): `13461dec` -> `62fdc8d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754503522,
-        "narHash": "sha256-V0iiDcYvNeMOP2FyfgC4H8Esx+JodXEl80lD4hFD4SI=",
+        "lastModified": 1754525296,
+        "narHash": "sha256-S6287NdqBGJ0rNbmZj+/8qv/4g7c6LreIzFarun9uQ0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "13461dec40bf03d9196ff79d1abe48408268cc35",
+        "rev": "62fdc8d41097313e681446b46681a4f89544e51c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`62fdc8d4`](https://github.com/nix-community/home-manager/commit/62fdc8d41097313e681446b46681a4f89544e51c) | `` keepassxc: add autostart option ``     |
| [`cb8cfa0e`](https://github.com/nix-community/home-manager/commit/cb8cfa0eb9a7f2ab2edaaf934f5e413b91800c31) | `` keepassxc: add maintainer bmrips ``    |
| [`13c5c2fb`](https://github.com/nix-community/home-manager/commit/13c5c2fb4cbed19ee40552a29a1b0fac8839a2dd) | `` Translate using Weblate (Ukrainian) `` |