### PR TITLE
chore(flake/nixos-hardware): `9368056b` -> `26ed7a0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1754316476,
-        "narHash": "sha256-Ry1gd1BQrNVJJfT11cpVP0FY8XFMx4DJV2IDp01CH9w=",
+        "lastModified": 1754564048,
+        "narHash": "sha256-dz303vGuzWjzOPOaYkS9xSW+B93PSAJxvBd6CambXVA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9368056b73efb46eb14fd4667b99e0f81b805f28",
+        "rev": "26ed7a0d4b8741fe1ef1ee6fa64453ca056ce113",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`df02f4f1`](https://github.com/NixOS/nixos-hardware/commit/df02f4f16a46d258967705383f408ce4a684f3e7) | `` framework/12-inch: Fix tabletmode on some kernels `` |
| [`659b41d5`](https://github.com/NixOS/nixos-hardware/commit/659b41d59cf586362a99adbfc9e0fb9de1acac3b) | `` framework/desktop: Add minimum kernel version ``     |
| [`91575528`](https://github.com/NixOS/nixos-hardware/commit/915755282509cdb7d707eb1b3c4e4ef5919bf4ef) | `` framework: Add Framework Desktop ``                  |