### PR TITLE
chore(flake/stylix): `82242e0f` -> `9810b32b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1755378131,
-        "narHash": "sha256-0GKZEzTUcaoama56xaagKnMk5hqMbTUfGF4KfzLwje4=",
+        "lastModified": 1755546184,
+        "narHash": "sha256-KxRj/8SydDk3gzamS0VEewo5pu8JAYhSZ5GPcImPGNQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "82242e0f9b1d91b6f170807a6ec622cfdb816eac",
+        "rev": "9810b32b9b7520e3b37358ff8e793fb5034c3299",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`9810b32b`](https://github.com/nix-community/stylix/commit/9810b32b9b7520e3b37358ff8e793fb5034c3299) | `` ci: request-reviewers: use generated token (#1848) `` |
| [`de0ff3cc`](https://github.com/nix-community/stylix/commit/de0ff3cc8fc407e7c749b097aae61181e181d9ee) | `` qt: add fonts (#983) ``                               |
| [`05ac1c70`](https://github.com/nix-community/stylix/commit/05ac1c707498caa77881e5cd6de041584073cf09) | `` gdm: apply icon theme (#970) ``                       |