### PR TITLE
chore(flake/home-manager): `9f408dc5` -> `a504aee7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758119172,
-        "narHash": "sha256-LnVuGLf0PJHqqIHroxEzwXS57mjAdHSrXi0iODKbbiU=",
+        "lastModified": 1758160734,
+        "narHash": "sha256-4YoMTUZRXb2XggJi11lSJnehrwM6u31Ylu2cOzb96JQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9f408dc51c8e8216a94379e6356bdadbe8b4fef9",
+        "rev": "a504aee7d452ecf8881b933b1eb573535a543a03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`a504aee7`](https://github.com/nix-community/home-manager/commit/a504aee7d452ecf8881b933b1eb573535a543a03) | `` news: add formiko entry `` |
| [`9093a3f2`](https://github.com/nix-community/home-manager/commit/9093a3f2002298239de7f10bd8bcdd9652d6904e) | `` formiko: add module ``     |