### PR TITLE
chore(flake/nh): `a7d8a3ff` -> `a8182189`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757505144,
-        "narHash": "sha256-ZYlFuJO0gOeWGgClBfAI7quhfmpksQspoOp66gEhdPc=",
+        "lastModified": 1757656889,
+        "narHash": "sha256-WtmW6PeMEemuUSMEw7fnmsqRkFXkYALe5N2HaeV3hLg=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "a7d8a3ff279d52236632f8fab33017f74cc3a9dd",
+        "rev": "a8182189f854597652e2acfe5363876241af3511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                 |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`a8182189`](https://github.com/nix-community/nh/commit/a8182189f854597652e2acfe5363876241af3511) | `` nixos: allow specifying fields to display in `info` subcmd (#413) `` |