### PR TITLE
chore(flake/disko): `8246829f` -> `f64ab152`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754971456,
-        "narHash": "sha256-p04ZnIBGzerSyiY2dNGmookCldhldWAu03y0s3P8CB0=",
+        "lastModified": 1755499523,
+        "narHash": "sha256-Bh+S72huB2jFEPsOGlFXKFn7/VaV864IqxOcqaZZue0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8246829f2e675a46919718f9a64b71afe3bfb22d",
+        "rev": "f64ab1525b34d5d9202f5801db36f364075abde1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                             |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`f64ab152`](https://github.com/nix-community/disko/commit/f64ab1525b34d5d9202f5801db36f364075abde1) | `` docs: add recursive method for fetching flake input out paths `` |