### PR TITLE
chore(flake/home-manager): `a504aee7` -> `bf7056c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758160734,
-        "narHash": "sha256-4YoMTUZRXb2XggJi11lSJnehrwM6u31Ylu2cOzb96JQ=",
+        "lastModified": 1758184248,
+        "narHash": "sha256-TOazVsj8D1LTGQ6q8xdtfoPs9Z+PiqUS952WvZPssR0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a504aee7d452ecf8881b933b1eb573535a543a03",
+        "rev": "bf7056c6a2d893d80db18d06d7e730d6515aaae8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`bf7056c6`](https://github.com/nix-community/home-manager/commit/bf7056c6a2d893d80db18d06d7e730d6515aaae8) | `` nextcloud-client: add stop and restart settings to the service `` |
| [`be9c10d4`](https://github.com/nix-community/home-manager/commit/be9c10d4a7286e9940147d8933a78dd308c760a0) | `` Translate using Weblate (Bulgarian) ``                            |
| [`64507361`](https://github.com/nix-community/home-manager/commit/64507361488885f315c2911728499d25790fc1de) | `` Translate using Weblate (Bulgarian) ``                            |
| [`4dbbc965`](https://github.com/nix-community/home-manager/commit/4dbbc965c0becd3c0adfdbce703ee9ad602b312a) | `` Translate using Weblate (Bulgarian) ``                            |
| [`9e771132`](https://github.com/nix-community/home-manager/commit/9e771132aa2bce8e65eab2c5557d508f5218dda9) | `` Translate using Weblate (Bulgarian) ``                            |