### PR TITLE
chore(flake/nixos-hardware): `4c38a024` -> `67a709cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1757891025,
-        "narHash": "sha256-NfiTk59huy/YK9H4W4wVwRYyiP2u86QqROM5KK4f5F4=",
+        "lastModified": 1757943327,
+        "narHash": "sha256-w6cDExPBqbq7fTLo4dZ1ozDGeq3yV6dSN4n/sAaS6OM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4c38a024fa32e61db2be8573e5282b15d9733a79",
+        "rev": "67a709cfe5d0643dafd798b0b613ed579de8be05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`0632a5e1`](https://github.com/NixOS/nixos-hardware/commit/0632a5e10fa0d4a81a59e9b084d4dc898f0e26ba) | `` MacBookAir6,x: fix wireless `` |