### PR TITLE
chore(flake/home-manager): `55b1f5b7` -> `edc7468e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758296614,
-        "narHash": "sha256-l60D1i0aaSqemy9dL7wP0ePMfcv/oZbeKpvUMY+q0kQ=",
+        "lastModified": 1758375677,
+        "narHash": "sha256-BLtD+6qWz7fQjPk2wpwyXQLGI0E30Ikgf2ppn2nVadI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "55b1f5b7b191572257545413b98e37abab2fdb00",
+        "rev": "edc7468e12be92e926847cb02418e649b02b59dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`edc7468e`](https://github.com/nix-community/home-manager/commit/edc7468e12be92e926847cb02418e649b02b59dd) | `` yazi: add extraPackages option for wrapper PATH extension `` |
| [`d5fb6ebc`](https://github.com/nix-community/home-manager/commit/d5fb6ebc4f7304f4485a8adb7258b1b65547a3f9) | `` Translate using Weblate (Basque) ``                          |