### PR TITLE
chore(flake/git-hooks): `d1d8fe5c` -> `302af509`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757953049,
-        "narHash": "sha256-PwWGLIn8XNXSP4iRno2vK6b/Hy/mo6qZuRDzSB1VA4Y=",
+        "lastModified": 1757974173,
+        "narHash": "sha256-4DpXmct/2rcLgScT1CXOLr0TUeIlrBB1rnFqCOf5MUw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d1d8fe5cece10276fb7108e17c9a5efc07926ce5",
+        "rev": "302af509428169db34f268324162712d10559f74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f9c8c3fa`](https://github.com/cachix/git-hooks.nix/commit/f9c8c3fab7fef6e7677cfb8e9b586e92e5fe0ac8) | `` feat: Add comrak formatter ``                       |
| [`3200f1fc`](https://github.com/cachix/git-hooks.nix/commit/3200f1fccb682e28860be8f9eccf73828d654bcb) | `` Do not pass filenames to ansible-lint by default `` |