### PR TITLE
chore(flake/home-manager): `9eab59f3` -> `a3fcc921`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757650187,
-        "narHash": "sha256-OrythrqccPKtuVt0mj26rr83Qo3Ljb4ZmwLdPGjzjMU=",
+        "lastModified": 1757698511,
+        "narHash": "sha256-UqHHGydF/q3jfYXCpvYLA0TWtvByOp1NwOKCUjhYmPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9eab59f3e71ea3a725e4817d8dcf0da0824ad19d",
+        "rev": "a3fcc92180c7462082cd849498369591dfb20855",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`a3fcc921`](https://github.com/nix-community/home-manager/commit/a3fcc92180c7462082cd849498369591dfb20855) | `` jjui: add adda maintainer `` |
| [`69083b3c`](https://github.com/nix-community/home-manager/commit/69083b3cdd2e16825d928a800bf1812baad8b7a6) | `` jjui: init module ``         |