### PR TITLE
chore(flake/disko): `bafad29f` -> `a5c4f2ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756115622,
-        "narHash": "sha256-iv8xVtmLMNLWFcDM/HcAPLRGONyTRpzL9NS09RnryRM=",
+        "lastModified": 1756733629,
+        "narHash": "sha256-dwWGlDhcO5SMIvMSTB4mjQ5Pvo2vtxvpIknhVnSz2I8=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bafad29f89e83b2d861b493aa23034ea16595560",
+        "rev": "a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                           |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`a5c4f2ab`](https://github.com/nix-community/disko/commit/a5c4f2ab72e3d1ab43e3e65aa421c6f2bd2e12a1) | `` make-disk-image: use modules  output of a kernel if present `` |