### PR TITLE
chore(flake/home-manager): `e31db614` -> `f3d3b459`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756777514,
-        "narHash": "sha256-BVCWCoYNCqTt8UuEUbsHJmwjEOGjKatbrBTlLg2rwzU=",
+        "lastModified": 1756788591,
+        "narHash": "sha256-LOrOfPWpJU/ADWDyVwPv9XNuYPq5KJtmAmSzplpccmE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e31db6141e47f1007a54bc9e4d8b2a26a9fbd697",
+        "rev": "f3d3b4592a73fb64b5423234c01985ea73976596",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f3d3b459`](https://github.com/nix-community/home-manager/commit/f3d3b4592a73fb64b5423234c01985ea73976596) | `` news: add hyprland submap entry ``                   |
| [`06179315`](https://github.com/nix-community/home-manager/commit/061793150a092e24315d14ff9e06510889849e75) | `` tests/hyprland: add submap test ``                   |
| [`5f64bccc`](https://github.com/nix-community/home-manager/commit/5f64bcccef6d54a8fda5f70b29a3a423596c90ea) | `` hyprland: tweak submap line formatting ``            |
| [`1ecfd8e5`](https://github.com/nix-community/home-manager/commit/1ecfd8e5626b27a9610f468be32cd6a7011f56a0) | `` hyprland: add support for submaps (#6062) (#7277) `` |