### PR TITLE
chore(flake/nix-index-database): `3fe768e1` -> `b33c3aad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756612744,
-        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
+        "lastModified": 1757215509,
+        "narHash": "sha256-wCp1wHGzTSTtY3A8BLEJKRqbnD2oFlBBD4NKwZimRqw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
+        "rev": "b33c3aadca9343dbbcba8be71cb741d095aab8a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`b33c3aad`](https://github.com/nix-community/nix-index-database/commit/b33c3aadca9343dbbcba8be71cb741d095aab8a9) | `` flake.lock: Update `` |