### PR TITLE
chore(flake/treefmt-nix): `1aabc6c0` -> `128222dc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -899,11 +899,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756662192,
-        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "lastModified": 1758206697,
+        "narHash": "sha256-/DbPkh6PZOgfueCbs3uzlk4ASU2nPPsiVWhpMCNkAd0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "rev": "128222dc911b8e2e18939537bed1762b7f3a04aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`128222dc`](https://github.com/numtide/treefmt-nix/commit/128222dc911b8e2e18939537bed1762b7f3a04aa) | `` nixfmt-classic: remove warning (#407) `` |