### PR TITLE
chore(flake/darwin): `e04a3882` -> `7220b01d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751313918,
-        "narHash": "sha256-HsJM3XLa43WpG+665aGEh8iS8AfEwOIQWk3Mke3e7nk=",
+        "lastModified": 1755275010,
+        "narHash": "sha256-lEApCoWUEWh0Ifc3k1JdVjpMtFFXeL2gG1qvBnoRc2I=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e04a388232d9a6ba56967ce5b53a8a6f713cdfcf",
+        "rev": "7220b01d679e93ede8d7b25d6f392855b81dd475",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                 |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------- |
| [`585cd058`](https://github.com/nix-darwin/nix-darwin/commit/585cd058e88f7f280ced3a9e3cb868f1b4f198f5) | `` ci: bump macOS version (13 -> 14) `` |
| [`6f245953`](https://github.com/nix-darwin/nix-darwin/commit/6f24595362421412d2cf18155f10059db37497ae) | `` fish: add shellAbbrs config ``       |