### PR TITLE
chore(flake/nixpkgs): `b599843b` -> `ab0f3607`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757347588,
-        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
+        "lastModified": 1757487488,
+        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
+        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`5449eb3a`](https://github.com/NixOS/nixpkgs/commit/5449eb3a6997f48bd109d1add071e90e1dbc3774) | `` lasuite-meet{,-frontend}: 0.1.34 -> 0.1.35 ``                     |
| [`5f746cb2`](https://github.com/NixOS/nixpkgs/commit/5f746cb259a8608c0acb2f146cca4584f3dfade1) | `` rust: add powerpc-linux as a target platform ``                   |
| [`b6d48619`](https://github.com/NixOS/nixpkgs/commit/b6d48619ed872c60d3008665c2a5b94e0a6b2b7a) | `` lib.systems: add ppc32 target ``                                  |
| [`69cde4d5`](https://github.com/NixOS/nixpkgs/commit/69cde4d543f12ac55c47987b67412ddd10ac5bb3) | `` gcc: fix powerpc-linux cross compilers ``                         |
| [`e64a95d9`](https://github.com/NixOS/nixpkgs/commit/e64a95d943652629730e0d8d398e4b2cc68cdb2a) | `` qemu: 10.0.3 -> 10.1.0 ``                                         |
| [`718d792b`](https://github.com/NixOS/nixpkgs/commit/718d792beeaad81fbeb93c9a6bca04f313c2ae43) | `` linux_5_4: 5.4.298 -> 5.4.299 ``                                  |
| [`7170de33`](https://github.com/NixOS/nixpkgs/commit/7170de339b349d61dd20d5a47cc1bb520475008e) | `` linux_5_10: 5.10.242 -> 5.10.243 ``                               |
| [`df887423`](https://github.com/NixOS/nixpkgs/commit/df8874236095a9a8784a025b06d33960bf7e4608) | `` linux_5_15: 5.15.191 -> 5.15.192 ``                               |
| [`f2020308`](https://github.com/NixOS/nixpkgs/commit/f20203081d2dc219d29a0fe2e4fe94bad0be9737) | `` linux_6_1: 6.1.150 -> 6.1.151 ``                                  |
| [`fee92324`](https://github.com/NixOS/nixpkgs/commit/fee9232449a108d731ec9bc4e0f9e7c72ce8cf49) | `` linux_6_6: 6.6.104 -> 6.6.105 ``                                  |
| [`7f7d17a7`](https://github.com/NixOS/nixpkgs/commit/7f7d17a771743253c4a7dcdadabc484bee8c8ef1) | `` linux_6_12: 6.12.45 -> 6.12.46 ``                                 |
| [`6a0b5259`](https://github.com/NixOS/nixpkgs/commit/6a0b5259d2c8749e402394604318cf030f0d7583) | `` linux_6_16: 6.16.5 -> 6.16.6 ``                                   |
| [`222cacca`](https://github.com/NixOS/nixpkgs/commit/222caccafe5f07827af33fbefc527b2ca1818456) | `` linux_testing: 6.17-rc4 -> 6.17-rc5 ``                            |
| [`64503e53`](https://github.com/NixOS/nixpkgs/commit/64503e53414e70744d8e5cd5b9541ffec9544e8a) | `` gitlab-container-registry: fix by pinning back to go 1.24 ``      |
| [`1ddb8960`](https://github.com/NixOS/nixpkgs/commit/1ddb89603939503df136268a0bd3d2a0b3755521) | `` nixos/release-notes: add new module entry for Sshwifty ``         |
| [`e758231d`](https://github.com/NixOS/nixpkgs/commit/e758231d105d441f37b661e77e96cfca4ed3a043) | `` sshwifty: add NixOS test ``                                       |
| [`3a6eb5b0`](https://github.com/NixOS/nixpkgs/commit/3a6eb5b0e361eb097bde5ef4e5d9abc74fa7f969) | `` nixos/sshwifty: init test ``                                      |
| [`695b0bfb`](https://github.com/NixOS/nixpkgs/commit/695b0bfbe3099009529a0fa3dc00dc0e285868cf) | `` nixos/sshwifty: init module ``                                    |
| [`24eb583c`](https://github.com/NixOS/nixpkgs/commit/24eb583cc94c5b3301163325d9cdd74a4c1709cd) | `` herwig: fix build by providing --with-boost (#441326) ``          |
| [`59cf39c4`](https://github.com/NixOS/nixpkgs/commit/59cf39c4eeaf93044e07275844b3704a18799897) | `` zed-editor: 0.202.7 -> 0.202.8 ``                                 |
| [`cda82db1`](https://github.com/NixOS/nixpkgs/commit/cda82db150841f5b35ad59648d2ea29e663e9b4f) | `` python3Packages.niquests: init at 3.15.2 ``                       |
| [`f2357009`](https://github.com/NixOS/nixpkgs/commit/f2357009792624063213e836faa7cb7d66a60146) | `` python3Packages.wassima: init at 2.0.1 ``                         |
| [`dd4af1f3`](https://github.com/NixOS/nixpkgs/commit/dd4af1f390e925751198b374a2308da87be7883a) | `` python3Packages.urllib3-future: init at 2.13.907 ``               |
| [`e6c2a6cd`](https://github.com/NixOS/nixpkgs/commit/e6c2a6cd6463523cce9eb2eee41c88d77349ccac) | `` paq: 1.1.1 -> 1.2.0 ``                                            |
| [`f98fe9dd`](https://github.com/NixOS/nixpkgs/commit/f98fe9dd4d6571b3b6136ff6124399a9d26a77b8) | `` writers.writeBash(Bin): use bashNonInteractive as interpreter ``  |
| [`2dc031fa`](https://github.com/NixOS/nixpkgs/commit/2dc031fafbd4f8ba01be7a4b02231f83d0a9e3bf) | `` gh: 2.78.0 -> 2.79.0 ``                                           |
| [`04da6921`](https://github.com/NixOS/nixpkgs/commit/04da692121e320e5fe1a34394a4ddbcc14a9ca99) | `` uutils-coreutils: 0.2.0 -> 0.2.2 ``                               |
| [`09669ef9`](https://github.com/NixOS/nixpkgs/commit/09669ef9d243437185db488851779592573b6717) | `` awsbck: 0.3.15 -> 1.0.0 ``                                        |
| [`c5959065`](https://github.com/NixOS/nixpkgs/commit/c5959065a18f28fd6ddab81a68727927bfac77c0) | `` dokuwiki: 2025-05-14a -> 2025-05-14b ``                           |
| [`661b4801`](https://github.com/NixOS/nixpkgs/commit/661b48015a99534e5f270cc7970e0c3350ccb2cd) | `` wl-screenrec: 0.1.7 -> 0.2.0 ``                                   |
| [`6fca8013`](https://github.com/NixOS/nixpkgs/commit/6fca8013764906170d431f4e7f6a5ac6aa22d572) | `` julia-mono: 0.060 -> 0.061 ``                                     |
| [`99f608a8`](https://github.com/NixOS/nixpkgs/commit/99f608a8e2d2099b08debc9d9cd0951ba645dc31) | `` gyb: 1.82 -> 1.95 ``                                              |
| [`f780a3d0`](https://github.com/NixOS/nixpkgs/commit/f780a3d078b2ca7d477ddec53200228caa6aacfe) | `` python313Packages.aiosmtplib: 4.0.1 -> 4.0.2 ``                   |
| [`5594b662`](https://github.com/NixOS/nixpkgs/commit/5594b66225a55470cf664dfbff1fc26b3980f1a6) | `` ocamlPackages.menhir: 20240715 → 20250903 ``                      |
| [`5a6c7261`](https://github.com/NixOS/nixpkgs/commit/5a6c726111fcdde30e70b9404f0e2b044107aaaf) | `` python313Packages.avidtools: modernize ``                         |
| [`b5a8a16f`](https://github.com/NixOS/nixpkgs/commit/b5a8a16f7d110ad7393c6affa11486cf3ea8d3e0) | `` python313Packages.avidtools: add changelog entry to meta ``       |
| [`61ae1849`](https://github.com/NixOS/nixpkgs/commit/61ae18498c616375bbb5be82ac88af86c56716f3) | `` rosa: 1.2.55 -> 1.2.56 ``                                         |
| [`9b754ced`](https://github.com/NixOS/nixpkgs/commit/9b754ced3a520d94429164c50a67fec73444b201) | `` minio-client: 2025-07-21T05-28-08Z -> 2025-08-13T08-35-41Z ``     |
| [`82139057`](https://github.com/NixOS/nixpkgs/commit/82139057436e2cf9cb6497a6b967719371b973a7) | `` plantuml: 1.2025.4 -> 1.2025.7 ``                                 |
| [`f13dcb12`](https://github.com/NixOS/nixpkgs/commit/f13dcb1213b9b65d1017e4e455cefa63ff5b721f) | `` python313Packages.nvdlib: 0.8.1 -> 0.8.3 ``                       |
| [`9971e539`](https://github.com/NixOS/nixpkgs/commit/9971e539cb94cf46f8913dda60265bd953cad938) | `` python313Packages.jsonargparse: update changelog enty ``          |
| [`69d9508d`](https://github.com/NixOS/nixpkgs/commit/69d9508d780ca87c922be52aef21e1a2b6f5241f) | `` openrefine: 3.9.3 -> 3.9.5 ``                                     |
| [`4ad3615c`](https://github.com/NixOS/nixpkgs/commit/4ad3615cc4b3ce9fd811acbba4ce1f51366252db) | `` botamusqiue: fix runtime deps for python313 ``                    |
| [`439e8b21`](https://github.com/NixOS/nixpkgs/commit/439e8b21eda5ec09ba7da1198e7ce0b8da89beeb) | `` python3Packages.llama-index-readers-file: 0.5.2 -> 0.5.4 ``       |
| [`3d4fb2c3`](https://github.com/NixOS/nixpkgs/commit/3d4fb2c3e6adada942b4566fe09fcf48b03eeefe) | `` fetchurl: Add missing arg to `toPretty` invocation ``             |
| [`8f194d5d`](https://github.com/NixOS/nixpkgs/commit/8f194d5d431819a8ab679cc664824528dbbe390b) | `` openstack-rs: 0.13.0 -> 0.13.1 ``                                 |
| [`046a4bd1`](https://github.com/NixOS/nixpkgs/commit/046a4bd1dfdabebb498a6695e5c8069cc32cb2f4) | `` hcxdumptool: 7.0.0 -> 7.0.1 ``                                    |
| [`30b14dc9`](https://github.com/NixOS/nixpkgs/commit/30b14dc9db11f8dd2620236d8cd25860781d0475) | `` maintainers: add arcstur ``                                       |
| [`096fd16d`](https://github.com/NixOS/nixpkgs/commit/096fd16d57be035d75fcdd6f050f4256f2c1375a) | `` talosctl: 1.11.0 -> 1.11.1 ``                                     |
| [`c328fa86`](https://github.com/NixOS/nixpkgs/commit/c328fa86d65ae4a7d0632dd0b0eb569a75eaa361) | `` crosvm: 0-unstable-2025-08-28 -> 0-unstable-2025-09-09 ``         |
| [`61db2e4b`](https://github.com/NixOS/nixpkgs/commit/61db2e4b3a18a68ca6d3e506166dc9113241fc96) | `` nnd: 0.45 -> 0.46 ``                                              |
| [`715ed806`](https://github.com/NixOS/nixpkgs/commit/715ed80669d6a15163ad1b9cf297fb4f7fc52dc4) | `` nats-server: 2.11.8 -> 2.11.9 ``                                  |
| [`f27409cd`](https://github.com/NixOS/nixpkgs/commit/f27409cdf86d9273a89232376df204e26333a63a) | `` kiro: 0.2.13 -> 0.2.38 ``                                         |
| [`f2d190e2`](https://github.com/NixOS/nixpkgs/commit/f2d190e221f1dd6d625fb643d46652b4e918027c) | `` packer: 1.14.1 -> 1.14.2 ``                                       |
| [`9cbbf14f`](https://github.com/NixOS/nixpkgs/commit/9cbbf14ff9daa002353f7b979e4de22ef44f61c5) | `` lintspec: 0.7.0 -> 0.7.1 ``                                       |
| [`f0536932`](https://github.com/NixOS/nixpkgs/commit/f053693286315bdb06903efc75efab9ced93667e) | `` python3Packages.elevenlabs: 2.12.1 -> 2.15.1 ``                   |
| [`2c867cf1`](https://github.com/NixOS/nixpkgs/commit/2c867cf1ed770155cd20654eff82a4afe2de2ebb) | `` yq-go: 4.47.1 -> 4.47.2 ``                                        |
| [`6483a3e0`](https://github.com/NixOS/nixpkgs/commit/6483a3e01223c98cd30cfe0fed4fde910d3ed4c6) | `` nixos/calibre-web: fix malformed environment variable ``          |
| [`654d2414`](https://github.com/NixOS/nixpkgs/commit/654d24144ad839f2febc403a8c41cbe3c6ab1d34) | `` tutanota-desktop: 304.250825.0 -> 304.250901.0 ``                 |
| [`86283ed3`](https://github.com/NixOS/nixpkgs/commit/86283ed33c9ef4723393569207f2d634b8b14215) | `` zipline: 4.3.0 -> 4.3.1 ``                                        |
| [`23f1db63`](https://github.com/NixOS/nixpkgs/commit/23f1db638cdd96f479516cfe7aea6eba461d6f8d) | `` matrix-synapse-unwrapped: allow setuptools_rust 1.12 ``           |
| [`b8055448`](https://github.com/NixOS/nixpkgs/commit/b80554483b281d4f93e32507fc07fade7755ae14) | `` fetchFromSourcehut: allow passthru args ``                        |
| [`c26b4b1c`](https://github.com/NixOS/nixpkgs/commit/c26b4b1c5128e202c86f19930a34232a2ba6c265) | `` pyfa: 2.63.1 -> 2.64.1 ``                                         |
| [`c949d4b4`](https://github.com/NixOS/nixpkgs/commit/c949d4b4bacba96346d6481b344de83384d9ed8e) | `` python3Packages.google-cloud-compute: 1.35.0 -> 1.37.0 ``         |
| [`c9c64965`](https://github.com/NixOS/nixpkgs/commit/c9c64965a96707f307ef04e0067f3a7976bba41f) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.857 -> 0.0.858 ``    |
| [`fe38fcf5`](https://github.com/NixOS/nixpkgs/commit/fe38fcf5b270c718b4831190f6404119f03b2224) | `` discord-canary: 0.0.751 -> 0.0.752 ``                             |
| [`a69946a8`](https://github.com/NixOS/nixpkgs/commit/a69946a83af8077b2e95e049a83c8f332455e27e) | `` apko: 0.30.6 -> 0.30.9 ``                                         |
| [`3e96324c`](https://github.com/NixOS/nixpkgs/commit/3e96324c461ce7345aeea2071f94527ba8e60f8f) | `` firefox-devedition-unwrapped: 143.0b8 -> 143.0b9 ``               |
| [`0fdb9ab0`](https://github.com/NixOS/nixpkgs/commit/0fdb9ab0386ac17c5e93480d93a0a0185eab8651) | `` firefox-beta-unwrapped: 143.0b8 -> 143.0b9 ``                     |
| [`0340fc70`](https://github.com/NixOS/nixpkgs/commit/0340fc70fd227db2a5ad35216b2e09f3a060f819) | `` python3Packages.llama-index-graph-stores-neo4j: 0.5.0 -> 0.5.1 `` |
| [`b86a67bd`](https://github.com/NixOS/nixpkgs/commit/b86a67bdd4f62de51d57742a4bcb9ea8e5bea178) | `` python3Packages.jsonargparse: 4.40.2 -> 4.41.0 ``                 |
| [`5c23f404`](https://github.com/NixOS/nixpkgs/commit/5c23f404337ca39943b279cca0118b1715e332e0) | `` lasuite-meet{,-frontend}: 0.1.33 -> 0.1.34 ``                     |
| [`ca3da948`](https://github.com/NixOS/nixpkgs/commit/ca3da94865c0e61e6b38d7bf7f856001854ae3a2) | `` haskellPackages.cabal2nix-unstable: 2025-06-14 -> 2025-09-06 ``   |
| [`4fce1788`](https://github.com/NixOS/nixpkgs/commit/4fce17888df0df369e4fe070cede828a9a0335a9) | `` nauty: 2.9.0 -> 2.9.1 ``                                          |
| [`9da01716`](https://github.com/NixOS/nixpkgs/commit/9da01716ef240668ca86c73d7d9c90de0f5db1e6) | `` python3Packages.django-tenants: 3.7.8 -> 3.9.0 ``                 |
| [`b19037ed`](https://github.com/NixOS/nixpkgs/commit/b19037edcd1729c4fa6b1a5b052952dad31182c8) | `` shpool: 0.9.1 -> 0.9.2 ``                                         |
| [`1f7c853d`](https://github.com/NixOS/nixpkgs/commit/1f7c853dac4527680e6a06fce4244a5511bb51e7) | `` solana-cli: 1.18.26 -> 2.3.8 ``                                   |
| [`713a26dd`](https://github.com/NixOS/nixpkgs/commit/713a26dd6697f62a176f6a6ab511f5a049370df8) | `` butane: 0.24.0 -> 0.25.0 ``                                       |
| [`301e5cca`](https://github.com/NixOS/nixpkgs/commit/301e5cca9cd670aacfca1c9df0babfd6c37e1bf9) | `` nixos/canaille: remove HTTP header X-XSS-Protection ``            |
| [`68851412`](https://github.com/NixOS/nixpkgs/commit/688514126ef6332e9fb1dec116eeff86ffdb6dc2) | `` unison-ucm: 0.5.42 -> 0.5.47 ``                                   |
| [`483208ee`](https://github.com/NixOS/nixpkgs/commit/483208ee9c4584b0fdc2a53f7c39b1601e36cd7e) | `` kdePackages.marble: unsplit outputs ``                            |
| [`b2314a5b`](https://github.com/NixOS/nixpkgs/commit/b2314a5b371b24c0beeeae9486a590a481ad4a88) | `` python3Packages.json-repair: 0.50.0 -> 0.50.1 ``                  |
| [`904c5e47`](https://github.com/NixOS/nixpkgs/commit/904c5e4792fd0f82a3bd083366f4942c1570738f) | `` kdePackages: Plasma 6.4.4 -> 6.4.5 ``                             |