### PR TITLE
chore(flake/home-manager): `17a10049` -> `11cc5449`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757809953,
-        "narHash": "sha256-29mlXbfAJhz9cWVrPP4STvVPDVZFCfCOmaIN5lFJa+Y=",
+        "lastModified": 1757920978,
+        "narHash": "sha256-Mv16aegXLulgyDunijP6SPFJNm8lSXb2w3Q0X+vZ9TY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "17a10049486f6698fca32097d8f52c0c895542b0",
+        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`11cc5449`](https://github.com/nix-community/home-manager/commit/11cc5449c50e0e5b785be3dfcb88245232633eb8) | `` tests: fix tests ``                                                                   |
| [`0ab5e3c0`](https://github.com/nix-community/home-manager/commit/0ab5e3c054d6555d6239ab9d17c92be5e844b259) | `` flake.lock: Update ``                                                                 |
| [`5e06d0f1`](https://github.com/nix-community/home-manager/commit/5e06d0f1844bd150e7813368b06f32b03c816a0d) | `` claude-code: added 'hooks' and 'hooksDir' options to specify hooks from filesystem `` |
| [`be37a349`](https://github.com/nix-community/home-manager/commit/be37a3492d256910e7f9d5a6d8354f37aadd2c07) | `` claude-code: added 'commandsDir' option to specify commands from filesystem ``        |
| [`a641bbbb`](https://github.com/nix-community/home-manager/commit/a641bbbb9bb475181c5d867d01de2ebb6c286ba3) | `` claude-code: added 'agentsDir' option to specify agents from filesystem ``            |
| [`343e5556`](https://github.com/nix-community/home-manager/commit/343e5556575f2b6e00fa7f9f4623e46445a2fb8a) | `` claude-code: added memories (claude.md) generation ``                                 |