### PR TITLE
chore(flake/home-manager): `d507f57d` -> `fb928abb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758081610,
-        "narHash": "sha256-WPstpmGIP5B8LfKLDOFO6oMMqIHAdL/8jSogK8NVlpY=",
+        "lastModified": 1758085625,
+        "narHash": "sha256-D0KVKNgWSDVjYFgPLEtSQvSKchTBT0YqSbNlH7OQ+bo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d507f57df23d067165f3d1a1dd5fb169b4f6bc37",
+        "rev": "fb928abb67bd4df99040721ed48c3b42e24b1d08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`fb928abb`](https://github.com/nix-community/home-manager/commit/fb928abb67bd4df99040721ed48c3b42e24b1d08) | `` tests/claude-code: add path tests for agents/commands `` |
| [`846f27fb`](https://github.com/nix-community/home-manager/commit/846f27fba84839a93015c3378449edd255071e42) | `` claude-code: support paths for agents/commands ``        |
| [`10f5a0cc`](https://github.com/nix-community/home-manager/commit/10f5a0cc4b98c61298a8d130185a25032e9fe3b8) | `` tests/oh-my-posh: expand test coverage ``                |
| [`51372c4a`](https://github.com/nix-community/home-manager/commit/51372c4afb961c310beab90090f93d88e3b1c1e6) | `` oh-my-posh: add assertion for config source ``           |
| [`624c97de`](https://github.com/nix-community/home-manager/commit/624c97de9cae5ba1432557df579b64a79d90fadc) | `` oh-my-posh: added option to supply config path ``        |