### PR TITLE
chore(flake/home-manager): `b7112b12` -> `6d7c11a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757578556,
-        "narHash": "sha256-w1PGkTGow5XzsjccV364No46rkuGxTqo7m/4cfhnkIk=",
+        "lastModified": 1757598712,
+        "narHash": "sha256-5PWVrdMp8u31Q247jqnJcwxKg3MJrs1TadTyTBRVBDY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b7112b12ea5b8c3aa6af344498ed9ca27dd03ba3",
+        "rev": "6d7c11a0adee0db21e3a8ef90ae07bb89bc20b8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`6d7c11a0`](https://github.com/nix-community/home-manager/commit/6d7c11a0adee0db21e3a8ef90ae07bb89bc20b8f) | `` waybar: use X-Reload-Triggers `` |