### PR TITLE
chore(flake/stylix): `9810b32b` -> `7bd8d9c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1755546184,
-        "narHash": "sha256-KxRj/8SydDk3gzamS0VEewo5pu8JAYhSZ5GPcImPGNQ=",
+        "lastModified": 1755633766,
+        "narHash": "sha256-h2nJYe3MMULYPibeVXDI9Nm/k/3IPcNjQ0h29RpvLWI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9810b32b9b7520e3b37358ff8e793fb5034c3299",
+        "rev": "7bd8d9c5b1e2a1edf94dad246436a9f6f19e4d27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`3335202e`](https://github.com/nix-community/stylix/commit/3335202ed032912053e8132efc25b5cd4c8982b7) | `` ci: ISSUE_TEMPLATE: improve and match PR template `` |
| [`f6a351a4`](https://github.com/nix-community/stylix/commit/f6a351a444e9c3992c2573853f23e196899fb139) | `` treewide: add awwpotato to core maintainers list ``  |