### PR TITLE
chore(flake/lovesegfault-vim-config): `2d712d16` -> `793bb6d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754698038,
-        "narHash": "sha256-0gftGB81wpm489m+t8M2r1/ei6Wo6KFDfXOAskTruog=",
+        "lastModified": 1754698352,
+        "narHash": "sha256-g8yYp8c+qX17tqtpMbiC7khgGQoN+/DBPvFwaU5Djik=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "2d712d162a8472a28e40e4defe46cc6ed2494ede",
+        "rev": "793bb6d326312c6e88fc77f96090f9d0fb45717e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`793bb6d3`](https://github.com/lovesegfault/vim-config/commit/793bb6d326312c6e88fc77f96090f9d0fb45717e) | `` chore(flake/nixpkgs): 5b09dc45 -> c2ae88e0 `` |