### PR TITLE
chore(flake/home-manager): `77f348da` -> `77a71380`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756261190,
-        "narHash": "sha256-eiy0klFK5EVJLNilutR7grsZN/7Itj9DyD75eyOf83k=",
+        "lastModified": 1756496801,
+        "narHash": "sha256-IYIsnPy+cJxe8RbDHBrCtfJY0ry2bG2H7WvMcewiGS8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77f348da3176dc68b20a73dab94852a417daf361",
+        "rev": "77a71380c38fb2a440b4b5881bbc839f6230e1cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`77a71380`](https://github.com/nix-community/home-manager/commit/77a71380c38fb2a440b4b5881bbc839f6230e1cb) | `` ssh: provide code snippet in enableDefaultConfig description `` |
| [`a3d90c99`](https://github.com/nix-community/home-manager/commit/a3d90c996f8af2333b96512a973686d7559172ec) | `` docs: fix typo in collision.md ``                               |