### PR TITLE
chore(flake/home-manager): `282b4c98` -> `6911d3e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755755322,
-        "narHash": "sha256-spCxkNihCk3uT3LUrUwzdEAjLA/E0EtEgF3KVI05nlM=",
+        "lastModified": 1755810213,
+        "narHash": "sha256-QdenO8f0PTg+tC6HuSvngKcbRZA5oZKmjUT+MXKOLQg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "282b4c98de97da6667cb03de4f427371734bc39c",
+        "rev": "6911d3e7f475f7b3558b4f5a6aba90fa86099baa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`6911d3e7`](https://github.com/nix-community/home-manager/commit/6911d3e7f475f7b3558b4f5a6aba90fa86099baa) | `` nix-gc: rename frequency to dates ``                 |
| [`3001400e`](https://github.com/nix-community/home-manager/commit/3001400e9ff29ec5e6d81d82dc3865d3df7254aa) | `` rclone: move activation script to systemd service `` |
| [`56b87499`](https://github.com/nix-community/home-manager/commit/56b87499874d16c43f4a732084650cb50b048f15) | `` rclone: modularize subtests ``                       |
| [`e6422763`](https://github.com/nix-community/home-manager/commit/e6422763eb4594099a889d05304c3cfd06e47c8f) | `` Translate using Weblate (Hebrew) ``                  |