### PR TITLE
chore(flake/stylix): `8410296a` -> `63bb34a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1754438321,
-        "narHash": "sha256-sRRV9FAZyCbq91IXc6gokBGNe0mF3DPbX/ceY8vUvw0=",
+        "lastModified": 1754597531,
+        "narHash": "sha256-OpC9/PBIuL2WEJUkcuD/wVxI8r+3o6f5RylSIefjHo4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8410296a30e62e06305020cb74d3247cfa45d9cc",
+        "rev": "63bb34a66ad7d1af2e95ee20dd675896b2074c32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`928e61f4`](https://github.com/nix-community/stylix/commit/928e61f4ed08162de3569cb03acc314caf74e35d) | `` ci: request-reviewers: add missing members permission `` |
| [`5b265fac`](https://github.com/nix-community/stylix/commit/5b265fac06646d5af36004144e3f8094a6a80c1d) | `` ci: request-reviewers: fix modules path ``               |