### PR TITLE
chore(flake/disko): `4073ff2f` -> `bafad29f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755519972,
-        "narHash": "sha256-bU4nqi3IpsUZJeyS8Jk85ytlX61i4b0KCxXX9YcOgVc=",
+        "lastModified": 1756115622,
+        "narHash": "sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "4073ff2f481f9ef3501678ff479ed81402caae6d",
+        "rev": "bafad29f89e83b2d861b493aa23034ea16595560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                             |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`bafad29f`](https://github.com/nix-community/disko/commit/bafad29f89e83b2d861b493aa23034ea16595560) | `` make-disk-image: also use xcp `` |
| [`49c1bc1b`](https://github.com/nix-community/disko/commit/49c1bc1b348aff130cf7d018b4c0d060c9397344) | `` disko-install: switch to xcp ``  |