### PR TITLE
chore(flake/nh): `036c141e` -> `450cc45d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757153783,
-        "narHash": "sha256-HtnGRQX7BCze1eNlcc5ejAMExPk4DSqBPh6j2Byov7E=",
+        "lastModified": 1757249208,
+        "narHash": "sha256-2hVyIgE6iBGUiepRhvYWnTr9lmVW6uK76Nh0IfNLgNE=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "036c141e2f14fb481f12c4d1498bc5d03d9e1865",
+        "rev": "450cc45d0c71b9e1cc215780f10e4e970c5a6975",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                             |
| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`450cc45d`](https://github.com/nix-community/nh/commit/450cc45d0c71b9e1cc215780f10e4e970c5a6975) | `` docs: mention environment vars used to control NH in README ``   |
| [`def8fe0e`](https://github.com/nix-community/nh/commit/def8fe0e6271c783f75f78b376ea858052543b84) | `` chore: bump version ``                                           |
| [`582552a1`](https://github.com/nix-community/nh/commit/582552a12293f3f0c86f604cf9046eb8d7bdfe48) | `` commands: store passwords in memory using `SecretString` ``      |
| [`540b3bcc`](https://github.com/nix-community/nh/commit/540b3bcc68d4f7f3b6124ec8cea3ee7ede974853) | `` docs: fix wording in CHANGELOG ``                                |
| [`64ae969c`](https://github.com/nix-community/nh/commit/64ae969c71a9320927216365f80a7904b8323ad0) | `` commands: ask for SSH password locally for remote deployments `` |