### PR TITLE
chore(flake/home-manager): `0e0a16b3` -> `dd026d86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755618859,
-        "narHash": "sha256-VGEZMAX/bOKrkg9x5DjXBfjpxm9gvU3kRVps7RKm8mQ=",
+        "lastModified": 1755625756,
+        "narHash": "sha256-t57ayMEdV9g1aCfHzoQjHj1Fh3LDeyblceADm2hsLHM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e0a16b342bcd435ad83c62f4794ce1a4ccff0ea",
+        "rev": "dd026d86420781e84d0732f2fa28e1c051117b59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`dd026d86`](https://github.com/nix-community/home-manager/commit/dd026d86420781e84d0732f2fa28e1c051117b59) | `` sherlock: add `74k1` as maintainer ``                       |
| [`a9c81dbc`](https://github.com/nix-community/home-manager/commit/a9c81dbcc4d6f4777f11a5eadc45c8cf5501c8e5) | `` sherlock: use `X-Restart-Triggers` instead of `onChange` `` |