### PR TITLE
chore(flake/nh): `2b2c678a` -> `036c141e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757074697,
-        "narHash": "sha256-pcUB+M2cRod2M2tHfkQziVHpP62Ns5uv/xC2AtX3WfU=",
+        "lastModified": 1757153783,
+        "narHash": "sha256-HtnGRQX7BCze1eNlcc5ejAMExPk4DSqBPh6j2Byov7E=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "2b2c678a7c99c81e7f8ad300c25500ef0bf243e7",
+        "rev": "036c141e2f14fb481f12c4d1498bc5d03d9e1865",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`036c141e`](https://github.com/nix-community/nh/commit/036c141e2f14fb481f12c4d1498bc5d03d9e1865) | `` chore: format rustfmt config with taplo ``                          |
| [`24990d71`](https://github.com/nix-community/nh/commit/24990d71c5eea35e9dbce068ef8f89f519b7eada) | `` chore: bump all dependencies ``                                     |
| [`f50c05e1`](https://github.com/nix-community/nh/commit/f50c05e1801651034d0874bbb6a7bffe32421c6b) | `` build(deps): bump beatlabs/delete-old-branches-action ``            |
| [`c895642e`](https://github.com/nix-community/nh/commit/c895642ed6f9c0d57594414eb46efe6d3d596a20) | `` build(deps): bump actions/checkout from 3 to 5 ``                   |
| [`fa10b000`](https://github.com/nix-community/nh/commit/fa10b0003d52b18c5a38fb4f1f05108ed5c4000e) | `` ci: set up dependabot ``                                            |
| [`5d523aa3`](https://github.com/nix-community/nh/commit/5d523aa32716284fe7bb247f37815e2d7d44fbd4) | `` treewide: format with new rustfmt configuration ``                  |
| [`efa6fa67`](https://github.com/nix-community/nh/commit/efa6fa674e8849363ed372443dcbfecea5af71e2) | `` meta: move rustfmt config to a dotfile ``                           |
| [`43479277`](https://github.com/nix-community/nh/commit/4347927796a587bc6cdcd1393e81d06a194078b0) | `` docs: mention new privilege escalation improvements in changelog `` |