### PR TITLE
chore(flake/home-manager): `d19f3213` -> `27a26be5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754950654,
-        "narHash": "sha256-30f9MF+zIKLodQRuSLyY4OSDZSOy5O+/FslgPt/prbc=",
+        "lastModified": 1754974548,
+        "narHash": "sha256-XMjUjKD/QRPcqUnmSDczSYdw46SilnG0+wkho654DFM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d19f3213e51469321835a9188adfa20391ff9371",
+        "rev": "27a26be51ff0162a8f67660239f9407dba68d7c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`27a26be5`](https://github.com/nix-community/home-manager/commit/27a26be51ff0162a8f67660239f9407dba68d7c5) | `` gemini-cli: init module `` |
| [`461706d2`](https://github.com/nix-community/home-manager/commit/461706d28bd9e2ef2555756a17edc93e79612047) | `` maintainers: add rrvsh ``  |