### PR TITLE
chore(flake/nix-index-database): `b33c3aad` -> `9b144dc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757215509,
-        "narHash": "sha256-wCp1wHGzTSTtY3A8BLEJKRqbnD2oFlBBD4NKwZimRqw=",
+        "lastModified": 1757218147,
+        "narHash": "sha256-IwOwN70HvoBNB2ckaROxcaCvj5NudNc52taPsv5wtLk=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b33c3aadca9343dbbcba8be71cb741d095aab8a9",
+        "rev": "9b144dc3ef6e42b888c4190e02746aab13b0e97f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`9b144dc3`](https://github.com/nix-community/nix-index-database/commit/9b144dc3ef6e42b888c4190e02746aab13b0e97f) | `` update generated.nix to release 2025-09-07-032516 `` |