### PR TITLE
chore(flake/stylix): `9991299f` -> `834a743c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -716,11 +716,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1757172691,
-        "narHash": "sha256-VOn/s24rb+iO6auhmGfT5kyr0ixRK6weBsNCKkGo2yY=",
+        "lastModified": 1757360005,
+        "narHash": "sha256-VwzdFEQCpYMU9mc7BSQGQe5wA1MuTYPJnRc9TQCTMcM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9991299fe9aad330fb6b96bb58def37033271177",
+        "rev": "834a743c11d66ea18e8c54872fbcc72ce48bc57f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`5575b88d`](https://github.com/nix-community/stylix/commit/5575b88d6daf8b9721907ecbca82a5f5536d35fa) | `` river: leverage config.lib.stylix.mkOpacityHexColor ``                    |
| [`1a83d26d`](https://github.com/nix-community/stylix/commit/1a83d26d4cdb67c401d4223c886e55543b29be67) | `` stylix: add config.lib.stylix.{mkHexColor,mkOpacityHexColor} functions `` |