### PR TITLE
chore(flake/nh): `a8182189` -> `8bf32348`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757656889,
-        "narHash": "sha256-WtmW6PeMEemuUSMEw7fnmsqRkFXkYALe5N2HaeV3hLg=",
+        "lastModified": 1757846222,
+        "narHash": "sha256-papocgox6HOM+BJrWmWZuRnuDXi625diuC3sajCXd9A=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "a8182189f854597652e2acfe5363876241af3511",
+        "rev": "8bf323483166797a204579a43ed8810113eb128c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                   |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`df9fdd6a`](https://github.com/nix-community/nh/commit/df9fdd6ac3f8bf5ea6f241ec5bb44d1a36e70272) | `` search: update nixos-search version `` |