### PR TITLE
chore(flake/lovesegfault-vim-config): `8fcccca4` -> `a725ee16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757203719,
-        "narHash": "sha256-74ih5FJJcVwODZVytmT8g49Q4GFQ4aGXkXlblyixFYo=",
+        "lastModified": 1757290070,
+        "narHash": "sha256-dMI/fAQsLKfas9HREDJSbxLa7BkIvmHTFucqaxqHu7k=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "8fcccca44ca96eafa41ee42b26e54fadb681bdc8",
+        "rev": "a725ee1618a1d076fa5c2a544f0e978568add0e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                            |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`a725ee16`](https://github.com/lovesegfault/vim-config/commit/a725ee1618a1d076fa5c2a544f0e978568add0e8) | `` chore(flake/git-hooks): e891a93b -> ab82ab08 `` |