### PR TITLE
chore(flake/git-hooks): `ff879b26` -> `d1d8fe5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757952139,
-        "narHash": "sha256-EqetPuxgUWdmOWXC9rKDSFBmSeUnHzOejfmrxmC68k4=",
+        "lastModified": 1757953049,
+        "narHash": "sha256-PwWGLIn8XNXSP4iRno2vK6b/Hy/mo6qZuRDzSB1VA4Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ff879b26ff20c8947b3371b9d29130a71182dddf",
+        "rev": "d1d8fe5cece10276fb7108e17c9a5efc07926ce5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                      |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`d9d4a28c`](https://github.com/cachix/git-hooks.nix/commit/d9d4a28c7c5f24a5c0997a7c05b02a55b8e980f4) | `` lint ``                                   |
| [`222d5504`](https://github.com/cachix/git-hooks.nix/commit/222d5504823a26d320a59356d5a4a55ddb7a0654) | `` feat(convco): add option configPath ``    |
| [`6bd8ba28`](https://github.com/cachix/git-hooks.nix/commit/6bd8ba28a461c6b4f4339703663238596b1ac52d) | `` feat(alejandra): add option configPath `` |
| [`8e35904c`](https://github.com/cachix/git-hooks.nix/commit/8e35904c288570cbf7467a227e4ba4e8d608064e) | `` feat: add action-validator hook ``        |
| [`f73b7bbe`](https://github.com/cachix/git-hooks.nix/commit/f73b7bbe1564b8f4e91e204765ebe4d3c867d2b1) | `` feat: add woodpecker-cli lint hook ``     |
| [`c3b6489a`](https://github.com/cachix/git-hooks.nix/commit/c3b6489a1d860af63bdf91cbd4602f37e54cb4d9) | `` feat: add nbstripout hook ``              |