### PR TITLE
chore(flake/home-manager): `f35703b4` -> `26993d87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757256385,
-        "narHash": "sha256-WK7tOhWwr15mipcckhDg2no/eSpM1nIh4C9le8HgHhk=",
+        "lastModified": 1757385184,
+        "narHash": "sha256-LCxtQn9ajvOgGRbQIRUJgfP7clMGGvV1SDW1HcSb0zk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f35703b412c67b48e97beb6e27a6ab96a084cd37",
+        "rev": "26993d87fd0d3b14f7667b74ad82235f120d986e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`26993d87`](https://github.com/nix-community/home-manager/commit/26993d87fd0d3b14f7667b74ad82235f120d986e) | `` ci: bump actions/labeler from 5 to 6 ``    |
| [`d2881029`](https://github.com/nix-community/home-manager/commit/d28810298c27951ea8f52052d75d36ae86b8a5e8) | `` maintainers: update all-maintainers.nix `` |