### PR TITLE
chore(flake/nixos-hardware): `a65b650d` -> `47eb4856`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1756245047,
-        "narHash": "sha256-9bHzrVbjAudbO8q4vYFBWlEkDam31fsz0J7GB8k4AsI=",
+        "lastModified": 1756750488,
+        "narHash": "sha256-e4ZAu2sjOtGpvbdS5zo+Va5FUUkAnizl4wb0/JlIL2I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a65b650d6981e23edd1afa1f01eb942f19cdcbb7",
+        "rev": "47eb4856cfd01eaeaa7bb5944a0f27db8fb9b94a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`f4a07aa3`](https://github.com/NixOS/nixos-hardware/commit/f4a07aa370c5cb3d39f3d0f2215bbf5bce8f87b2) | `` system76-gaze18: add laptop and ssd imports ``                                 |
| [`7fe67c44`](https://github.com/NixOS/nixos-hardware/commit/7fe67c44d1ca93e55219cdd470e64da6ce3fee64) | `` system76-gaze18: use xserver.videoDrivers instead of initrd.kernelModules ``   |
| [`c69cdbed`](https://github.com/NixOS/nixos-hardware/commit/c69cdbed34aa6a39e91a7217a11833358f198036) | `` system76-gaze18: add CPU module ``                                             |
| [`e903fd79`](https://github.com/NixOS/nixos-hardware/commit/e903fd796da4396598e1d0573f7516927feb3577) | `` Revert "apple: add hid_apple.iso_layout=0 kernel param" ``                     |
| [`a57aded4`](https://github.com/NixOS/nixos-hardware/commit/a57aded40e877bb419d98f8290efa4b8aa5beada) | `` Update README.md - wireplumber example issue ``                                |
| [`f3444245`](https://github.com/NixOS/nixos-hardware/commit/f3444245a78f55dd22fca2f9f52b1f3e5382572b) | `` apple/t2: sync stable patches (6.12.43 -> 6.12.44) ``                          |
| [`9691e6ee`](https://github.com/NixOS/nixos-hardware/commit/9691e6ee8a33dec6f8222314785868415bb78560) | `` apple/t2: sync stable patches ``                                               |
| [`bfda6f34`](https://github.com/NixOS/nixos-hardware/commit/bfda6f34d3eaf310ea2565bd51bc48aabcc45f3a) | `` dell/precision/7520: use stable nvidia driver (not legacy) ``                  |
| [`59e2d82c`](https://github.com/NixOS/nixos-hardware/commit/59e2d82cc23b05e99815ae7ad95f454905f3689d) | `` ran formatter for mbp11,4 ``                                                   |
| [`6439a46c`](https://github.com/NixOS/nixos-hardware/commit/6439a46c7ce9bf5b0d51438e0e316b748cf42fd5) | `` feat: add MECHREVO Yilong15Pro(GM5HG0A) ``                                     |
| [`cfb36e4f`](https://github.com/NixOS/nixos-hardware/commit/cfb36e4feb6a9a423510260a7959eb0831461570) | `` fix: add missing import of ideapad 16iah8 ``                                   |
| [`5e741b56`](https://github.com/NixOS/nixos-hardware/commit/5e741b56dc39de0ff7f2565867dd08a2118155b2) | `` added supporting files ``                                                      |
| [`17113fc1`](https://github.com/NixOS/nixos-hardware/commit/17113fc124517f837c27f3ebb3a23659a7ca4442) | `` Added g533q ``                                                                 |
| [`0413405b`](https://github.com/NixOS/nixos-hardware/commit/0413405b45b381c8c8fa25d8e81fcbb395bc423e) | `` feat: ✨ add ThinkPad T14 Intel Gen 6 hardware support ``                       |
| [`e3e3717d`](https://github.com/NixOS/nixos-hardware/commit/e3e3717d85ca1105afc9ec5b3a6a4ce4ba204135) | `` apple/t2: kernel 6.15 -> 6.16; sync patches ``                                 |
| [`2d512d0f`](https://github.com/NixOS/nixos-hardware/commit/2d512d0f4ef9908c104c4e451bb1571fe81a4267) | `` removed s2idle for macbookpro11,4 as default ``                                |
| [`6287c9e1`](https://github.com/NixOS/nixos-hardware/commit/6287c9e15f1f575157e8c8b7627b5b5858265821) | `` build(deps): bump actions/checkout from 4 to 5 ``                              |
| [`292aeb6f`](https://github.com/NixOS/nixos-hardware/commit/292aeb6fd6a33045f73e24cbf51ed22ef4156094) | `` added macbook pro 11,4 config ``                                               |
| [`c4af46bb`](https://github.com/NixOS/nixos-hardware/commit/c4af46bb6a91f90a99d9fc0b89a0fda85122943b) | `` raspberry-pi/4: support enabling/disabling media-controller api on tc358743 `` |
| [`79649965`](https://github.com/NixOS/nixos-hardware/commit/79649965c5f00f1a13c0517625828f3df0f50f47) | `` fix(raspberry-pi-4): enable building kernel ``                                 |
| [`680761f0`](https://github.com/NixOS/nixos-hardware/commit/680761f019c3d37c5a3d920b1ff8c61ded68cd6b) | `` fix: tc358743 dt overlay ``                                                    |
| [`139a6586`](https://github.com/NixOS/nixos-hardware/commit/139a6586edaa656ca7beee79d6bf397af4066fc3) | `` Add Lenovo Thinkpad P16s AMD Gen 4 ``                                          |
| [`aaecdd8d`](https://github.com/NixOS/nixos-hardware/commit/aaecdd8d3bd6e7e52a6375e7bab914582ce5e540) | `` Update flake.lock, dropping unused `nixpkgs` input ``                          |
| [`26c9d906`](https://github.com/NixOS/nixos-hardware/commit/26c9d906630821f49ca7ee755bf745f7fdb406ca) | `` lenovo/yoga/7/14ILL10: update kernel version requirement ``                    |
| [`f30fc54b`](https://github.com/NixOS/nixos-hardware/commit/f30fc54b0ea2039cbd06342ffcba1faa665931e6) | `` surface: linux 6.15.6 -> 6.15.9 ``                                             |
| [`28fc4150`](https://github.com/NixOS/nixos-hardware/commit/28fc41508c1fa7c7b1f13e2e3f81f7dcdbf7c883) | `` lenovo-legion-15ach6h: added hybrid and nvidia configurations ``               |
| [`85070738`](https://github.com/NixOS/nixos-hardware/commit/85070738e9016a53f834b1804d63d5024be05ed7) | `` macbook-pro/8-1: remove redundant line in readme ``                            |
| [`1f7ed621`](https://github.com/NixOS/nixos-hardware/commit/1f7ed6211f956ceaa2261e89f5c17d61b2dc521a) | `` macbook-pro/12-1: remove redundant bracket in readme ``                        |
| [`c46bd952`](https://github.com/NixOS/nixos-hardware/commit/c46bd952e9d3645913ebc587619be271645c181f) | `` Forgot to add lib.mkDefault ``                                                 |
| [`25fdfb36`](https://github.com/NixOS/nixos-hardware/commit/25fdfb36a7db4e468a246b55c36a8bf0c99e43cb) | `` Adding Power Management on Asus fa507nv ``                                     |