### PR TITLE
chore(flake/nh): `450cc45d` -> `440d3a69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757249208,
-        "narHash": "sha256-2hVyIgE6iBGUiepRhvYWnTr9lmVW6uK76Nh0IfNLgNE=",
+        "lastModified": 1757354666,
+        "narHash": "sha256-GqePFa+v6dzZD+Y4ri/8i1lgFaaew+76IBjREWfaTeY=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "450cc45d0c71b9e1cc215780f10e4e970c5a6975",
+        "rev": "440d3a6928996b484e17afb0c417642a7e482bfe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                               |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`440d3a69`](https://github.com/nix-community/nh/commit/440d3a6928996b484e17afb0c417642a7e482bfe) | `` docs: rename 'unreleased' section to latest tag `` |
| [`54ff943b`](https://github.com/nix-community/nh/commit/54ff943bbf62c9db4f1398b771cf1ac6e2cbafe4) | `` chore: format with taplo again ``                  |
| [`5e04bd57`](https://github.com/nix-community/nh/commit/5e04bd5723bb547bd404752ed629c02b89f06645) | `` chore: bump crate version ``                       |
| [`29cf5664`](https://github.com/nix-community/nh/commit/29cf56641888ada4733f2f52a9cfaa79c8dc75e8) | `` chore: bump dependencies ``                        |