### PR TITLE
chore(flake/lanzaboote): `892cbdca` -> `747b7912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -415,11 +415,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1754297745,
-        "narHash": "sha256-aD6/scLN3L4ZszmNbhhd3JQ9Pzv1ScYFphz14wHinfs=",
+        "lastModified": 1756744479,
+        "narHash": "sha256-EyZXusK/wRD3V9vDh00W2Re3Eg8UQ+LjVBQrrH9dq1U=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "892cbdca865d6b42f9c0d222fe309f7720259855",
+        "rev": "747b7912f49e2885090c83364d88cf853a020ac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                      |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`e3a86958`](https://github.com/nix-community/lanzaboote/commit/e3a869581e5fd4acdac024d05f29080d9faa4dc2) | `` chore: avoid `with lib` ``                |
| [`5c423e6b`](https://github.com/nix-community/lanzaboote/commit/5c423e6bc6b7179be5cbf4f9f0549411c5e9f292) | `` chore: avoid rec in options definition `` |