### PR TITLE
chore(flake/home-manager): `c613ac14` -> `8af2e064`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755569926,
-        "narHash": "sha256-s7D28zPHlFWVZ7dDxm0L1o5+t423rMJUfgCMGUeyYSk=",
+        "lastModified": 1755601933,
+        "narHash": "sha256-iXZeeYyfy8NdpvH/OOW9V3C2AfsXE+fzDHfrIOHBPF0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c613ac14f5600033bf84ae75c315d5ce24a0229b",
+        "rev": "8af2e064f93234ee79df8b9858eeefbf84394488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`8af2e064`](https://github.com/nix-community/home-manager/commit/8af2e064f93234ee79df8b9858eeefbf84394488) | `` satty: add satty to program modules `` |
| [`589efcf9`](https://github.com/nix-community/home-manager/commit/589efcf9c039db9dbc9410d53cf722d9e483dfd3) | `` maintainers: add gauthsvenkat ``       |