### PR TITLE
chore(flake/home-manager): `29ab63bb` -> `e31db614`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756734952,
-        "narHash": "sha256-H6jmduj4QIncLPAPODPSG/8ry9lpr1kRq6fYytU52qU=",
+        "lastModified": 1756777514,
+        "narHash": "sha256-BVCWCoYNCqTt8UuEUbsHJmwjEOGjKatbrBTlLg2rwzU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29ab63bbb3d9eee4a491f7ce701b189becd34068",
+        "rev": "e31db6141e47f1007a54bc9e4d8b2a26a9fbd697",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`e31db614`](https://github.com/nix-community/home-manager/commit/e31db6141e47f1007a54bc9e4d8b2a26a9fbd697) | `` Translate using Weblate (Hindi) `` |
| [`aa35affc`](https://github.com/nix-community/home-manager/commit/aa35affc6f8561bed3dd6ca67fc9d1a7d01a8233) | `` Translate using Weblate (Hindi) `` |
| [`9bd58094`](https://github.com/nix-community/home-manager/commit/9bd580947cdd01f30f043d827cef7b6ac8733f7a) | `` Translate using Weblate (Hindi) `` |
| [`e7c24fc5`](https://github.com/nix-community/home-manager/commit/e7c24fc522443c402b21b25f8cd78ec90d238ee2) | `` Translate using Weblate (Dutch) `` |