### PR TITLE
chore(flake/home-manager): `4b6dd06c` -> `279ca5ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755107032,
-        "narHash": "sha256-ckb/RX9rJ/FslBA3K4hYAXgVW/7JdQ50Z+28XZT96zg=",
+        "lastModified": 1755121891,
+        "narHash": "sha256-UtYkukiGnPRJ5rpd4W/wFVrLMh8fqtNkqHTPgHEtrqU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4b6dd06c6a92308c06da5e0e55f2c505237725c9",
+        "rev": "279ca5addcdcfa31ac852b3ecb39fc372684f426",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`279ca5ad`](https://github.com/nix-community/home-manager/commit/279ca5addcdcfa31ac852b3ecb39fc372684f426) | `` PULL_REQUEST_TEMPLATE: fix commit message link formatting (#7673) `` |
| [`d9a57c59`](https://github.com/nix-community/home-manager/commit/d9a57c597c31f4c7523a395fe2a7ae4910e193e2) | `` davmail: enable access to the display server (#7671) ``              |