### PR TITLE
chore(flake/home-manager): `e4454907` -> `b4b5f008`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756650373,
-        "narHash": "sha256-Iz0dNCNvLLxVGjOOF1/TJvZ4iKXE96BTgKDObCs9u+M=",
+        "lastModified": 1756669196,
+        "narHash": "sha256-E/l+K8WIjbH5AUv/B17RX1hzx1CsuPaT86g1xDwiYY8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e44549074a574d8bda612945a88e4a1fd3c456a8",
+        "rev": "b4b5f008d772c0e8e9c420cfa0d240a447747e0a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`b4b5f008`](https://github.com/nix-community/home-manager/commit/b4b5f008d772c0e8e9c420cfa0d240a447747e0a) | `` hyprpanel: deprecate `theme.name` option ``     |
| [`1e759786`](https://github.com/nix-community/home-manager/commit/1e759786e526a87a3c05beeff5db41743d763569) | `` qt: deprecate kde6 ``                           |
| [`f671e772`](https://github.com/nix-community/home-manager/commit/f671e772d3c3b893e44399afedb84a0b3f27f922) | `` qt: Remove Plasma 5 and related Qt5 packages `` |
| [`71b57070`](https://github.com/nix-community/home-manager/commit/71b57070771aac60ca949b47d6b2bd2afd5e49d8) | `` tests/darwinScrublist: add pgclii ``            |
| [`2842bac6`](https://github.com/nix-community/home-manager/commit/2842bac626ed087e83400a7a23da8e8923c6c7e6) | `` flake.lock: Update ``                           |
| [`f27974d3`](https://github.com/nix-community/home-manager/commit/f27974d3b4aa0af533539ce626622c7b6b53c3f5) | `` shpool: init shpool module ``                   |