### PR TITLE
chore(flake/home-manager): `f8af2cbe` -> `bf450a08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755491080,
-        "narHash": "sha256-ib1Xi13NEalrFqQAHceRsb+6aIPANFuQq80SS/bY10M=",
+        "lastModified": 1755538029,
+        "narHash": "sha256-XVsragfuN8A/tMiPToejH7RofH15toeIGhlXraX+yBo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8af2cbe386f9b96dd9efa57ab15a09377f38f4d",
+        "rev": "bf450a0844e80e6aa22652d3f3728f20cd974527",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`bf450a08`](https://github.com/nix-community/home-manager/commit/bf450a0844e80e6aa22652d3f3728f20cd974527) | `` maintainers: update all-maintainers.nix (#7693) `` |
| [`0a06e46a`](https://github.com/nix-community/home-manager/commit/0a06e46a3b888123780eecd1cb81757b431dd7c4) | `` anyrun: Added `margin` config option (#7687) ``    |