### PR TITLE
chore(flake/lovesegfault-vim-config): `cd26c6de` -> `6fb2178f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758154114,
-        "narHash": "sha256-os3m42CTfH3L0k9OlZNHp5kD3XyYdbbTKZKJ69TECP4=",
+        "lastModified": 1758240590,
+        "narHash": "sha256-mLQczmxdg6+Dzz4W2mkMyC9GlqTZ8XG44Ak1N9YxKZg=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "cd26c6de8bbd8694e2e5199695500b65a675d612",
+        "rev": "6fb2178f4921d9351b48fc0904cfe6ee13208b69",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`6fb2178f`](https://github.com/lovesegfault/vim-config/commit/6fb2178f4921d9351b48fc0904cfe6ee13208b69) | `` chore(flake/nixpkgs): c23193b9 -> 8d4ddb19 ``     |
| [`01c51dd9`](https://github.com/lovesegfault/vim-config/commit/01c51dd9d8e90449c8035dab799d7980ed3c3f7a) | `` chore(flake/treefmt-nix): 1aabc6c0 -> 128222dc `` |