### PR TITLE
chore(flake/home-manager): `5820376b` -> `d507f57d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757997814,
-        "narHash": "sha256-F+1aoG+3NH4jDDEmhnDUReISyq6kQBBuktTUqCUWSiw=",
+        "lastModified": 1758081610,
+        "narHash": "sha256-WPstpmGIP5B8LfKLDOFO6oMMqIHAdL/8jSogK8NVlpY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5820376beb804de9acf07debaaff1ac84728b708",
+        "rev": "d507f57df23d067165f3d1a1dd5fb169b4f6bc37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`d507f57d`](https://github.com/nix-community/home-manager/commit/d507f57df23d067165f3d1a1dd5fb169b4f6bc37) | `` maintainers: update all-maintainers.nix (#7815) ``                  |
| [`fad8e303`](https://github.com/nix-community/home-manager/commit/fad8e3033e95d0a4595080e1efc8927b16ac18ed) | `` fontconfig: add fonts.fontconfig.extraConfigFiles option (#7754) `` |
| [`75f97fcb`](https://github.com/nix-community/home-manager/commit/75f97fcbe31cd6d4151527f3ac50cacbe8f1ff0d) | `` sway: order input config from least to most specific (#7684) ``     |
| [`ec73c06d`](https://github.com/nix-community/home-manager/commit/ec73c06d34859ed01e2ce0e15d5972b4dd539694) | `` vscode: add config and exension dir for kiro (#7825) ``             |
| [`6efc49be`](https://github.com/nix-community/home-manager/commit/6efc49be7c6115a0e07b3a2fa042cd41d9195545) | `` floorp: use -bin, as source package was dropped (#7818) ``          |
| [`0a2145ea`](https://github.com/nix-community/home-manager/commit/0a2145eae2546f8fb7ce20b5bf21c9dacce37092) | `` activitywatch: add service status cmd to desc (#7823) ``            |
| [`6c1a1efa`](https://github.com/nix-community/home-manager/commit/6c1a1efa028aff04a277fc69781081a0bd6e0ca2) | `` watcher: fix example typo for aw-watcher-window (#7822) ``          |