### PR TITLE
chore(flake/tinted-schemes): `6486b6b0` -> `097d751b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -805,11 +805,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1754664340,
-        "narHash": "sha256-mpOzHOsADgh17tGekyuXxUbUEqXVv4An1vTDvx5pXOI=",
+        "lastModified": 1754779259,
+        "narHash": "sha256-8KG2lXGaXLUE0F/JVwLQe7kOVm21IDfNEo0gfga5P4M=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "6486b6b01cbc5421a9f4a64f726ef4ad97a5b09e",
+        "rev": "097d751b9e3c8b97ce158e7d141e5a292545b502",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                             |
| ------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`097d751b`](https://github.com/tinted-theming/schemes/commit/097d751b9e3c8b97ce158e7d141e5a292545b502) | `` Add missing MIT license (#70) `` |