### PR TITLE
chore(flake/nh): `440d3a69` -> `a7d8a3ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757354666,
-        "narHash": "sha256-GqePFa+v6dzZD+Y4ri/8i1lgFaaew+76IBjREWfaTeY=",
+        "lastModified": 1757505144,
+        "narHash": "sha256-ZYlFuJO0gOeWGgClBfAI7quhfmpksQspoOp66gEhdPc=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "440d3a6928996b484e17afb0c417642a7e482bfe",
+        "rev": "a7d8a3ff279d52236632f8fab33017f74cc3a9dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                           |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`201eba5d`](https://github.com/nix-community/nh/commit/201eba5d39d9fbdecc0e686e0d7c9d8d5bc5c31a) | `` meta: fix readme grammar errors found by @coderabbitai ``      |
| [`04040b14`](https://github.com/nix-community/nh/commit/04040b1498c31fbc5123f00674d0d18e5c76f820) | `` meta: fix pull request template typos ``                       |
| [`77c52015`](https://github.com/nix-community/nh/commit/77c52015b23830b48b85698a3e26ccf6d23cbc47) | `` meta: update broken changelog link in pull request template `` |
| [`aa9d11fc`](https://github.com/nix-community/nh/commit/aa9d11fc405b1c093b9c55038cdcd510d11c1df5) | `` meta: fix a few typos in the README ``                         |