### PR TITLE
chore(flake/nh): `5d53f2b8` -> `f3095b9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756701567,
-        "narHash": "sha256-v32Ns4zmQgO/ILCeEPxxbOOGCDYNtam4QGBX6mjfZLI=",
+        "lastModified": 1756801442,
+        "narHash": "sha256-uNaSFIlyJRsvcMNoN7gxkhr7V6gORtQVUEfFQnwTdWQ=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "5d53f2b8c3e6b3a88576bd347d0de2d048f5dace",
+        "rev": "f3095b9f00092717a694f39a2723fb04e3f575e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                               |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f28f52e0`](https://github.com/nix-community/nh/commit/f28f52e05855e6313cf5d6505585dc2de45f0b56) | `` gitignore: fix `gen*` pattern wrongly excludes `generations.rs` `` |