### PR TITLE
chore(flake/lovesegfault-vim-config): `4eb76fa0` -> `e21fc798`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756166834,
-        "narHash": "sha256-6oHI9xtb2SbBwub0C5wDk3EEVEDins8aAxyFPkY7IPA=",
+        "lastModified": 1756253409,
+        "narHash": "sha256-ZNMiih2OR9bxSIR1yWCD3ZphTqxHK4lT7MK7VOWxWL4=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "4eb76fa016215bd52726bf184c237ac5e88a0422",
+        "rev": "e21fc7989a3e65a452b33b959fd57113a4b42ac2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`e21fc798`](https://github.com/lovesegfault/vim-config/commit/e21fc7989a3e65a452b33b959fd57113a4b42ac2) | `` chore(flake/nixpkgs): 20075955 -> 3b9f00d7 `` |