### PR TITLE
chore(flake/nixos-hardware): `47eb4856` -> `ba6fab29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1756750488,
-        "narHash": "sha256-e4ZAu2sjOtGpvbdS5zo+Va5FUUkAnizl4wb0/JlIL2I=",
+        "lastModified": 1756925795,
+        "narHash": "sha256-kUb5hehaikfUvoJDEc7ngiieX88TwWX/bBRX9Ar6Tac=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "47eb4856cfd01eaeaa7bb5944a0f27db8fb9b94a",
+        "rev": "ba6fab29768007e9f2657014a6e134637100c57d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
| [`4091b501`](https://github.com/NixOS/nixos-hardware/commit/4091b501aa0953259197f588bb89019a506936f3) | `` Add HP ProBook 460 G11 to hardware table in /README.md ``                                                 |
| [`4a395855`](https://github.com/NixOS/nixos-hardware/commit/4a395855464bd8740cff5d6b3be5b5a57d5a5013) | `` Add HP ProBook 460 G11 ``                                                                                 |
| [`2dbfb943`](https://github.com/NixOS/nixos-hardware/commit/2dbfb943a027f47552a8725f995e211c6a04c95f) | `` bsp update for imx8mp-evk ``                                                                              |
| [`2f7f1dc6`](https://github.com/NixOS/nixos-hardware/commit/2f7f1dc6ec1f3ef483eec820d2f0ffca3af63b1d) | `` renamed flake modules in README.md to match them in flake.nix; add missing nixos modules to flake.nix; `` |
| [`cd3d24b0`](https://github.com/NixOS/nixos-hardware/commit/cd3d24b038b375208dbf204ca71131764b8b4ea8) | `` Add Framework Laptop 16 AMD AI 300 Series ``                                                              |
| [`ebd8f57c`](https://github.com/NixOS/nixos-hardware/commit/ebd8f57cd95295264da6b92537c28c6e654fddf4) | `` Fix probe id and switch from sync to offload ``                                                           |
| [`b90855f9`](https://github.com/NixOS/nixos-hardware/commit/b90855f92a87c0e3b849004396baf178dd801ff9) | `` Added Dell Precision 5570 ``                                                                              |
| [`6015af43`](https://github.com/NixOS/nixos-hardware/commit/6015af43f34b6cf943adc29cbbc7acf85983cb1f) | `` raspberry-pi/4: support 4lane csi ``                                                                      |