### PR TITLE
chore(flake/nh): `f3095b9f` -> `edfb8c45`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756801442,
-        "narHash": "sha256-uNaSFIlyJRsvcMNoN7gxkhr7V6gORtQVUEfFQnwTdWQ=",
+        "lastModified": 1757071548,
+        "narHash": "sha256-2vw03vnEN5Fe6tCbzOKQoMbKJ6DJhP16duzd+IZNkXk=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "f3095b9f00092717a694f39a2723fb04e3f575e0",
+        "rev": "edfb8c459b3d4f0afb4dfdd026e05278ce1eeffe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                  |
| ------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d8798c2b`](https://github.com/nix-community/nh/commit/d8798c2b01fc2d322c77f56aa5a1ea007607c2f9) | `` fix: support to other privilege elevation programs `` |