### PR TITLE
chore(flake/tinted-schemes): `097d751b` -> `4d4a8b9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -826,11 +826,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1754779259,
-        "narHash": "sha256-8KG2lXGaXLUE0F/JVwLQe7kOVm21IDfNEo0gfga5P4M=",
+        "lastModified": 1757482789,
+        "narHash": "sha256-TKV6qMibFOYMW1Imx5BvKBTTyCckEP4XButR5tbvRfA=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "097d751b9e3c8b97ce158e7d141e5a292545b502",
+        "rev": "4d4a8b9a0e13e01520466b734268c775a965c966",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                            |
| ------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`4d4a8b9a`](https://github.com/tinted-theming/schemes/commit/4d4a8b9a0e13e01520466b734268c775a965c966) | `` Create hardhacker.yaml (#77) `` |