### PR TITLE
chore(flake/home-manager): `11cc5449` -> `5820376b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757920978,
-        "narHash": "sha256-Mv16aegXLulgyDunijP6SPFJNm8lSXb2w3Q0X+vZ9TY=",
+        "lastModified": 1757997814,
+        "narHash": "sha256-F+1aoG+3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11cc5449c50e0e5b785be3dfcb88245232633eb8",
+        "rev": "5820376beb804de9acf07debaaff1ac84728b708",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`5820376b`](https://github.com/nix-community/home-manager/commit/5820376beb804de9acf07debaaff1ac84728b708) | `` news: add cudatext entry ``           |
| [`10d30c91`](https://github.com/nix-community/home-manager/commit/10d30c9185697d86477e1e539ca755403d7a3216) | `` cudatext: add module ``               |
| [`a88781a3`](https://github.com/nix-community/home-manager/commit/a88781a35cf9de9042396c4b84d2fae127b316b5) | `` sway: drop oxalica from maintainer `` |