### PR TITLE
chore(flake/stylix): `2355da45` -> `f47c0edc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1755708361,
-        "narHash": "sha256-RmqBx2EamhIk0WVhQSNb8iehaVhilO7D0YAnMoFPqJQ=",
+        "lastModified": 1755997543,
+        "narHash": "sha256-/fejmCQ7AWa655YxyPxRDbhdU7c5+wYsFSjmEMXoBCM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2355da455d7188228aaf20ac16ea9386e5aa6f0c",
+        "rev": "f47c0edcf71e802378b1b7725fa57bb44fe85ee8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f47c0edc`](https://github.com/nix-community/stylix/commit/f47c0edcf71e802378b1b7725fa57bb44fe85ee8) | `` treewide: remove Plasma 5 support dropped upstream (#1860) `` |