### PR TITLE
chore(flake/stylix): `584d9c57` -> `5c34e203`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -716,11 +716,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1756960927,
-        "narHash": "sha256-iG2DUobrDPzuVpDVHyqph1jtgAS0XOg1x8KGdsEkBms=",
+        "lastModified": 1757096054,
+        "narHash": "sha256-bpPZL0cY5JcRf5sc1t4oSlgaZRRpFsahcNVUu+YWPoE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "584d9c57a8550bace5ffa2901dfebbde367bea54",
+        "rev": "5c34e203c57bcbaaf3d9e5c60a4a584f5bcc4f12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`5c34e203`](https://github.com/nix-community/stylix/commit/5c34e203c57bcbaaf3d9e5c60a4a584f5bcc4f12) | `` gnome: get extension UUID from package metadata (#1876) `` |