### PR TITLE
chore(flake/home-manager): `d587e11c` -> `a60021a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757443987,
-        "narHash": "sha256-T7E4CIsZBUzrUcPRyTG9FA2xd48MtbQ/HpIaaCfwZwc=",
+        "lastModified": 1757475826,
+        "narHash": "sha256-x6x30IzUOxKmOtE0KzQu9UxLrxg0HLurd5rpak62OL0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d587e11cef9caa9484ed090eddc55f4c56908342",
+        "rev": "a60021a8c99bf5a28919c0a9fbb6b04422a6a8da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a60021a8`](https://github.com/nix-community/home-manager/commit/a60021a8c99bf5a28919c0a9fbb6b04422a6a8da) | `` pianobar: add module to create config file (#7734) ``                |
| [`ede1f891`](https://github.com/nix-community/home-manager/commit/ede1f891c01b948bdbdde507cffa1fc3497f329b) | `` Translate using Weblate (Polish) (#7797) ``                          |
| [`0c7c71a2`](https://github.com/nix-community/home-manager/commit/0c7c71a2128000a8596495ec0b8841cf7407bb60) | `` oh-my-posh: add cache clearing on package version changes (#7757) `` |