### PR TITLE
chore(flake/home-manager): `d8a475e1` -> `5de16c70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754575993,
-        "narHash": "sha256-0ut8TM76DeMnexgwNyMx2c5flhp4IPtqQ79XR0hpmY0=",
+        "lastModified": 1754593726,
+        "narHash": "sha256-bo6aSfDS/GGfM/6LXCKLH/246fDSKjFnBsaRMNE+Wmc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d8a475e179888553b6863204a93295da6ee13eb4",
+        "rev": "5de16c704b0fc8f519b2c19ed3f683a9e68f3884",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5de16c70`](https://github.com/nix-community/home-manager/commit/5de16c704b0fc8f519b2c19ed3f683a9e68f3884) | `` getmail: remove redundant filter ``                 |
| [`dbfcd329`](https://github.com/nix-community/home-manager/commit/dbfcd3292d8af44eed8e41b222cbbf8685b950c6) | `` accounts.email: add option to disable an account `` |
| [`07b994ba`](https://github.com/nix-community/home-manager/commit/07b994baedd3647f57b3fa8c6b022bff56bddbc9) | `` tests: include integration tests in buildbot ``     |
| [`2b87f9a5`](https://github.com/nix-community/home-manager/commit/2b87f9a53a9fc3ba95caa262b6e887a9c933b8b5) | `` tests: refactor outputs ``                          |
| [`faa5b42e`](https://github.com/nix-community/home-manager/commit/faa5b42eca5b59ec9edcda3a5aa4b4524f4c2a12) | `` codex: support XDG Base Directory specification ``  |