### PR TITLE
chore(flake/home-manager): `b4b5f008` -> `fccb44df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756669196,
-        "narHash": "sha256-E/l+K8WIjbH5AUv/B17RX1hzx1CsuPaT86g1xDwiYY8=",
+        "lastModified": 1756683562,
+        "narHash": "sha256-3fcIqwm1u+rF3kkgUYYEIcLrs93+Pi+a6AwiEAxdP5g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b4b5f008d772c0e8e9c420cfa0d240a447747e0a",
+        "rev": "fccb44df77266a3891939f35197f538dace3442f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`fccb44df`](https://github.com/nix-community/home-manager/commit/fccb44df77266a3891939f35197f538dace3442f) | `` mkFirefoxModule: make policies work on darwin ``                 |
| [`b7cc2466`](https://github.com/nix-community/home-manager/commit/b7cc2466f1a695326ffc1a14040cd4d3b4358ea0) | `` distrobox: add settings option and other general improvements `` |
| [`a48dd228`](https://github.com/nix-community/home-manager/commit/a48dd228d977b1c5085cb8e014fd0ccfc45ca77b) | `` jq: make `colors` and `package` nullable ``                      |