### PR TITLE
chore(flake/home-manager): `8af2e064` -> `0e0a16b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755601933,
-        "narHash": "sha256-iXZeeYyfy8NdpvH/OOW9V3C2AfsXE+fzDHfrIOHBPF0=",
+        "lastModified": 1755618859,
+        "narHash": "sha256-VGEZMAX/bOKrkg9x5DjXBfjpxm9gvU3kRVps7RKm8mQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8af2e064f93234ee79df8b9858eeefbf84394488",
+        "rev": "0e0a16b342bcd435ad83c62f4794ce1a4ccff0ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`0e0a16b3`](https://github.com/nix-community/home-manager/commit/0e0a16b342bcd435ad83c62f4794ce1a4ccff0ea) | `` anyrun: minor description fix `` |