### PR TITLE
chore(flake/nix-index-database): `6784a9ce` -> `b65f8d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -514,11 +514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754798233,
-        "narHash": "sha256-90xBodgTkYAee4jO6qx5Lwa7yYVT9gc+w7qiAizx+DE=",
+        "lastModified": 1754800038,
+        "narHash": "sha256-UbLO8/0pVBXLJuyRizYOJigtzQAj8Z2bTnbKSec/wN0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6784a9ce7688876ff7f1c93b1af1de47da48a16f",
+        "rev": "b65f8d80656f9fcbd1fecc4b7f0730f468333142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b65f8d80`](https://github.com/nix-community/nix-index-database/commit/b65f8d80656f9fcbd1fecc4b7f0730f468333142) | `` update generated.nix to release 2025-08-10-035719 `` |