### PR TITLE
chore(flake/stylix): `7bd8d9c5` -> `2567b924`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1755633766,
-        "narHash": "sha256-h2nJYe3MMULYPibeVXDI9Nm/k/3IPcNjQ0h29RpvLWI=",
+        "lastModified": 1755636375,
+        "narHash": "sha256-HQQ7LdyHWCUcRBeGLTwJm+tJ8hmuglSzP/ZLeNBjFkk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7bd8d9c5b1e2a1edf94dad246436a9f6f19e4d27",
+        "rev": "2567b924669c566d132ce4cafd4bc0a119846b52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`e01d56cf`](https://github.com/nix-community/stylix/commit/e01d56cf5c00449f4d0af4013512ed906ed7d3c9) | `` stylix/droid: fix import droid modules (#1823) `` |
| [`7abe83d1`](https://github.com/nix-community/stylix/commit/7abe83d1ed362ecc874dce06a3d686b778cfdf27) | `` fontconfig: set defaultFonts with mkOrder 600 ``  |
| [`f2711be0`](https://github.com/nix-community/stylix/commit/f2711be0a3038686bdbfff7cc0854418fa4f2551) | `` fontconfig: refactor using `lib.genAttrs` ``      |