### PR TITLE
chore(flake/stylix): `f6e9a1b6` -> `9991299f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -716,11 +716,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1757119848,
-        "narHash": "sha256-DxxKBdP6MFleepcB1hsQYU4cHvvFTekFWlomqot7k9A=",
+        "lastModified": 1757172691,
+        "narHash": "sha256-VOn/s24rb+iO6auhmGfT5kyr0ixRK6weBsNCKkGo2yY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f6e9a1b62457efcbf48a09aafbf7233f306fcdc9",
+        "rev": "9991299fe9aad330fb6b96bb58def37033271177",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`9991299f`](https://github.com/nix-community/stylix/commit/9991299fe9aad330fb6b96bb58def37033271177) | `` ci: bump actions/labeler from 5.0.0 to 6.0.1 (#1883) ``       |
| [`f544772a`](https://github.com/nix-community/stylix/commit/f544772a6064cc5dea7ab93b6551db868531d6ce) | `` ci: bump actions/github-script from 7.0.1 to 8.0.0 (#1882) `` |
| [`c1ac8e9b`](https://github.com/nix-community/stylix/commit/c1ac8e9b3f96648e065fead56c63d8023b89a47d) | `` blender: add more versions (#1886) ``                         |