### PR TITLE
chore(flake/home-manager): `dd026d86` -> `3c3510e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755625756,
-        "narHash": "sha256-t57ayMEdV9g1aCfHzoQjHj1Fh3LDeyblceADm2hsLHM=",
+        "lastModified": 1755739851,
+        "narHash": "sha256-SC703bnPGOPWSEdZN2J2MkJWQBcUHV4QzuvFPdSVUME=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd026d86420781e84d0732f2fa28e1c051117b59",
+        "rev": "3c3510e61ca5c15a0f13d73c2232fa2d5478a86c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`3c3510e6`](https://github.com/nix-community/home-manager/commit/3c3510e61ca5c15a0f13d73c2232fa2d5478a86c) | `` programs/nix-search-tv: add quotes ``     |
| [`c2977f8b`](https://github.com/nix-community/home-manager/commit/c2977f8bca62a38ba42fea88a85f67e09d8ffcb2) | `` Add translation using Weblate (Hebrew) `` |