### PR TITLE
chore(flake/home-manager): `e286f848` -> `17a10049`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757808490,
-        "narHash": "sha256-p2NXpmIr6qd/qjD9asNF+n5XZ2d6na7JXYscVP+CIUY=",
+        "lastModified": 1757809953,
+        "narHash": "sha256-29mlXbfAJhz9cWVrPP4STvVPDVZFCfCOmaIN5lFJa+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e286f848a032a94b875af703f7b9ad77faf58b32",
+        "rev": "17a10049486f6698fca32097d8f52c0c895542b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`17a10049`](https://github.com/nix-community/home-manager/commit/17a10049486f6698fca32097d8f52c0c895542b0) | `` lsd: allow specifying a path type value for `icons` and `colors` options (#7733) `` |
| [`c3abf8ea`](https://github.com/nix-community/home-manager/commit/c3abf8ea1adf8f601e993de64921bcf4f52b6358) | `` khard: support discover entries (#7785) ``                                          |
| [`20c79634`](https://github.com/nix-community/home-manager/commit/20c79634716ecc790fb46fb26b7bcdd9bcbc23a4) | `` powerline-go: fix PROMPT_COMMAND duplicate in bash initialization (#7697) ``        |
| [`768a7042`](https://github.com/nix-community/home-manager/commit/768a7042a69998382d123aa73a627658973bed8d) | `` go: use env file instead of home.sessionVariables (#7751) ``                        |
| [`987b1140`](https://github.com/nix-community/home-manager/commit/987b11408213a943933853df92667fe94b90467b) | `` podman: add nftables to default container path (#7802) ``                           |