### PR TITLE
chore(flake/nixpkgs): `c2ae88e0` -> `85dbfc7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754498491,
-        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`cb55cd08`](https://github.com/NixOS/nixpkgs/commit/cb55cd0848f11424ef6042551efa482fe5038873) | `` steam.buildRuntimeEnv: plumb privateTmp ``                                         |
| [`73eb63ff`](https://github.com/NixOS/nixpkgs/commit/73eb63ffc5bb9ac78f979e36b267981db65eb03b) | `` python3Packages.ping3: 4.0.8 -> 5.1.3 ``                                           |
| [`9e8df3a7`](https://github.com/NixOS/nixpkgs/commit/9e8df3a7a2bd746c2f2658ca8fafe6432cc06758) | `` postfix-tlspol: 1.8.12 -> 1.8.13 ``                                                |
| [`aab638f1`](https://github.com/NixOS/nixpkgs/commit/aab638f1745ae732e56155cef3a7dfa91c8c8a54) | `` python3Packages.yamlloader: 1.5.1 -> 1.5.2 ``                                      |
| [`07446506`](https://github.com/NixOS/nixpkgs/commit/074465065221dc33b3fa97b263e42c3e2222ae26) | `` errbot: fix build ``                                                               |
| [`8b39dd56`](https://github.com/NixOS/nixpkgs/commit/8b39dd562cbb1f72190f1f34ef5e82d783775ff5) | `` harper: 0.55.0 -> 0.56.0; add myself as maintainer (#431594) ``                    |
| [`d14020e6`](https://github.com/NixOS/nixpkgs/commit/d14020e6d30d6314ad6906970af32f77cd3ae27e) | `` nuclei-templates: 10.2.6 -> 10.2.7 ``                                              |
| [`4a9be786`](https://github.com/NixOS/nixpkgs/commit/4a9be786e85a71916dc2ebc7cf1c3f4a8eed3ed3) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.85.0 -> 1.88.0 ``           |
| [`f0c856e7`](https://github.com/NixOS/nixpkgs/commit/f0c856e7125c61a7198f639a8ccb3dc32911cbaa) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.16.1 -> 0.18.3 ``      |
| [`cb18829c`](https://github.com/NixOS/nixpkgs/commit/cb18829c07484f56b9b37b59d322c58005d40762) | `` vscode-extensions.coder.coder-remote: 1.9.2 -> 1.10.0 ``                           |
| [`71263d01`](https://github.com/NixOS/nixpkgs/commit/71263d016a93915a8ab3b1a1f7c20af9ece8630d) | `` python313Packages.canopen: refactor ``                                             |
| [`720bdf06`](https://github.com/NixOS/nixpkgs/commit/720bdf064426ffe4177dad1d8c676a2b29e8d1dd) | `` packer: 1.14.0 -> 1.14.1 ``                                                        |
| [`65742b9d`](https://github.com/NixOS/nixpkgs/commit/65742b9d5638798fdc59060801e2d8446dbadce0) | `` openbao: 2.3.1 -> 2.3.2 (#431937) ``                                               |
| [`f73ecaea`](https://github.com/NixOS/nixpkgs/commit/f73ecaea1b6fdb2839f6a0702f4f457af12967ce) | `` python313Packages.tencentcloud-sdk-python: 3.0.1439 -> 3.0.1441 ``                 |
| [`4a4d122b`](https://github.com/NixOS/nixpkgs/commit/4a4d122bb77040078aa983ecdff80c5f3bb42c9a) | `` conduwuit: drop ``                                                                 |
| [`b4e057c1`](https://github.com/NixOS/nixpkgs/commit/b4e057c1255448fdfd105f8ae433a316c4c2ad9f) | `` python313Packages.rigour: 0.8.2 -> 1.2.2 ``                                        |
| [`42e35b79`](https://github.com/NixOS/nixpkgs/commit/42e35b79728c2514ca8d1f1608af59876d72802c) | `` python313Packages.python-stdnum: 1.20 -> 2.1 ``                                    |
| [`743084df`](https://github.com/NixOS/nixpkgs/commit/743084df4502b3f5a98b1481e7a8ad1871e90480) | `` python313Packages.fingerprints: 1.2.3 -> 1.3.1 ``                                  |
| [`3cbc97be`](https://github.com/NixOS/nixpkgs/commit/3cbc97be2c5b4a9c15af527fd1dc6938af63fb13) | `` python313Packages.normality: 2.6.1 -> 3.0.1 ``                                     |
| [`791ee7f0`](https://github.com/NixOS/nixpkgs/commit/791ee7f0731909a8f9398ae4e77c216ca158b9df) | `` heroic: disable privateTmp ``                                                      |
| [`bf04c362`](https://github.com/NixOS/nixpkgs/commit/bf04c362e6b43b169949d976276b50cc8b9d4f44) | `` viceroy: 0.13.0 -> 0.14.0 ``                                                       |
| [`3af9029c`](https://github.com/NixOS/nixpkgs/commit/3af9029ca0de5a6146103e1d252a532c29820186) | `` scooter: 0.5.4 -> 0.6.0 ``                                                         |
| [`84afbb9b`](https://github.com/NixOS/nixpkgs/commit/84afbb9bf217ea0d7fb46d053a897742ee69b36f) | `` mubeng: 0.22.0 -> 0.23.0 ``                                                        |
| [`3e0278ab`](https://github.com/NixOS/nixpkgs/commit/3e0278ab7cf559573b6f2fa8b5d67bdc9358f39d) | `` terraform-providers.checkly: 1.11.1 -> 1.12.0 ``                                   |
| [`b98ad280`](https://github.com/NixOS/nixpkgs/commit/b98ad28008b8602f12a261742e3b124a55294cfd) | `` python313Packages.functions-framework: 3.8.3 -> 3.9.2 ``                           |
| [`e0fd0de5`](https://github.com/NixOS/nixpkgs/commit/e0fd0de587aa7a19d007694d0f2f753f05ac5c81) | `` python313Packages.uvicorn-worker: init at 0.3.0 ``                                 |
| [`a3b68070`](https://github.com/NixOS/nixpkgs/commit/a3b6807072b871ae45c9ea492d571bcf892d5360) | `` optnix: init at 0.2.0 ``                                                           |
| [`0a1284db`](https://github.com/NixOS/nixpkgs/commit/0a1284dba699a615315997d15b49e687eac3492f) | `` luaPackages.plenary-nvim: bump to latest commit ``                                 |
| [`0a34020c`](https://github.com/NixOS/nixpkgs/commit/0a34020c16c69419de8def76a61b22f9607b3291) | `` linuxKernel.kernels.linux_lqx: 6.15.8 -> 6.15.9 ``                                 |
| [`4c95f06f`](https://github.com/NixOS/nixpkgs/commit/4c95f06f13ec3774ab6fc26c54ba2a24676ecda9) | `` python3Packages.langchain-aws: 0.2.29 -> 0.2.30 ``                                 |
| [`e9c71d97`](https://github.com/NixOS/nixpkgs/commit/e9c71d971f7ec6379284ac58b3ea236996fb7b39) | `` nixos/filesystem: remove mount-pstore ``                                           |
| [`4ce19d45`](https://github.com/NixOS/nixpkgs/commit/4ce19d45cc8fe78acffcda39a850cac2dcdf45b4) | `` emmylua-doc-cli: 0.10.0 -> 0.11.0 ``                                               |
| [`91e706e1`](https://github.com/NixOS/nixpkgs/commit/91e706e1014afed0f033dc363e348d3c41e90b96) | `` nix-update: 1.12.0 -> 1.12.1 ``                                                    |
| [`99dc30c0`](https://github.com/NixOS/nixpkgs/commit/99dc30c03e58b43b0f90dd7b24af6022e7562630) | `` openmoji-color,openmoji-black: 15.1.0 -> 16.0.0 (#431983) ``                       |
| [`c5d1a4b8`](https://github.com/NixOS/nixpkgs/commit/c5d1a4b8073d1ea1670257f60ed6905ef1eaa555) | `` scalingo: 1.36.0 -> 1.37.0 ``                                                      |
| [`f08ea144`](https://github.com/NixOS/nixpkgs/commit/f08ea14467a1029400a4a5663b73a56f1701bea8) | `` tempo: 2.8.1 -> 2.8.2 ``                                                           |
| [`eaa2525a`](https://github.com/NixOS/nixpkgs/commit/eaa2525ab54071e431fed6cdd3f73997777bac8a) | `` ghidra-extensions.wasm: 2.3.1 -> 2.3.2 ``                                          |
| [`6238ed3a`](https://github.com/NixOS/nixpkgs/commit/6238ed3a0f8e3fcca4d3b8ba52afaae14c99cfa9) | `` python3Packages.safetensors: 0.6.1 -> 0.6.2 ``                                     |
| [`25d9628e`](https://github.com/NixOS/nixpkgs/commit/25d9628e87e07012b2f25801fed1ac4446a95691) | `` doctl: 1.135.0 -> 1.137.0 ``                                                       |
| [`25f54a02`](https://github.com/NixOS/nixpkgs/commit/25f54a029a1e28d564d9769be7769cb2ea8c268f) | `` openvas-scanner: 23.22.1 -> 23.23.0 ``                                             |
| [`cbb7f7a4`](https://github.com/NixOS/nixpkgs/commit/cbb7f7a46a1c5ec4e7c0cb9fd1ee58fb2a6a4658) | `` ollama: mark as broken on darwin ``                                                |
| [`67216908`](https://github.com/NixOS/nixpkgs/commit/67216908b352d4f2f1adf6211fbc0dca07a2e53c) | `` zellij: 0.43.0 -> 0.43.1 ``                                                        |
| [`f1da5ab5`](https://github.com/NixOS/nixpkgs/commit/f1da5ab5da393c14356d44f4e5d3f2e3d4ae9dd0) | `` vimPlugins: update on 2025-08-08 ``                                                |
| [`c214b7fc`](https://github.com/NixOS/nixpkgs/commit/c214b7fc2c061186bf051c479735f188e8daed53) | `` vimPlugins(augment.vim): change main branch to prerelease ``                       |
| [`d195495b`](https://github.com/NixOS/nixpkgs/commit/d195495b9944b08cbfa3903a6492bf6de7ed1a1a) | `` codex: 0.14.0 -> 0.19.0 ``                                                         |
| [`6d57bd2a`](https://github.com/NixOS/nixpkgs/commit/6d57bd2ab5782cb962d4501c6061e0b3b6dc8772) | `` release-notes: move command-not-found note from nixpkgs notes to nixos ``          |
| [`01c15b87`](https://github.com/NixOS/nixpkgs/commit/01c15b8752d569f11489278cf3abc734fbce3d2e) | `` nixos/tests/kanidm: restore eval when calling `nixosTests.kanidm` directly ``      |
| [`ce6168bd`](https://github.com/NixOS/nixpkgs/commit/ce6168bd6d81d156bd6f86080cd7d7a0ee06f15a) | `` kanidm: use `finalAttrs` everywhere ``                                             |
| [`7f4761ea`](https://github.com/NixOS/nixpkgs/commit/7f4761ea997e24a2d9926e770087c39b9a27d23f) | `` agate: 3.3.17 -> 3.3.18 ``                                                         |
| [`1273efa6`](https://github.com/NixOS/nixpkgs/commit/1273efa67f5ea516eebc3332e538437d2f00b25c) | `` linux-firmware: 20250708 -> 20250808 ``                                            |
| [`bfa19339`](https://github.com/NixOS/nixpkgs/commit/bfa19339391ccb59972b8874b13644253a145c66) | `` nh: Delay run on boot so clean service doesnt make the boot process wait for it `` |
| [`c3716865`](https://github.com/NixOS/nixpkgs/commit/c37168656bba03f25ddd1294a3557f7e15bc109b) | `` vscode: add FHS dependencies for extensions with embedded headless browsers ``     |
| [`98646505`](https://github.com/NixOS/nixpkgs/commit/986465051dc183074bef38e089646f31301ca310) | `` python3Packages.pymodbus: 3.10.0 -> 3.11.0 ``                                      |
| [`a459d6e2`](https://github.com/NixOS/nixpkgs/commit/a459d6e261ec336365eec02a8791d260db89f2dd) | `` phpPackages.phan: 5.5.0 -> 5.5.1 ``                                                |
| [`16dd98c1`](https://github.com/NixOS/nixpkgs/commit/16dd98c1367b53dcc73762ba734d180d3a08ac0c) | `` python3Packages.debugpy: 1.8.15 -> 1.8.16 ``                                       |
| [`a282257e`](https://github.com/NixOS/nixpkgs/commit/a282257e0a51912b53837bef4b36156dc13cc12a) | `` release.nix: don't use special treatment for more package sets ``                  |
| [`4d0a5b9e`](https://github.com/NixOS/nixpkgs/commit/4d0a5b9e86974787ffa157f3b0b86516190b1de5) | `` terraform-providers.sakuracloud: 2.28.1 -> 2.29.0 ``                               |
| [`9c67dea7`](https://github.com/NixOS/nixpkgs/commit/9c67dea744fba216a8fb28c907d2aac862dad484) | `` trufflehog: 3.90.2 -> 3.90.3 ``                                                    |
| [`ea8555c0`](https://github.com/NixOS/nixpkgs/commit/ea8555c087a60e30e6b536d6d25cdf070d16a495) | `` python313Packages.ollama: 0.5.1 -> 0.5.3 ``                                        |
| [`2304954b`](https://github.com/NixOS/nixpkgs/commit/2304954b8c52c468063277a3410e6ee77fd5a694) | `` dunst: 1.12.2 -> 1.13.0 ``                                                         |
| [`70116a0e`](https://github.com/NixOS/nixpkgs/commit/70116a0ee27dd0d06a2f10109a08cca193314d30) | `` burpsuite: 2025.7.1 -> 2025.8 ``                                                   |
| [`651b7e9d`](https://github.com/NixOS/nixpkgs/commit/651b7e9d04b4d66c78976d015204ec353968a1cb) | `` cnspec: 11.66.0 -> 11.66.1 ``                                                      |
| [`c55a801c`](https://github.com/NixOS/nixpkgs/commit/c55a801cfe025a57bd120fff8f40f97689fde5d8) | `` nixos/netbird: clarify routing features & brand adjustments ``                     |
| [`4113779d`](https://github.com/NixOS/nixpkgs/commit/4113779dd9e60d27cb5b5f2488124a886b6c8a0e) | `` check-meta: Fix typos in comment and error message ``                              |
| [`d20b9913`](https://github.com/NixOS/nixpkgs/commit/d20b9913fc0837eb320c018f9e12658f2c7f95b7) | `` python3Packages.pynvml: relax nvidia-ml-py dependency ``                           |
| [`cc76d175`](https://github.com/NixOS/nixpkgs/commit/cc76d175ad2b381927abba331532df85ee6f169d) | `` waybar: 0.13.0 -> 0.14.0 ``                                                        |
| [`662c3de6`](https://github.com/NixOS/nixpkgs/commit/662c3de678a196111e8f7e8945867f971dfbb3aa) | `` python3Packages.treescope: 0.1.9 -> 0.1.10 ``                                      |
| [`adaab0a3`](https://github.com/NixOS/nixpkgs/commit/adaab0a3f9a3e2fe71e8b47c44128b9b43786459) | `` postgresqlPackages.plr: 8.4.7 -> 8.4.8 ``                                          |
| [`3951f3b1`](https://github.com/NixOS/nixpkgs/commit/3951f3b158246f22e924b1b0f6f62dbba000e247) | `` postgresqlPackages.pg_squeeze: 1.7.0 -> 1.9.0 ``                                   |
| [`ca232376`](https://github.com/NixOS/nixpkgs/commit/ca232376ae70986f436dbab248300a8fb10d74f2) | `` psqlodbc: fix update script ``                                                     |
| [`8b183cf9`](https://github.com/NixOS/nixpkgs/commit/8b183cf9aa1c877c35d5cda4fc6c7ce4abb66d6b) | `` psqlodbc: refactor ``                                                              |
| [`67a79abc`](https://github.com/NixOS/nixpkgs/commit/67a79abc4552e5f608c2615db21fbff71a34cd57) | `` postgresqlPackages.wal2json: fix update script and version ``                      |
| [`65049d45`](https://github.com/NixOS/nixpkgs/commit/65049d4556bc710b4a439f42f1b7bca5152cece5) | `` postgresqlPackages.plr: fix update script and version ``                           |
| [`16ba3f82`](https://github.com/NixOS/nixpkgs/commit/16ba3f829441ce3dbd74ccfd95c7068be02fdea8) | `` breakpad: 2023.06.01 -> 2024.02.16 ``                                              |
| [`3225149f`](https://github.com/NixOS/nixpkgs/commit/3225149f15fece1486a6cfc9b4e17fa54b46fa5a) | `` openmvs: remove unused breakpad input ``                                           |
| [`a5230b17`](https://github.com/NixOS/nixpkgs/commit/a5230b17933bf4131498cfce8c9af888285fa339) | `` opencode: use `_api.json` produced by `models-dev` instead of `api.json` ``        |
| [`091bb526`](https://github.com/NixOS/nixpkgs/commit/091bb526029ce15c7e8efbfe838e2ba942a54a23) | `` models-dev: 0-unstable-2025-08-01 -> 0-unstable-2025-08-07 ``                      |
| [`2ac52df0`](https://github.com/NixOS/nixpkgs/commit/2ac52df051a07819a6a089ead6e57e47c0df4604) | `` python3Packages.pyexploitdb: 0.2.91 -> 0.2.92 ``                                   |
| [`ddf16c9c`](https://github.com/NixOS/nixpkgs/commit/ddf16c9c794febbb9d3987aae9d35da81b5c9903) | `` postgresqlPackages.pg_squeeze: fix update script and version ``                    |
| [`c2e897a7`](https://github.com/NixOS/nixpkgs/commit/c2e897a78006f216f178d1b68de67966156eca27) | `` opencode 0.3.132 -> 0.4.1 ``                                                       |
| [`c6059ad1`](https://github.com/NixOS/nixpkgs/commit/c6059ad1a0620c3df8833af82343c15194ccf9ae) | `` dnf5: 5.2.15.0 -> 5.2.16.0 ``                                                      |
| [`98713302`](https://github.com/NixOS/nixpkgs/commit/98713302667073df004f3cabe7e73ebebc193b9f) | `` python313Packages.boto3-stubs: 1.40.4 -> 1.40.5 ``                                 |
| [`aff64cfb`](https://github.com/NixOS/nixpkgs/commit/aff64cfbc2b445dcddf8be6325881fa8c4109db0) | `` home-assistant: update component packages ``                                       |
| [`fe58bf9e`](https://github.com/NixOS/nixpkgs/commit/fe58bf9ec427d9017daee3d9dc0ce3e1466cac0e) | `` python312Packages.mypy-boto3-guardduty: 1.40.0 -> 1.40.5 ``                        |
| [`983b8735`](https://github.com/NixOS/nixpkgs/commit/983b8735519de239d7dcab222d5e099d66373e92) | `` python312Packages.mypy-boto3-glue: 1.40.0 -> 1.40.5 ``                             |
| [`bf8fce02`](https://github.com/NixOS/nixpkgs/commit/bf8fce02ae3b244a16781441855aa6c3351f2b7f) | `` python3Packages.kaiterra-async-client: init at 1.1.0 ``                            |
| [`b115e623`](https://github.com/NixOS/nixpkgs/commit/b115e623f71f8934321589546a1ce1daffebf209) | `` python312Packages.mypy-boto3-codebuild: 1.40.0 -> 1.40.5 ``                        |
| [`80c7e69a`](https://github.com/NixOS/nixpkgs/commit/80c7e69af6a389e84e352dd698b0f897079daf55) | `` python312Packages.mypy-boto3-cloudfront: 1.40.0 -> 1.40.5 ``                       |
| [`a63e39f0`](https://github.com/NixOS/nixpkgs/commit/a63e39f0afdd17a4d48dfd3bf30a431562b0a9f4) | `` python312Packages.mypy-boto3-batch: 1.40.0 -> 1.40.5 ``                            |
| [`6c52c38c`](https://github.com/NixOS/nixpkgs/commit/6c52c38ca9bfd9091c33135ccabde07c8e7d6880) | `` python313Packages.pymodbus: 3.10.0 -> 3.11.0 ``                                    |
| [`6f9aedc4`](https://github.com/NixOS/nixpkgs/commit/6f9aedc4c5e69884842117c3a9731eff73c55003) | `` python313Packages.huum: refactor ``                                                |
| [`b87c562f`](https://github.com/NixOS/nixpkgs/commit/b87c562f87e988539f136b63286acf25f46caa33) | `` python313Packages.opower: refactor ``                                              |