### PR TITLE
chore(flake/home-manager): `fb928abb` -> `9f408dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758085625,
-        "narHash": "sha256-D0KVKNgWSDVjYFgPLEtSQvSKchTBT0YqSbNlH7OQ+bo=",
+        "lastModified": 1758119172,
+        "narHash": "sha256-LnVuGLf0PJHqqIHroxEzwXS57mjAdHSrXi0iODKbbiU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fb928abb67bd4df99040721ed48c3b42e24b1d08",
+        "rev": "9f408dc51c8e8216a94379e6356bdadbe8b4fef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`9f408dc5`](https://github.com/nix-community/home-manager/commit/9f408dc51c8e8216a94379e6356bdadbe8b4fef9) | `` ssh-tpm-agent: fix test case ``                               |
| [`5c14260f`](https://github.com/nix-community/home-manager/commit/5c14260fad23f9fda91a0dd74b1c58cf3be95221) | `` systemd: make unit definitions freeform modules ``            |
| [`12dfb0cf`](https://github.com/nix-community/home-manager/commit/12dfb0cff99865ea9e7fd0e3db3a301102b948f9) | `` restic: fix integration test ``                               |
| [`bc8967cd`](https://github.com/nix-community/home-manager/commit/bc8967cdb03c9d805288dd80b845b16ef8c4111b) | `` gpg-agent: write nushell initialization to config file ``     |
| [`b0355462`](https://github.com/nix-community/home-manager/commit/b035546241d842053c7f19c517e330d79d1dc801) | `` news: add opencode entry for new agent and command support `` |
| [`53538044`](https://github.com/nix-community/home-manager/commit/53538044d9e23b30ea7d5c1b0028feb9517995b3) | `` tests/opencode: expand tests for agents / commands ``         |
| [`c104ee92`](https://github.com/nix-community/home-manager/commit/c104ee92bf1cf4c9b4ccaa773fd108627a83bbf3) | `` opencode: path support for agents/commands ``                 |
| [`d7686f26`](https://github.com/nix-community/home-manager/commit/d7686f26e8b623f32f2739cf2c5f1b37efbf1366) | `` opencode: add support for agent and command files ``          |