### PR TITLE
chore(flake/home-manager): `58320509` -> `91586008`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754840484,
-        "narHash": "sha256-FM9pGZhje4ZPkz5j57KSXLFqTxobG5hojLzutDagI+k=",
+        "lastModified": 1754842705,
+        "narHash": "sha256-2vvncPLsBWV6dRM5LfGHMGYZ+vzqRDqSPBzxPAS0R/A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "58320509c5b83c93012b328c9c9a943d8d90f932",
+        "rev": "91586008a23c01cc32894ee187dca8c0a7bd20a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`91586008`](https://github.com/nix-community/home-manager/commit/91586008a23c01cc32894ee187dca8c0a7bd20a4) | `` firefoxpwa: fix ULID length typo (#7653) ``                |
| [`e7969e2f`](https://github.com/nix-community/home-manager/commit/e7969e2ffa261e6c0587183f67bc906f482ba115) | `` PULL_REQUEST_TEMPLATE: format ``                           |
| [`85ed337f`](https://github.com/nix-community/home-manager/commit/85ed337f360f5039a83f6dbda87564fa227df0b4) | `` PULL_REQUEST_TEMPLATE: update flake test runner command `` |
| [`715ecee4`](https://github.com/nix-community/home-manager/commit/715ecee4511d3d8da741335b1cecc29e2c4bd3cb) | `` jrnl: add module (#7652) ``                                |