### PR TITLE
chore(flake/home-manager): `f3d3b459` -> `30fc1b53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756788591,
-        "narHash": "sha256-LOrOfPWpJU/ADWDyVwPv9XNuYPq5KJtmAmSzplpccmE=",
+        "lastModified": 1756842514,
+        "narHash": "sha256-XbtRMewPGJwTNhBC4pnBu3w/xT1XejvB0HfohC2Kga8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f3d3b4592a73fb64b5423234c01985ea73976596",
+        "rev": "30fc1b532645a21e157b6e33e3f8b4c154f86382",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`30fc1b53`](https://github.com/nix-community/home-manager/commit/30fc1b532645a21e157b6e33e3f8b4c154f86382) | `` nix-init: ensure settings example produces a valid configuration `` |
| [`a1316b0a`](https://github.com/nix-community/home-manager/commit/a1316b0a77ef3e082a75bc5dc685c249b3c25f2c) | `` new: add swappy entry ``                                            |
| [`1a6f6fb4`](https://github.com/nix-community/home-manager/commit/1a6f6fb4091a6eb9c3bae8bac6d233f6ee51d489) | `` swappy: add module ``                                               |