### PR TITLE
chore(flake/git-hooks): `b084b2c2` -> `ff879b26`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757588530,
-        "narHash": "sha256-tJ7A8mID3ct69n9WCvZ3PzIIl3rXTdptn/lZmqSS95U=",
+        "lastModified": 1757952139,
+        "narHash": "sha256-EqetPuxgUWdmOWXC9rKDSFBmSeUnHzOejfmrxmC68k4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b084b2c2b6bc23e83bbfe583b03664eb0b18c411",
+        "rev": "ff879b26ff20c8947b3371b9d29130a71182dddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a2c1b352`](https://github.com/cachix/git-hooks.nix/commit/a2c1b352a1b98085dce6fa2f436956b360a714a2) | `` Add enabledPackages example to flake-parts example `` |
| [`9ebfc7b3`](https://github.com/cachix/git-hooks.nix/commit/9ebfc7b303a51808e9f50f7b708d958bfa05a013) | `` Fix terraform-fmt hook ``                             |
| [`6007ee95`](https://github.com/cachix/git-hooks.nix/commit/6007ee9515d68f90df845e831456a646725a7288) | `` feat(typos): multiple exclude globs ``                |
| [`ff52e34b`](https://github.com/cachix/git-hooks.nix/commit/ff52e34ba9354532dace8958f84db0711dee6009) | `` feat(typos): set `--force-exclude` by default ``      |
| [`457b222b`](https://github.com/cachix/git-hooks.nix/commit/457b222b7a1c9a62445803409e2a740695f45f91) | `` refactor(typos): structured attrs configuration ``    |
| [`1cd5759f`](https://github.com/cachix/git-hooks.nix/commit/1cd5759f4626b483824ef1adc0f2fcf9c69ca121) | `` fix(selene): do not print a summary ``                |