### PR TITLE
chore(flake/home-manager): `5de16c70` -> `cc2fa233`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754593726,
-        "narHash": "sha256-bo6aSfDS/GGfM/6LXCKLH/246fDSKjFnBsaRMNE+Wmc=",
+        "lastModified": 1754613544,
+        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5de16c704b0fc8f519b2c19ed3f683a9e68f3884",
+        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`cc2fa233`](https://github.com/nix-community/home-manager/commit/cc2fa2331aebf9661d22bb507d362b39852ac73f) | `` maintainers: add Kyure_A ``   |
| [`7a985e8f`](https://github.com/nix-community/home-manager/commit/7a985e8f5dca513a13c7060d0b7260cf1b63728a) | `` maintainers: add elanora96 `` |
| [`5f8bb123`](https://github.com/nix-community/home-manager/commit/5f8bb123b9b6d0a9e9bbc82a958d9013007f4955) | `` sheldon: init module ``       |