### PR TITLE
chore(flake/nixpkgs): `ab0f3607` -> `c23193b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1757745802,
+        "narHash": "sha256-hLEO2TPj55KcUFUU1vgtHE9UEIOjRcH/4QbmfHNF820=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "c23193b943c6c689d70ee98ce3128239ed9e32d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`6f5ccfbd`](https://github.com/NixOS/nixpkgs/commit/6f5ccfbd8ead432e33d146a2e92a9e5ae65a1c32) | `` pscale: 0.255.0 -> 0.256.0 ``                                                |
| [`d41ab9d1`](https://github.com/NixOS/nixpkgs/commit/d41ab9d14b8d9a524dbc3fbb57dec3415915c8e1) | `` super-productivity: 14.4.1 -> 15.0.0 ``                                      |
| [`26446738`](https://github.com/NixOS/nixpkgs/commit/2644673811934d93e97db8ea591ac9b76c3b56fd) | `` beam26Packages.ex_doc: 0.38.3 -> 0.38.4 ``                                   |
| [`e7bd3a50`](https://github.com/NixOS/nixpkgs/commit/e7bd3a5094a43d9c2e1d05dc3d217f5fd657092e) | `` python3Packages.hf-xet: 1.1.9 -> 1.1.10 ``                                   |
| [`5456b77d`](https://github.com/NixOS/nixpkgs/commit/5456b77d6c28c848d394b2a1c2164ce19de5ec95) | `` immich: 1.140.1 -> 1.142.0 ``                                                |
| [`ede83dc1`](https://github.com/NixOS/nixpkgs/commit/ede83dc17a58d6e846a0125c87dd18dc3abfe2a5) | `` sd-switch: 0.6.1 -> 0.6.2 ``                                                 |
| [`5fcf0905`](https://github.com/NixOS/nixpkgs/commit/5fcf09051edc0bc4f693e98f28434d80e16025aa) | `` python3Packages.mkdocs-macros-plugin: 1.0.5 -> 1.3.9 ``                      |
| [`fa79411c`](https://github.com/NixOS/nixpkgs/commit/fa79411c9479d6b227866220d8b36ad2dac25c1c) | `` python3Packages.mkdocs-test: init at 0.5.6 ``                                |
| [`c8757324`](https://github.com/NixOS/nixpkgs/commit/c8757324a48e9eb776faf2b55686a3f5a8c8a2e1) | `` python3Packages.super-collections: init at 0.5.4 ``                          |
| [`ba0de21f`](https://github.com/NixOS/nixpkgs/commit/ba0de21fb0853c45523ea99359b3b2f35c7aa9b1) | `` got: 0.117 -> 0.118.1 ``                                                     |
| [`d1107527`](https://github.com/NixOS/nixpkgs/commit/d1107527d8fe88c1f937eec76295fc48e14fc8cf) | `` pychess: add standard-telnetlib ``                                           |
| [`e424a297`](https://github.com/NixOS/nixpkgs/commit/e424a2978d0e43e78a21823b00a0d4269cce71ce) | `` vips: 8.16.1 -> 8.17.1 ``                                                    |
| [`0f078f90`](https://github.com/NixOS/nixpkgs/commit/0f078f9059fb0e3ac7a1402926df32f2ae9b3380) | `` gitify: 6.6.0 -> 6.8.0 ``                                                    |
| [`f2a1154c`](https://github.com/NixOS/nixpkgs/commit/f2a1154c651c5bf9ffc9efe3edaff45bbd9bc18b) | `` nixos/mastodon: fix streaming path ``                                        |
| [`3ec97590`](https://github.com/NixOS/nixpkgs/commit/3ec975901581d553689ddde94180fe7f74b43944) | `` python313Packages.boto3-stubs: 1.40.28 -> 1.40.29 ``                         |
| [`627919da`](https://github.com/NixOS/nixpkgs/commit/627919dab00764715aace523d6642fb605c2c6c0) | `` python313Packages.botocore-stubs: 1.40.28 -> 1.40.29 ``                      |
| [`a259851b`](https://github.com/NixOS/nixpkgs/commit/a259851b80549165fd26fc08c05d1271b678c79d) | `` python312Packages.mypy-boto3-rds: 1.40.24 -> 1.40.29 ``                      |
| [`3b35753c`](https://github.com/NixOS/nixpkgs/commit/3b35753c0fbe234851321012ea4a5581bc4513e2) | `` python312Packages.mypy-boto3-quicksight: 1.40.7 -> 1.40.29 ``                |
| [`ca3cfa85`](https://github.com/NixOS/nixpkgs/commit/ca3cfa857dad8fc92e54d3d18c04c9709e340bf9) | `` python312Packages.mypy-boto3-medialive: 1.40.16 -> 1.40.29 ``                |
| [`bc55b62c`](https://github.com/NixOS/nixpkgs/commit/bc55b62c46ca0c46922ff335d8277a82d34ae017) | `` python312Packages.mypy-boto3-guardduty: 1.40.15 -> 1.40.29 ``                |
| [`658fcaa2`](https://github.com/NixOS/nixpkgs/commit/658fcaa2caec25dfe9812d446591a1b72c78f8a0) | `` python312Packages.mypy-boto3-emr-containers: 1.40.17 -> 1.40.29 ``           |
| [`29a3b1ae`](https://github.com/NixOS/nixpkgs/commit/29a3b1aed8174ae56f5fbb815e644c9fc683b948) | `` python312Packages.mypy-boto3-ecs: 1.40.25 -> 1.40.29 ``                      |
| [`b0044eb4`](https://github.com/NixOS/nixpkgs/commit/b0044eb49bf14d827e84cf6cd145645d5596fd90) | `` python312Packages.mypy-boto3-amp: 1.40.11 -> 1.40.29 ``                      |
| [`4d88b670`](https://github.com/NixOS/nixpkgs/commit/4d88b670b4648a1a59cbe600266224888664c9e4) | `` foot: 1.23.1 -> 1.24.0 ``                                                    |
| [`3d1f795d`](https://github.com/NixOS/nixpkgs/commit/3d1f795d3f06452ef6b9ef54d5db6ddcacf72481) | `` git-cola: 4.14.0 -> 4.15.0 ``                                                |
| [`7ca6f17b`](https://github.com/NixOS/nixpkgs/commit/7ca6f17bd12aa5becff39b1a0e19506dc427c9c7) | `` dockerfile-language-server: 0.11.0 -> 0.14.1 ``                              |
| [`56f5686d`](https://github.com/NixOS/nixpkgs/commit/56f5686d9697fe538e9076e2cff407abe59de106) | `` paperless-ngx: relax django-guardian ``                                      |
| [`b3e554d9`](https://github.com/NixOS/nixpkgs/commit/b3e554d9ef09225daf125355c73e4fce7922d6e3) | `` python313Packages.django-guardian: 3.0.3 -> 3.1.0 ``                         |
| [`915ca47f`](https://github.com/NixOS/nixpkgs/commit/915ca47f28fc64a65dab2c0b99c43b5b204cd2cc) | `` python3Packages.mitmproxy-macos: reuse meta attribute from mitmproxy-rs ``   |
| [`1637e391`](https://github.com/NixOS/nixpkgs/commit/1637e391b7a64871298ac4a7370c9c617a78730d) | `` zrc: 2.2 -> 2.3 ``                                                           |
| [`631be7a1`](https://github.com/NixOS/nixpkgs/commit/631be7a18e1942090e236425acfcbb066b577ae3) | `` ISSUE_TEMPLATE/03_bug_report_nixos: remove git blame ``                      |
| [`a441ce8a`](https://github.com/NixOS/nixpkgs/commit/a441ce8ae93fa2a5f6112f2c5facc9b6ecfc0d1b) | `` maintainers: add dlugoschvincent ``                                          |
| [`717ac3b8`](https://github.com/NixOS/nixpkgs/commit/717ac3b883c8f6bc0f518042d998a0a59f614e97) | `` haskellPackages.botan-low: add maintainer ``                                 |
| [`4a58ec0a`](https://github.com/NixOS/nixpkgs/commit/4a58ec0a791c2065dc9202f60f61f071c1b5579a) | `` haskellPackages.botan-bindings: add maintainer ``                            |
| [`995b3858`](https://github.com/NixOS/nixpkgs/commit/995b3858d07c31a2d33fafd8466e780006340e73) | `` maintainers: add `mikatammi` ``                                              |
| [`8568f9ab`](https://github.com/NixOS/nixpkgs/commit/8568f9ab19f682f9a061ea0f5616efa107f2d81f) | `` mdsf: 0.10.5 -> 0.10.6 ``                                                    |
| [`b7db6d1f`](https://github.com/NixOS/nixpkgs/commit/b7db6d1f1f369017452405ee1c1cb4bad374d17b) | `` mdsf: remove cargoCheck to fix build failure ``                              |
| [`ebe923b9`](https://github.com/NixOS/nixpkgs/commit/ebe923b94ecc8280d53bfac217572754462e9327) | `` fwupd: add johnazoidberg as maintainer ``                                    |
| [`5bb80d52`](https://github.com/NixOS/nixpkgs/commit/5bb80d52070101aa0f3fe6ebc336a19999ce33d2) | `` fwupd: 2.0.15 -> 2.0.16 ``                                                   |
| [`9c4d1466`](https://github.com/NixOS/nixpkgs/commit/9c4d1466bf715121fcdc0f740bb82867506475b2) | `` emacsPackages.pdf-meta-edit: replace pdftk program ``                        |
| [`574148ae`](https://github.com/NixOS/nixpkgs/commit/574148ae04f6c0f6a56cc0a7ae13289eda42b97a) | `` dprint-plugins.dprint-plugin-biome: 0.10.1 -> 0.10.3 ``                      |
| [`75fd01ed`](https://github.com/NixOS/nixpkgs/commit/75fd01eda91b860f7d73dd76c7ee5505023d57da) | `` paretosecurity: 0.3.3 -> 0.3.4 ``                                            |
| [`ed3c7d75`](https://github.com/NixOS/nixpkgs/commit/ed3c7d75ef51be613b0955820325fd4ceb0fd2d4) | `` gitea: 1.24.5 -> 1.24.6 ``                                                   |
| [`e08f7a53`](https://github.com/NixOS/nixpkgs/commit/e08f7a53ffe5f527f110e4a565c338f7da36c9f6) | `` discord-ptb: 0.0.159 -> 0.0.160 ``                                           |
| [`a71d3d10`](https://github.com/NixOS/nixpkgs/commit/a71d3d10ef0d85b0dfc0106c17154f48bf5e6436) | `` tigervnc: fix build failed ``                                                |
| [`7ff43c0b`](https://github.com/NixOS/nixpkgs/commit/7ff43c0b5c3433acee74c75d4e9fe975d029ce0c) | `` vivaldi: 7.5.3735.66 -> 7.5.3735.74 ``                                       |
| [`f63cfe57`](https://github.com/NixOS/nixpkgs/commit/f63cfe57afdf7b6e614fade573fbcbc69941938e) | `` runc: switch to makeBinaryWrapper ``                                         |
| [`3c3caa50`](https://github.com/NixOS/nixpkgs/commit/3c3caa5059c8c53e4df0d1cf13c9f7478763f0d5) | `` runc: switch to finalAttrs pattern ``                                        |
| [`e5223cda`](https://github.com/NixOS/nixpkgs/commit/e5223cdab019287017c67f1fd219dff024c7d2f5) | `` runc: fix cross-compilation ``                                               |
| [`8bd7f773`](https://github.com/NixOS/nixpkgs/commit/8bd7f773477e663446bf209b9f3e779237246137) | `` rosa: fix hash ``                                                            |
| [`0b869ae4`](https://github.com/NixOS/nixpkgs/commit/0b869ae4d4f6ab0f4253fda7f8cc9c135ece5e70) | `` kubeseal: 0.31.0 -> 0.32.1 ``                                                |
| [`23027e3b`](https://github.com/NixOS/nixpkgs/commit/23027e3b77735fb999b6aa0ae40bfb45ed1079b5) | `` microsoft-edge: add maintainer iedame ``                                     |
| [`b7e125c1`](https://github.com/NixOS/nixpkgs/commit/b7e125c1f69aaee0c1e59b30aefb09596662defe) | `` microsoft-edge: 139.0.3405.125 -> 140.0.3485.66 ``                           |
| [`be1f081a`](https://github.com/NixOS/nixpkgs/commit/be1f081af2b56e6d350067e74947d83d117db123) | `` socket_wrapper: 1.5.0 -> 1.5.1 ``                                            |
| [`8c13f3d7`](https://github.com/NixOS/nixpkgs/commit/8c13f3d7ff8b6cc473e8ed27313b013651f6d56b) | `` nixos/php-fpm: enable systemd watchdog ``                                    |
| [`bd8a83a7`](https://github.com/NixOS/nixpkgs/commit/bd8a83a747c6c1a4d475fbafaef93cd239093182) | `` rubyPackages.gtk3: fix build, add missing dependencies ``                    |
| [`f20b8015`](https://github.com/NixOS/nixpkgs/commit/f20b8015d788f3732f4fedd9c45598f968fffc01) | `` terraform-providers.gitlab: 18.2.0 -> 18.3.0 ``                              |
| [`bc1c33af`](https://github.com/NixOS/nixpkgs/commit/bc1c33af192361eee777fc8ffc23f9bea5a105c7) | `` parca-agent: 0.41.0 -> 0.41.1 ``                                             |
| [`c7735c5e`](https://github.com/NixOS/nixpkgs/commit/c7735c5ea62564723cef4df8b7dc4dc23322ed1c) | `` Revert "pdf2htmlex: init at 0.18.8.rc1" ``                                   |
| [`84aaffd1`](https://github.com/NixOS/nixpkgs/commit/84aaffd18cf6e4ac2b1a4216c52816e639c2dcd6) | `` backblaze-b2: 4.4.1 -> 4.4.2 ``                                              |
| [`abc932c3`](https://github.com/NixOS/nixpkgs/commit/abc932c374d7b5a3aedefe439d49417c2ab6e54c) | `` lemmy-server: 0.19.12 -> 0.19.13 ``                                          |
| [`459db987`](https://github.com/NixOS/nixpkgs/commit/459db9873a11d3b372df8e7bab5d2c2fda6c601b) | `` python3Packages.django-htmx: 1.23.2 -> 1.24.1 ``                             |
| [`efd5b6d2`](https://github.com/NixOS/nixpkgs/commit/efd5b6d2256f29553ef144551b11bf692f45a8ad) | `` python3Packages.pynitrokey: drop raitobezarius from maintainers ``           |
| [`225d8891`](https://github.com/NixOS/nixpkgs/commit/225d88914e9688d86d4b61f086ed039f04532040) | `` ts_query_ls: 3.11.0 -> 3.11.1 ``                                             |
| [`dbd51bb6`](https://github.com/NixOS/nixpkgs/commit/dbd51bb6990fdff70b8c73f4df09de129805d199) | `` python3Packages.okonomiyaki: drop stale substituteInPlace, unbreak darwin `` |
| [`007050c2`](https://github.com/NixOS/nixpkgs/commit/007050c28f141cd46ea9ab9765c473e75065e063) | `` prometheus-redis-exporter: 1.76.0 -> 1.77.0 ``                               |
| [`f52beb58`](https://github.com/NixOS/nixpkgs/commit/f52beb58a62539aec95bdaaf88a127557309654d) | `` terraform-providers.azurerm: 4.42.0 -> 4.44.0 ``                             |
| [`7446d71b`](https://github.com/NixOS/nixpkgs/commit/7446d71b910349aef702048a37fb6cf5e9389497) | `` phpExtensions.zstd: 0.15.1 -> 0.15.2 ``                                      |
| [`95a5e849`](https://github.com/NixOS/nixpkgs/commit/95a5e849e2a5fecbbaef6496843330c1ee080539) | `` xmake: 3.0.1 -> 3.0.2 ``                                                     |
| [`adab1c98`](https://github.com/NixOS/nixpkgs/commit/adab1c986340558dcb0ca22d96779468cd8789d7) | `` openapv: 0.2.0.2 -> 0.2.0.3 ``                                               |
| [`264cee13`](https://github.com/NixOS/nixpkgs/commit/264cee1319e566edad07b780742e3c56f53064ee) | `` holos: 0.104.2 -> 0.104.3 ``                                                 |
| [`dbb64825`](https://github.com/NixOS/nixpkgs/commit/dbb648253e3a675d7f2a90a59061de8b33287fdc) | `` lr: 2.0 -> 2.0.1 ``                                                          |
| [`642e0de4`](https://github.com/NixOS/nixpkgs/commit/642e0de49db2fae40ca44c621a290a7acfa0f636) | `` davfs2: remove merged patch ``                                               |
| [`9dd0e1be`](https://github.com/NixOS/nixpkgs/commit/9dd0e1be2c1fe22cc31bde7045d8342b178628b9) | `` davfs2: 1.7.1 -> 1.7.2 ``                                                    |
| [`a89a657c`](https://github.com/NixOS/nixpkgs/commit/a89a657cea526576adc0caddafba0d1861655290) | `` python313Packages.publicsuffixlist: 1.0.2.20250906 -> 1.0.2.20250911 ``      |
| [`2364bac4`](https://github.com/NixOS/nixpkgs/commit/2364bac4955e341f54e61a4d7e6a8b98d060ef1e) | `` librasterlite2: adopt package under geospatial team maintenance ``           |
| [`74940466`](https://github.com/NixOS/nixpkgs/commit/7494046620448bbe7fea98e15de4136a4ecaed70) | `` openbao: 2.4.0 -> 2.4.1 ``                                                   |
| [`9417decd`](https://github.com/NixOS/nixpkgs/commit/9417decd4fe5efbaf187e18c2adb3e4961d32f45) | `` shogihome: 1.24.3 -> 1.25.0 ``                                               |
| [`bbb83ebe`](https://github.com/NixOS/nixpkgs/commit/bbb83ebef06ae19b3b689c960afbadff0de99107) | `` python3Packages.pyiceberg: 0.9.1 -> 0.10.0 ``                                |
| [`8bcf8c57`](https://github.com/NixOS/nixpkgs/commit/8bcf8c575165904669ddf41f0cc450d98c75cdc6) | `` gittuf: 0.11.0 -> 0.12.0 ``                                                  |
| [`a7f8ee0b`](https://github.com/NixOS/nixpkgs/commit/a7f8ee0b91ccdbe46ca7f0a9f5edb88bb7a79c83) | `` bashate: move to by-name, cleanup, fix ``                                    |