### PR TITLE
chore(flake/home-manager): `363007f1` -> `55b1f5b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758250706,
-        "narHash": "sha256-Jv/V+PNi5RyqCUK2V6YJ0iCqdLPutU69LZas85EBUaU=",
+        "lastModified": 1758296614,
+        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "363007f12930caf8b0ea59c0bf5be109c52ad0ef",
+        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`55b1f5b7`](https://github.com/nix-community/home-manager/commit/55b1f5b7b191572257545413b98e37abab2fdb00) | `` wleave: init (#7835) ``                                 |
| [`efcba687`](https://github.com/nix-community/home-manager/commit/efcba687d355f4e46cb7754c385720ae454fe543) | `` xdg-mime-apps: add defaultApplicationPackages option `` |
| [`e3875193`](https://github.com/nix-community/home-manager/commit/e38751933802481b37fee1f9251cbb86e63df381) | `` news: add entry for nix-remote-build ``                 |
| [`e81d71d5`](https://github.com/nix-community/home-manager/commit/e81d71d53aa7f54e9cae745dc06d389217ff172d) | `` nix-remote-build: add module ``                         |
| [`ace87597`](https://github.com/nix-community/home-manager/commit/ace8759715a203f6cc63fd7235f4fbb78b5d476a) | `` swaync: fix eval problem (#7844) ``                     |