### PR TITLE
chore(flake/nixos-hardware): `3dac8a87` -> `a65b650d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1755330281,
-        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
+        "lastModified": 1756245047,
+        "narHash": "sha256-9bHzrVbjAudbO8q4vYFBWlEkDam31fsz0J7GB8k4AsI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
+        "rev": "a65b650d6981e23edd1afa1f01eb942f19cdcbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`3a4da5f8`](https://github.com/NixOS/nixos-hardware/commit/3a4da5f8c13b542c1298e7f0da6c1767db59602d) | `` framework: Enable fwupd by default `` |
| [`c13241f1`](https://github.com/NixOS/nixos-hardware/commit/c13241f1c0ba923840b2598db289ef120818c88b) | `` framework 16: Remove headset quirk `` |