### PR TITLE
chore(flake/home-manager): `e0154ae4` -> `b7112b12`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757529548,
-        "narHash": "sha256-If5AT3dPXH0BM+q+pwyZvtWLTmlqJmGW6IDZ2MqlGRU=",
+        "lastModified": 1757578556,
+        "narHash": "sha256-w1PGkTGow5XzsjccV364No46rkuGxTqo7m/4cfhnkIk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e0154ae41614e32a443c43ee51eee9eed3ad9a48",
+        "rev": "b7112b12ea5b8c3aa6af344498ed9ca27dd03ba3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`61124583`](https://github.com/nix-community/home-manager/commit/61124583121108b5927d73247df663a7ddc4fdf6) | `` dunst: fix deprecated configuration in example ``       |
| [`584fccfd`](https://github.com/nix-community/home-manager/commit/584fccfdfa32e720295ec456146b1a18567eda8e) | `` dunst: add tests ``                                     |
| [`174ba89c`](https://github.com/nix-community/home-manager/commit/174ba89ccbbfd9fbae185cf6e8ae6ca88ba3e51d) | `` dunst: use dbus service file from configured package `` |
| [`5cd2bf51`](https://github.com/nix-community/home-manager/commit/5cd2bf5153a878342c0e6df16d739ba201f750e6) | `` dunst: support reload on configuration change ``        |