### PR TITLE
chore(flake/nixos-hardware): `7e56e39d` -> `af3dd1cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757081837,
-        "narHash": "sha256-wAgZ+BaRR/cqmKP0bWnJ9rO9KLz91R5aOdJiT+k/J2E=",
+        "lastModified": 1757094860,
+        "narHash": "sha256-OeMwZhwSnLJxRwzGUTBy5ZYvWoSN64IMNyp/Bgu43os=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "7e56e39db4008521552e9d2b0d9ae9bf8e0cdce2",
+        "rev": "af3dd1cb201703103896bb52991927bbef0810b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`e9db0225`](https://github.com/NixOS/nixos-hardware/commit/e9db02252a3bdccb1031ec0f7ecddadd0d308401) | `` fydetab/duo: fix typo with enable option `` |