### PR TITLE
chore(flake/home-manager): `0d492b89` -> `67393957`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754886238,
-        "narHash": "sha256-LTQomWOwG70lZR+78ZYSZ9sYELWNq3HJ7/tdHzfif/s=",
+        "lastModified": 1754924470,
+        "narHash": "sha256-asI/or9AcUMydwzodCgpHGytnMSNUlciw3uaycpXm4E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d492b89d1993579e63b9dbdaed17fd7824834da",
+        "rev": "67393957c27b4e4c6c48a60108a201413ced7800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`67393957`](https://github.com/nix-community/home-manager/commit/67393957c27b4e4c6c48a60108a201413ced7800) | `` less: configure LESS options ``                              |
| [`dfcea057`](https://github.com/nix-community/home-manager/commit/dfcea0573da618e24ff74f95fbf21e72ba72856b) | `` less: rename `keys` to `config` ``                           |
| [`9a132f29`](https://github.com/nix-community/home-manager/commit/9a132f297117f802fdb31ae6271e888d40fc83fe) | `` less: generate `lesskey` only when non-empty ``              |
| [`18ea6d7a`](https://github.com/nix-community/home-manager/commit/18ea6d7a8f8e6b5378db269ec6cdbb38f22d0356) | `` pizauth: init module ``                                      |
| [`0b7147a5`](https://github.com/nix-community/home-manager/commit/0b7147a547cadfc4b13f5ef0c33164bf00795312) | `` maintainers: add Swarsel ``                                  |
| [`9248ba7c`](https://github.com/nix-community/home-manager/commit/9248ba7ce10d06ca46a17ff891892a2b7ac8cfce) | `` news: add missing news entries for new modules ``            |
| [`627a3932`](https://github.com/nix-community/home-manager/commit/627a3932b9cfccd276e028c128f7fbbeef285804) | `` swww: add extraArgs for swww-daemon ``                       |
| [`e11d6c32`](https://github.com/nix-community/home-manager/commit/e11d6c321f3f848178a3fb2a8984aa5fe08c0996) | `` PULL_REQUEST_TEMPLATE: fix commit message link formatting `` |
| [`b4a07cd1`](https://github.com/nix-community/home-manager/commit/b4a07cd14b6ad8bd26f4753107dde2fd71af4803) | `` docs/tests: expand test documentation for contributors ``    |
| [`eb243d27`](https://github.com/nix-community/home-manager/commit/eb243d27f8eb51896b1df601d95817ec9c50510c) | `` PULL_REQUEST_TEMPLATE: add some additional check ``          |
| [`fc68e110`](https://github.com/nix-community/home-manager/commit/fc68e1100ae6b2d46e3d423945121a41901eca9b) | `` maintainers: jkarlson -> ethorsoe ``                         |
| [`600e3f67`](https://github.com/nix-community/home-manager/commit/600e3f6712735452a39451e1f8db86bfc631362f) | `` yambar: remove deleted maintainer ``                         |
| [`2aceb6a8`](https://github.com/nix-community/home-manager/commit/2aceb6a8cc23fc657602137be42bbc280074cd79) | `` maintainers: update all-maintainers.nix (#7657) ``           |