### PR TITLE
chore(flake/nix-index-database): `52dec1cb` -> `3fe768e1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756008611,
-        "narHash": "sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE=",
+        "lastModified": 1756612744,
+        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "52dec1cb33a614accb9e01307e17816be974d24d",
+        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`3fe768e1`](https://github.com/nix-community/nix-index-database/commit/3fe768e1f058961095b4a0d7a2ba15dc9736bdc6) | `` update generated.nix to release 2025-08-31-032935 `` |
| [`ff040ab4`](https://github.com/nix-community/nix-index-database/commit/ff040ab44e4c81bf985466f247a375d3f60eb371) | `` flake.lock: Update ``                                |