### PR TITLE
chore(flake/home-manager): `2a749f47` -> `8b4ac149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755313937,
-        "narHash": "sha256-pQb7bNcolxYGRiylUCrTddiF+qW2wsUiM9+eRIDUrVU=",
+        "lastModified": 1755397986,
+        "narHash": "sha256-qwrF5laj6eE3Zht0wKYTmH6QzL7bdOyE2f6jd3WCO8g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a749f4790a14f7168be67cdf6e548ef1c944e10",
+        "rev": "8b4ac149687e8520187a66f05e9d4eafebf96522",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`8b4ac149`](https://github.com/nix-community/home-manager/commit/8b4ac149687e8520187a66f05e9d4eafebf96522) | `` claude-code: init module (#7685) ``    |
| [`56731200`](https://github.com/nix-community/home-manager/commit/567312006a06ccb398816152eb1a5f6b65f8a8b2) | `` tmux: make package nullable (#7682) `` |