### PR TITLE
chore(flake/home-manager): `475d3579` -> `d8a475e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754527677,
-        "narHash": "sha256-qAzCtmKkMz40xFgP9KN+TCKjVieK4u04EWwl2KvVk0E=",
+        "lastModified": 1754575993,
+        "narHash": "sha256-0ut8TM76DeMnexgwNyMx2c5flhp4IPtqQ79XR0hpmY0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "475d35797d9537354d825260cf583114537affc2",
+        "rev": "d8a475e179888553b6863204a93295da6ee13eb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`d8a475e1`](https://github.com/nix-community/home-manager/commit/d8a475e179888553b6863204a93295da6ee13eb4) | `` tests: add mullvad-vpn to darwin scrublist ``     |
| [`a5506862`](https://github.com/nix-community/home-manager/commit/a5506862dc265a20b6790ae48e017ac2b3da6454) | `` mullvad-vpn: fix home.package -> home.packages `` |
| [`c7acf2b1`](https://github.com/nix-community/home-manager/commit/c7acf2b1bf1ec6c3a17b0b598e62e4190a1f1844) | `` mullvad-vpn: add module ``                        |
| [`6275d1fc`](https://github.com/nix-community/home-manager/commit/6275d1fc57d3c149691cddba0809ef040dfa7843) | `` accounts.email: add 'davmail' flavor ``           |
| [`5ab62b61`](https://github.com/nix-community/home-manager/commit/5ab62b61fb4d47f2740bfcef52d540f95335360e) | `` accounts.email: add authentication mechanism ``   |