### PR TITLE
chore(flake/home-manager): `cc2fa233` -> `3ec1cd9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754613544,
-        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
+        "lastModified": 1754756528,
+        "narHash": "sha256-W1jYKMetZSOHP5m2Z5Wokdj/ct17swPHs+MiY2WT1HQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
+        "rev": "3ec1cd9a0703fbd55d865b7fd2b07d08374f0355",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3ec1cd9a`](https://github.com/nix-community/home-manager/commit/3ec1cd9a0703fbd55d865b7fd2b07d08374f0355) | `` launchd+targets/darwin: Escape XML in plists (#7356) `` |