### PR TITLE
chore(flake/home-manager): `b5698ed5` -> `363007f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758207369,
-        "narHash": "sha256-BG7GlXo5moXtrFSCqnkIb1Q00szOZXTj5Dx7NmWgves=",
+        "lastModified": 1758250706,
+        "narHash": "sha256-Jv/V+PNi5RyqCUK2V6YJ0iCqdLPutU69LZas85EBUaU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b5698ed57db7ee7da5e93df2e6bbada91c88f3ce",
+        "rev": "363007f12930caf8b0ea59c0bf5be109c52ad0ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`363007f1`](https://github.com/nix-community/home-manager/commit/363007f12930caf8b0ea59c0bf5be109c52ad0ef) | `` nushell: expose config dir location as option ``        |
| [`b47ea12f`](https://github.com/nix-community/home-manager/commit/b47ea12ff4442029c7016c13d5c55f86e10cbad3) | `` mise: statically generate nushell config ``             |
| [`3f47f72c`](https://github.com/nix-community/home-manager/commit/3f47f72c97ec23d117d9ce6ad15a42552cfce66d) | `` mise: disable shell integration when package == null `` |
| [`3cb08dd3`](https://github.com/nix-community/home-manager/commit/3cb08dd360e3bee6cf2ca4dd011802c523695fc1) | `` nvchecker: add module ``                                |
| [`891d675c`](https://github.com/nix-community/home-manager/commit/891d675cd62de524c50c4f1f0b60c789d0304cec) | `` news: add acd-cli entry ``                              |
| [`b8596c1b`](https://github.com/nix-community/home-manager/commit/b8596c1b2352cd31b34173001d8502c304f130c3) | `` acd-cli: add module ``                                  |
| [`32bfbc99`](https://github.com/nix-community/home-manager/commit/32bfbc996e4310c4d3a24464af88f5d3e6012505) | `` news: add abaddon entry ``                              |
| [`acaf3971`](https://github.com/nix-community/home-manager/commit/acaf3971c19f873c1a0d364439a2819b6a814310) | `` abaddon: add module ``                                  |