### PR TITLE
chore(flake/lovesegfault-vim-config): `f3874456` -> `9c46d530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755994216,
-        "narHash": "sha256-rd73OqVtiVa7ZDMCmo8gCE06UcDitYeQhwPaq7Y3P0M=",
+        "lastModified": 1755994344,
+        "narHash": "sha256-zLht7g7v1iiKzsVgfKdjLSL0hYm/wInk9IuPZBUgrDE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "f38744564e83379ef84411dd1abe57fc5850a391",
+        "rev": "9c46d5307eaeb28812e8b8b0993f46db9d69bc25",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                            |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`9c46d530`](https://github.com/lovesegfault/vim-config/commit/9c46d5307eaeb28812e8b8b0993f46db9d69bc25) | `` chore(flake/git-hooks): 3ff45966 -> e891a93b `` |