### PR TITLE
chore(flake/disko): `545aba02` -> `8246829f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753140376,
-        "narHash": "sha256-7lrVrE0jSvZHrxEzvnfHFE/Wkk9DDqb+mYCodI5uuB8=",
+        "lastModified": 1754971456,
+        "narHash": "sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "545aba02960caa78a31bd9a8709a0ad4b6320a5c",
+        "rev": "8246829f2e675a46919718f9a64b71afe3bfb22d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                              |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`8246829f`](https://github.com/nix-community/disko/commit/8246829f2e675a46919718f9a64b71afe3bfb22d) | `` build(deps): bump actions/checkout from 4 to 5 `` |