### PR TITLE
chore(flake/lovesegfault-vim-config): `7ec84f50` -> `0409b7d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756599003,
-        "narHash": "sha256-U6WH5RQ9RGD3KcL3iVj8s+M8CwpEC9hubwfIiwzPzgU=",
+        "lastModified": 1756685308,
+        "narHash": "sha256-rQn+7WStmW2NLxPkjCbowJBh7S5kjHC7eoYjFhxKSQY=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "7ec84f50ca32da6f5077284062277cc34bfd179d",
+        "rev": "0409b7d4911096014c822dd88bc239b5f4e0808e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0409b7d4`](https://github.com/lovesegfault/vim-config/commit/0409b7d4911096014c822dd88bc239b5f4e0808e) | `` chore(flake/treefmt-nix): 74e1a52d -> 1aabc6c0 `` |