### PR TITLE
chore(flake/lovesegfault-vim-config): `793bb6d3` -> `32291f20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754698352,
-        "narHash": "sha256-g8yYp8c+qX17tqtpMbiC7khgGQoN+/DBPvFwaU5Djik=",
+        "lastModified": 1754871066,
+        "narHash": "sha256-mkkY2TDuimOkyfg3U8JqLGBo40jyK6MXbEHl6zon51Y=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "793bb6d326312c6e88fc77f96090f9d0fb45717e",
+        "rev": "32291f2065d51ee5e2db105efdf92a7a56368bc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`32291f20`](https://github.com/lovesegfault/vim-config/commit/32291f2065d51ee5e2db105efdf92a7a56368bc8) | `` chore(flake/nixpkgs): c2ae88e0 -> 85dbfc7a ``     |
| [`39e835fb`](https://github.com/lovesegfault/vim-config/commit/39e835fba66b7b4a5f329d7f95ffffa0371d9311) | `` chore(flake/treefmt-nix): 1298185c -> 7d81f6fb `` |