### PR TITLE
chore(flake/home-manager): `bf450a08` -> `c613ac14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755538029,
-        "narHash": "sha256-XVsragfuN8A/tMiPToejH7RofH15toeIGhlXraX+yBo=",
+        "lastModified": 1755569926,
+        "narHash": "sha256-s7D28zPHlFWVZ7dDxm0L1o5+t423rMJUfgCMGUeyYSk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf450a0844e80e6aa22652d3f3728f20cd974527",
+        "rev": "c613ac14f5600033bf84ae75c315d5ce24a0229b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c613ac14`](https://github.com/nix-community/home-manager/commit/c613ac14f5600033bf84ae75c315d5ce24a0229b) | `` nh: allow absolute flake paths ``                   |
| [`e293a1a1`](https://github.com/nix-community/home-manager/commit/e293a1a12f448a6d92309daebd7cbda03e0f75c4) | `` aerospace: add test ``                              |
| [`bbfbda4a`](https://github.com/nix-community/home-manager/commit/bbfbda4ad8ee3e94cfab012249493a8375382dd0) | `` aerospace: allow colemak on key-mapping ``          |
| [`0d1e116e`](https://github.com/nix-community/home-manager/commit/0d1e116e4f2d9d22ff57e412a57b37b8edca3710) | `` ssh-tpm-agent: match the upstream systemd units ``  |
| [`3a5136d8`](https://github.com/nix-community/home-manager/commit/3a5136d8ddd2e264389868232abacd4c1ef846ea) | `` ssh-tpm-agent: on NixOS, check TPM accessibility `` |
| [`f9ea660b`](https://github.com/nix-community/home-manager/commit/f9ea660b241e95577ff3ccc58351e6a84aa0c017) | `` ssh-tpm-agent: fix ssh-agent proxy ``               |
| [`94a238f9`](https://github.com/nix-community/home-manager/commit/94a238f9c1b84dbb299b938bee2436ce9633c3ed) | `` ssh-agent: add option for the socket name ``        |
| [`af03309c`](https://github.com/nix-community/home-manager/commit/af03309c122ac714da6ec497f74dbd61d875f3f2) | `` ssh-tpm-agent: add maintainer bmrips ``             |
| [`ec369a58`](https://github.com/nix-community/home-manager/commit/ec369a58f9af13626cde7842b62e22e4dc36fc09) | `` ssh-agent: add maintainer bmrips ``                 |