### PR TITLE
chore(flake/nixpkgs): `3b9f00d7` -> `8a6d5427`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756125398,
-        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
+        "lastModified": 1756266583,
+        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
+        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`9610b365`](https://github.com/NixOS/nixpkgs/commit/9610b3651c469304a3bfae9b482fc67ef244ecb1) | `` gitui: fix build for v0.27.0 ``                                                              |
| [`6f17f09d`](https://github.com/NixOS/nixpkgs/commit/6f17f09df7117dfc00bf84c186325379baf8c638) | `` blender: 4.5.1 -> 4.5.2 (#436994) ``                                                         |
| [`f95d605a`](https://github.com/NixOS/nixpkgs/commit/f95d605add4682f8631f9443d60d7a7bfe276fad) | `` _1password-gui-beta: 8.11.8-32.BETA -> 8.11.8-39.BETA ``                                     |
| [`237b761f`](https://github.com/NixOS/nixpkgs/commit/237b761faae1cf79f6c42d038857bfa26ae52a4b) | `` _1password-gui: 8.11.6 -> 8.11.8 ``                                                          |
| [`11620175`](https://github.com/NixOS/nixpkgs/commit/116201756fb8601f8fc584a12b67f88e32480a03) | `` udiskie: 2.5.7 -> 2.5.8 ``                                                                   |
| [`f29d3a36`](https://github.com/NixOS/nixpkgs/commit/f29d3a361e2cedbfd08fa9a4a8560fc8612c4f59) | `` python3Packages.genie-partner-sdk: 1.0.9 -> 1.0.10 ``                                        |
| [`83de0534`](https://github.com/NixOS/nixpkgs/commit/83de0534f382ed81a5277f9ee2f7fecbd29b5bb5) | `` python313Packages.letpot: 0.6.1 -> 0.6.2 ``                                                  |
| [`0ee8a90d`](https://github.com/NixOS/nixpkgs/commit/0ee8a90d566958093001be67f7dc4641874ee3b6) | `` python313Packages.pyswitchbot: 0.68.4 -> 0.69.0 ``                                           |
| [`de61bb9f`](https://github.com/NixOS/nixpkgs/commit/de61bb9fd257fdff6d6d5c626770317657880649) | `` python313Packages.velbus-aio: 2025.5.0 -> 2025.8.0 ``                                        |
| [`9ecfc361`](https://github.com/NixOS/nixpkgs/commit/9ecfc36165ca742013adbea3888bc89a8ce8ab9c) | `` python313Packages.qingping-ble: 0.10.0 -> 1.0.1 ``                                           |
| [`72b5befd`](https://github.com/NixOS/nixpkgs/commit/72b5befda30353afddf73f8367b7a71b01f4da99) | `` python313Packages.iaqualink: 0.5.3 -> 0.6.0 ``                                               |
| [`bb47b7fe`](https://github.com/NixOS/nixpkgs/commit/bb47b7feecec34f148cf0865684d482de0311273) | `` python313Packages.aiohomeconnect: 0.18.1 -> 0.19.0 ``                                        |
| [`1e5b0170`](https://github.com/NixOS/nixpkgs/commit/1e5b0170bb7a83b66d6482579c1ed988dedc87e3) | `` mirrord: 3.157.2 -> 3.159.0 ``                                                               |
| [`a8abbb7f`](https://github.com/NixOS/nixpkgs/commit/a8abbb7f7109b58023893555c5e94a8b76b5f6f5) | `` cnspec: 11.68.0 -> 11.69.0 ``                                                                |
| [`87e9455a`](https://github.com/NixOS/nixpkgs/commit/87e9455abdb5f7afcfd58d1c801df025a95127f5) | `` kazumi: 1.7.6 -> 1.7.7 ``                                                                    |
| [`e47e0b8a`](https://github.com/NixOS/nixpkgs/commit/e47e0b8a148ca2a822b0d2bef23493bdefd067bd) | `` python313Packages.liccheck: modernize ``                                                     |
| [`4aebed42`](https://github.com/NixOS/nixpkgs/commit/4aebed42ee3797dd9693b8f1b0447e979dc58c18) | `` python3Packages.aws-lambda-builders: 1.56.0 -> 1.57.0 ``                                     |
| [`b6dde26b`](https://github.com/NixOS/nixpkgs/commit/b6dde26bb65612836fd518bdc3ac853bbc77a4a7) | `` shellhub-agent: 0.20.0 -> 0.20.1 ``                                                          |
| [`b53e9969`](https://github.com/NixOS/nixpkgs/commit/b53e99691d294b155f55a00fb1546c884de542da) | `` racket-minimal: 8.17 -> 8.18 ``                                                              |
| [`308698ab`](https://github.com/NixOS/nixpkgs/commit/308698ab3b509594549a53761acb16d41f0eaba3) | `` python313Packages.boto3-stubs: 1.40.16 -> 1.40.18 ``                                         |
| [`f997a1bf`](https://github.com/NixOS/nixpkgs/commit/f997a1bf2112887af1e755e471ba41b747292aa8) | `` python312Packages.mypy-boto3-wellarchitected: 1.40.0 -> 1.40.17 ``                           |
| [`2804ccd9`](https://github.com/NixOS/nixpkgs/commit/2804ccd95ab65caf9e194da94fc71dee939d1fc5) | `` python312Packages.mypy-boto3-waf-regional: 1.40.0 -> 1.40.18 ``                              |
| [`93a15595`](https://github.com/NixOS/nixpkgs/commit/93a1559522298d87053b2fe160ece8123c9ad9cb) | `` python312Packages.mypy-boto3-translate: 1.40.0 -> 1.40.17 ``                                 |
| [`84701dd3`](https://github.com/NixOS/nixpkgs/commit/84701dd335909a8fd09485e74a2a1c569bedb519) | `` python312Packages.mypy-boto3-support-app: 1.40.0 -> 1.40.17 ``                               |
| [`7ffc31ba`](https://github.com/NixOS/nixpkgs/commit/7ffc31ba525becdc7c7361cad5f8832feab7751b) | `` python312Packages.mypy-boto3-support: 1.40.0 -> 1.40.17 ``                                   |
| [`34c36dcf`](https://github.com/NixOS/nixpkgs/commit/34c36dcf2829093694b09d003595eec75bb0aac5) | `` python312Packages.mypy-boto3-sqs: 1.40.0 -> 1.40.17 ``                                       |
| [`7309b9e1`](https://github.com/NixOS/nixpkgs/commit/7309b9e16d3f063cf8c42df487dd6706cb546dd9) | `` python312Packages.mypy-boto3-snowball: 1.40.0 -> 1.40.17 ``                                  |
| [`3db51c82`](https://github.com/NixOS/nixpkgs/commit/3db51c82b43d83a50a0d4dd77a91b3143dd049ba) | `` python312Packages.mypy-boto3-signer: 1.40.0 -> 1.40.18 ``                                    |
| [`a183d986`](https://github.com/NixOS/nixpkgs/commit/a183d986db30650b68a8fd5c8cfcfccca6a7821d) | `` python312Packages.mypy-boto3-shield: 1.40.0 -> 1.40.17 ``                                    |
| [`833bfbe0`](https://github.com/NixOS/nixpkgs/commit/833bfbe01f21b54044fe082ba2f33aab78fdf362) | `` python312Packages.mypy-boto3-servicecatalog-appregistry: 1.40.0 -> 1.40.18 ``                |
| [`4e45a07d`](https://github.com/NixOS/nixpkgs/commit/4e45a07d1b7c0fd1680ac333d7667a4103c06954) | `` python312Packages.mypy-boto3-serverlessrepo: 1.40.0 -> 1.40.17 ``                            |
| [`2933f5aa`](https://github.com/NixOS/nixpkgs/commit/2933f5aabef3e0cbec09ff74c513e66be3ca646a) | `` python312Packages.mypy-boto3-sagemaker-runtime: 1.40.0 -> 1.40.17 ``                         |
| [`220a5740`](https://github.com/NixOS/nixpkgs/commit/220a574065bbd1344726927c6d58479ac21cdc1f) | `` python312Packages.mypy-boto3-sagemaker-geospatial: 1.40.0 -> 1.40.18 ``                      |
| [`af4ca32a`](https://github.com/NixOS/nixpkgs/commit/af4ca32ab89faaffc447cc319e6a87da7746b55b) | `` python312Packages.mypy-boto3-sagemaker-featurestore-runtime: 1.40.0 -> 1.40.17 ``            |
| [`deab96ea`](https://github.com/NixOS/nixpkgs/commit/deab96ead56653ab74af7fccdf8e3e2cd01c00d4) | `` python312Packages.mypy-boto3-sagemaker-edge: 1.40.0 -> 1.40.17 ``                            |
| [`bf60f494`](https://github.com/NixOS/nixpkgs/commit/bf60f49403c830ade3644b4e860c0746fcee811a) | `` python312Packages.mypy-boto3-route53-recovery-cluster: 1.40.0 -> 1.40.18 ``                  |
| [`b84f1715`](https://github.com/NixOS/nixpkgs/commit/b84f17151fe2dae2b71e5c0f15ea5ce5e0fb72d0) | `` python312Packages.mypy-boto3-resourcegroupstaggingapi: 1.40.0 -> 1.40.17 ``                  |
| [`8ec79b51`](https://github.com/NixOS/nixpkgs/commit/8ec79b515799dd0eb33a24f34c966557b72fa4ae) | `` python312Packages.mypy-boto3-rbin: 1.40.0 -> 1.40.18 ``                                      |
| [`45a864a1`](https://github.com/NixOS/nixpkgs/commit/45a864a160f27743767756934db1b19d53f75c4f) | `` python312Packages.mypy-boto3-ram: 1.40.0 -> 1.40.18 ``                                       |
| [`1a9f126c`](https://github.com/NixOS/nixpkgs/commit/1a9f126c913244d62d3f79d8f230b2bd5493f756) | `` python312Packages.mypy-boto3-pinpoint: 1.40.0 -> 1.40.18 ``                                  |
| [`dc5e5a14`](https://github.com/NixOS/nixpkgs/commit/dc5e5a14b074d2957912b15ac9665e122a2651cb) | `` python312Packages.mypy-boto3-personalize-runtime: 1.40.0 -> 1.40.17 ``                       |
| [`5cd542a0`](https://github.com/NixOS/nixpkgs/commit/5cd542a0afb5af900ea6f38d50a945d61f414389) | `` python312Packages.mypy-boto3-personalize-events: 1.40.0 -> 1.40.18 ``                        |
| [`d7f8a710`](https://github.com/NixOS/nixpkgs/commit/d7f8a7102df2f2e4d2533d6d60e38e3ed6e75baf) | `` python312Packages.mypy-boto3-mq: 1.40.0 -> 1.40.18 ``                                        |
| [`2c9a9ac1`](https://github.com/NixOS/nixpkgs/commit/2c9a9ac19c760f22a7d333d3addc14fe737eb567) | `` python312Packages.mypy-boto3-migration-hub-refactor-spaces: 1.40.0 -> 1.40.18 ``             |
| [`c38f9a67`](https://github.com/NixOS/nixpkgs/commit/c38f9a67e36a767bf8dea71583aed0f8b218dba5) | `` python312Packages.mypy-boto3-mgh: 1.40.0 -> 1.40.18 ``                                       |
| [`6fb6574f`](https://github.com/NixOS/nixpkgs/commit/6fb6574fa62d6cb3c89a521acc21c6f92bb43637) | `` python312Packages.mypy-boto3-mediastore: 1.40.0 -> 1.40.17 ``                                |
| [`67035a02`](https://github.com/NixOS/nixpkgs/commit/67035a02aa5f41f3665805beefaedacd3b12669e) | `` python312Packages.mypy-boto3-mediapackage-vod: 1.40.0 -> 1.40.17 ``                          |
| [`9d6d28f6`](https://github.com/NixOS/nixpkgs/commit/9d6d28f617e0b498a2dac7c9a6def0c3271148c9) | `` python312Packages.mypy-boto3-mediaconvert: 1.40.0 -> 1.40.17 ``                              |
| [`818eac6e`](https://github.com/NixOS/nixpkgs/commit/818eac6e9e77672610d8f3ccf0269b61455c632a) | `` python312Packages.mypy-boto3-lookoutvision: 1.40.0 -> 1.40.18 ``                             |
| [`29a01015`](https://github.com/NixOS/nixpkgs/commit/29a01015bcc1c4ff4e867529f30609294c169944) | `` python312Packages.mypy-boto3-lookoutequipment: 1.40.0 -> 1.40.17 ``                          |
| [`e629b5ee`](https://github.com/NixOS/nixpkgs/commit/e629b5eed1720bd4c632c3d4edd015f5ad58214c) | `` python312Packages.mypy-boto3-lex-runtime: 1.40.0 -> 1.40.17 ``                               |
| [`07fd147b`](https://github.com/NixOS/nixpkgs/commit/07fd147b7bdfd057a4b7e297729f4dca20ca2d5a) | `` python312Packages.mypy-boto3-kinesisanalytics: 1.40.0 -> 1.40.17 ``                          |
| [`5b32baa8`](https://github.com/NixOS/nixpkgs/commit/5b32baa8b899f9fed1504c9a947e48f327e640db) | `` python312Packages.mypy-boto3-kinesis-video-archived-media: 1.40.0 -> 1.40.17 ``              |
| [`438a6a26`](https://github.com/NixOS/nixpkgs/commit/438a6a26f126e944d1e48d00bb839a78cb0c9ade) | `` python312Packages.mypy-boto3-kendra: 1.40.0 -> 1.40.17 ``                                    |
| [`e411999b`](https://github.com/NixOS/nixpkgs/commit/e411999bc0fba9ed68a87bc3f50e682c3876a7b4) | `` python312Packages.mypy-boto3-kafka: 1.40.0 -> 1.40.18 ``                                     |
| [`4fe22385`](https://github.com/NixOS/nixpkgs/commit/4fe22385e15b39cdb9ef897d4c8afab0a815ee65) | `` python312Packages.mypy-boto3-iotsecuretunneling: 1.40.0 -> 1.40.18 ``                        |
| [`28901009`](https://github.com/NixOS/nixpkgs/commit/28901009255d259c606b7f39f45df409ed28552d) | `` python312Packages.mypy-boto3-iotfleethub: 1.40.0 -> 1.40.17 ``                               |
| [`340190e0`](https://github.com/NixOS/nixpkgs/commit/340190e07cadf2b6f4d8dc8ff7e53b76d875a2c6) | `` python312Packages.mypy-boto3-imagebuilder: 1.40.0 -> 1.40.18 ``                              |
| [`f0d6ae53`](https://github.com/NixOS/nixpkgs/commit/f0d6ae53d22811ef97d7009a2d45f247844e2ba6) | `` python312Packages.mypy-boto3-identitystore: 1.40.0 -> 1.40.18 ``                             |
| [`ded61f32`](https://github.com/NixOS/nixpkgs/commit/ded61f3277808485890d2082c98aaccbd474f98a) | `` python312Packages.mypy-boto3-greengrass: 1.40.0 -> 1.40.18 ``                                |
| [`4f7e53fb`](https://github.com/NixOS/nixpkgs/commit/4f7e53fb88bec08c8c43c7055e8e963f827690f1) | `` python312Packages.mypy-boto3-globalaccelerator: 1.40.0 -> 1.40.18 ``                         |
| [`b17ee9d5`](https://github.com/NixOS/nixpkgs/commit/b17ee9d56fb2f8b6e42d6c2e75e0f67c6fb1ee1f) | `` python312Packages.mypy-boto3-glacier: 1.40.0 -> 1.40.18 ``                                   |
| [`74a8fe4c`](https://github.com/NixOS/nixpkgs/commit/74a8fe4c645d4f318c79c5846d29d88cb7d6a367) | `` python312Packages.mypy-boto3-forecast: 1.40.0 -> 1.40.17 ``                                  |
| [`2b1d5301`](https://github.com/NixOS/nixpkgs/commit/2b1d53015a3916e098a19891f5ced8ab5eced780) | `` python312Packages.mypy-boto3-finspace-data: 1.40.0 -> 1.40.17 ``                             |
| [`655ec917`](https://github.com/NixOS/nixpkgs/commit/655ec9175ef824ad7a0d2c560c5f984f8376bf71) | `` python312Packages.mypy-boto3-finspace: 1.40.0 -> 1.40.18 ``                                  |
| [`04a0c5be`](https://github.com/NixOS/nixpkgs/commit/04a0c5be5ebddf8dcaa278d91cafb00bda878f45) | `` python312Packages.mypy-boto3-emr-containers: 1.40.0 -> 1.40.17 ``                            |
| [`29045bfc`](https://github.com/NixOS/nixpkgs/commit/29045bfcc0a7a6a99c2466a29e959f288aeb7484) | `` python312Packages.mypy-boto3-elastictranscoder: 1.40.0 -> 1.40.18 ``                         |
| [`a7b38c21`](https://github.com/NixOS/nixpkgs/commit/a7b38c21d609f0052327c69e22ea80f8dea5cb99) | `` python312Packages.mypy-boto3-ec2: 1.40.13 -> 1.40.18 ``                                      |
| [`13dcb6af`](https://github.com/NixOS/nixpkgs/commit/13dcb6af0a7355be7d2ea0dfc8aa25dfac2dbf8b) | `` python312Packages.mypy-boto3-dlm: 1.40.0 -> 1.40.18 ``                                       |
| [`472abf4f`](https://github.com/NixOS/nixpkgs/commit/472abf4f8518e8f69b9f622d97b3098e146d2098) | `` python312Packages.mypy-boto3-devops-guru: 1.40.0 -> 1.40.17 ``                               |
| [`a530fef6`](https://github.com/NixOS/nixpkgs/commit/a530fef6c758cc5d442fa8afdfd3f9be308f861a) | `` python312Packages.mypy-boto3-dax: 1.40.0 -> 1.40.17 ``                                       |
| [`2927cf71`](https://github.com/NixOS/nixpkgs/commit/2927cf718eb0bdf2214f9166b548db7f3f346aa9) | `` python312Packages.mypy-boto3-cur: 1.40.0 -> 1.40.17 ``                                       |
| [`1d4054e6`](https://github.com/NixOS/nixpkgs/commit/1d4054e622da72278473907531b0a14dcd37abcd) | `` python312Packages.mypy-boto3-connectparticipant: 1.40.12 -> 1.40.18 ``                       |
| [`7c59fb9b`](https://github.com/NixOS/nixpkgs/commit/7c59fb9b49e4b584fe5ae188faf51fdea76976f1) | `` python312Packages.mypy-boto3-comprehendmedical: 1.40.0 -> 1.40.18 ``                         |
| [`a189b35f`](https://github.com/NixOS/nixpkgs/commit/a189b35fa632758538deb8796b2313f0656fa371) | `` python312Packages.mypy-boto3-codestar-notifications: 1.40.0 -> 1.40.17 ``                    |
| [`6467809a`](https://github.com/NixOS/nixpkgs/commit/6467809aafff6d0a404beafa00201ce4c0030612) | `` python312Packages.mypy-boto3-codestar-connections: 1.40.0 -> 1.40.18 ``                      |
| [`b550e203`](https://github.com/NixOS/nixpkgs/commit/b550e20305e001207019c7c47ef9c0cf7c660896) | `` python312Packages.mypy-boto3-codeguru-security: 1.40.0 -> 1.40.17 ``                         |
| [`f215fdac`](https://github.com/NixOS/nixpkgs/commit/f215fdac5ff7bf9800626aef52f5465e7a78c79d) | `` python312Packages.mypy-boto3-codecommit: 1.40.0 -> 1.40.18 ``                                |
| [`d45381d6`](https://github.com/NixOS/nixpkgs/commit/d45381d6101420b9464a448b9339dd9d3ae51913) | `` python312Packages.mypy-boto3-codeartifact: 1.40.0 -> 1.40.17 ``                              |
| [`47ba1d65`](https://github.com/NixOS/nixpkgs/commit/47ba1d6537d40a69b66572fa47989e38e6b965c9) | `` python312Packages.mypy-boto3-cloudtrail-data: 1.40.0 -> 1.40.17 ``                           |
| [`39a1e083`](https://github.com/NixOS/nixpkgs/commit/39a1e083f708e0a0c7f3cf348e327815d991ebc1) | `` python312Packages.mypy-boto3-cloudsearch: 1.40.0 -> 1.40.17 ``                               |
| [`dce5b513`](https://github.com/NixOS/nixpkgs/commit/dce5b513f9e0e8e16249c128c9bbc0eea45847fe) | `` python312Packages.mypy-boto3-chime-sdk-messaging: 1.40.0 -> 1.40.17 ``                       |
| [`76a83dbe`](https://github.com/NixOS/nixpkgs/commit/76a83dbe0ce9a5482e62654ec39a8488adc9d2fa) | `` python312Packages.mypy-boto3-chime-sdk-media-pipelines: 1.40.0 -> 1.40.17 ``                 |
| [`eb1b7d6b`](https://github.com/NixOS/nixpkgs/commit/eb1b7d6bba1eec4dc3e28754b82ea2e5f8d24c9d) | `` python312Packages.mypy-boto3-arc-zonal-shift: 1.40.0 -> 1.40.18 ``                           |
| [`582c269f`](https://github.com/NixOS/nixpkgs/commit/582c269fe6fd97e1de61338d0e70f20c46b7540b) | `` python312Packages.mypy-boto3-apprunner: 1.40.0 -> 1.40.18 ``                                 |
| [`e6158c19`](https://github.com/NixOS/nixpkgs/commit/e6158c191ceaf848dfc9a11f0c8758a0a0ab4a57) | `` python312Packages.mypy-boto3-appflow: 1.40.0 -> 1.40.17 ``                                   |
| [`b9e09271`](https://github.com/NixOS/nixpkgs/commit/b9e09271b76a01bce3dd6ec276c1fbd42c396b89) | `` linuxPackages.v4l2loopback: Fix makeFlags for utils ``                                       |
| [`aac8f897`](https://github.com/NixOS/nixpkgs/commit/aac8f8975b0531c093930264433d3e320b36c076) | `` evcc: 0.207.4 -> 0.207.5 ``                                                                  |
| [`4f6db78d`](https://github.com/NixOS/nixpkgs/commit/4f6db78d211d0b5b236b2164340a77f585955afd) | `` v2ray-domain-list-community: 20250814002625 -> 20250826193754 ``                             |
| [`2612d7b7`](https://github.com/NixOS/nixpkgs/commit/2612d7b72e58c64914126bd8f4d1cbb4a512eaf6) | `` chromium,chromedriver: 139.0.7258.138 -> 139.0.7258.154 ``                                   |
| [`fd0ad4fe`](https://github.com/NixOS/nixpkgs/commit/fd0ad4fee834fa585bc70424c0e67003015671a4) | `` buildMozillaMach: restore MOZ_SYSTEM_DIR patch ``                                            |
| [`2eebcd6b`](https://github.com/NixOS/nixpkgs/commit/2eebcd6b91e9b0fe4c7be9a2c977a97955f37c73) | `` networkminer: fix desktop file ``                                                            |
| [`a6414cb3`](https://github.com/NixOS/nixpkgs/commit/a6414cb37ed4ad13e80f25c9309101c531d72953) | `` python3Packages.rigour: 1.2.2 -> 1.2.9 ``                                                    |
| [`ffa01f6d`](https://github.com/NixOS/nixpkgs/commit/ffa01f6d339d3bc31ce1aed95f5985787ab515af) | `` gdtoolkit_4: 4.3.3 -> 4.3.4 ``                                                               |
| [`014e046c`](https://github.com/NixOS/nixpkgs/commit/014e046c1cd9b9e751318ec1f281978e0f0c4ac2) | `` obs-studio-plugins.obs-vkcapture: 1.5.2 -> 1.5.3 ``                                          |
| [`66acc830`](https://github.com/NixOS/nixpkgs/commit/66acc8301e53b20e2f33c6c72377d97687154757) | `` python3Packages.bluecurrent-api: 1.2.4 -> 1.3.1 ``                                           |
| [`b90b5326`](https://github.com/NixOS/nixpkgs/commit/b90b532691add2b55fb292f0ceb5457261561d5e) | `` granian: 2.5.0 -> 2.5.1 ``                                                                   |
| [`465ab8f0`](https://github.com/NixOS/nixpkgs/commit/465ab8f0977d05657b1b4adc6e7e06fe4db04c0c) | `` windows: minimal eval (#437193) ``                                                           |
| [`6c0dee3d`](https://github.com/NixOS/nixpkgs/commit/6c0dee3d65c4c02f935b7d42af3422a2022a59c8) | `` mfaomp: init at 0.4.3 ``                                                                     |
| [`55b0193b`](https://github.com/NixOS/nixpkgs/commit/55b0193b0e23cb73628a4b1e86bcdf3254a2fb82) | `` maintainers: add neurofibromin ``                                                            |
| [`5610941d`](https://github.com/NixOS/nixpkgs/commit/5610941d362897519b0c258c003515491e51148c) | `` python3Packages.langgraph-checkpoint-sqlite: repair broken update, apply skipBulkUpdate ``   |
| [`e500804b`](https://github.com/NixOS/nixpkgs/commit/e500804b5d24fe35f3db0a636830fe26eabefa7f) | `` python3Packages.langgraph-checkpoint-postgres: repair broken update, apply skipBulkUpdate `` |
| [`bc72db39`](https://github.com/NixOS/nixpkgs/commit/bc72db398d1a51ce0b5b996b64db4e93f60c6672) | `` python3Packages.langgraph-checkpoint: apply skipBulkUpdate ``                                |
| [`bd7c3672`](https://github.com/NixOS/nixpkgs/commit/bd7c36721dcafe7a56908bc845f99eb3faf9055e) | `` python3Packages.langgraph-cli: 0.3.6 -> 0.4.0 ``                                             |
| [`6d2d77d3`](https://github.com/NixOS/nixpkgs/commit/6d2d77d31cad89ffac54e8e16b83dde0923b7b67) | `` python3Packages.langgraph-cli: repair broken update, apply skipBulkUpdate ``                 |
| [`7d288dec`](https://github.com/NixOS/nixpkgs/commit/7d288dec0188947ee4d0f77b6e8a84dd772ae3ac) | `` python3Packages.langgraph: repair broken update, apply skipBulkUpdate ``                     |
| [`97c7fb1c`](https://github.com/NixOS/nixpkgs/commit/97c7fb1c7f16f6c1299852fa437c953fa6987c7a) | `` maintainers: add armelclo ``                                                                 |
| [`c0c0e36d`](https://github.com/NixOS/nixpkgs/commit/c0c0e36ddd39d4f76e5c0dc6af9bcd4288830e7b) | `` gmobile: 0.2.1 -> 0.4.0 ``                                                                   |
| [`ab0b16dd`](https://github.com/NixOS/nixpkgs/commit/ab0b16dd05b55be93a259d16118578257784208a) | `` ocamlPackages: move removed packages behind allowAliases ``                                  |
| [`230ec755`](https://github.com/NixOS/nixpkgs/commit/230ec7554cf8f977019387d3cec3fb021ec69ed6) | `` terraform-providers.heroku: 5.2.8 -> 5.2.11 ``                                               |
| [`6eec03ac`](https://github.com/NixOS/nixpkgs/commit/6eec03acff37b43a7b4da3bac4dcde5f759a7f66) | `` ocamlPackages.janeStreet: recurseIntoAttrs ``                                                |
| [`9494f247`](https://github.com/NixOS/nixpkgs/commit/9494f24765d6f69de6e6bc9a030acebd8195462e) | `` ocamlPackages.systemd: replace `meta.platform` with `meta.platforms` ``                      |
| [`dad6a74c`](https://github.com/NixOS/nixpkgs/commit/dad6a74cab89bb8c35127d88c9b5ddf20bf5d3de) | `` phoc: 0.44.1 -> 0.48.0 ``                                                                    |