### PR TITLE
chore(flake/lovesegfault-vim-config): `8dac2fa4` -> `a340e360`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754525558,
-        "narHash": "sha256-57cWuFHKZlB6gdTWTxrVGSkBxJewdPf6pNvKme0CFAo=",
+        "lastModified": 1754611667,
+        "narHash": "sha256-U7jFLnDWO2TK447To8OqByAcm+b5/RyutY4OZtM9Iyw=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8dac2fa45d68323905ddff08e6de18fafd3983be",
+        "rev": "a340e360dca40d062a97daae566ff808105184ef",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1754506651,
-        "narHash": "sha256-LcpDSjGtTVU0S+aWJPE3/8RONQV0q8dDuanfCj7mAW0=",
+        "lastModified": 1754572513,
+        "narHash": "sha256-BN2a2Lft9BwdDPBplaWe8kYW2wLaaVLDwcWwMJeBw3I=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "085ef66994f94226dd3d62921e1d48bf731b663a",
+        "rev": "1db179502524f21fe4e3175e3348202ed0ef253f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a340e360`](https://github.com/lovesegfault/vim-config/commit/a340e360dca40d062a97daae566ff808105184ef) | `` chore(flake/nixvim): 085ef669 -> 1db17950 `` |