### PR TITLE
chore(flake/darwin): `ebd0bfc1` -> `7be9c1b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758102940,
-        "narHash": "sha256-wwqf3+A8EiqwWpcAaPN20QXJLlpGPpwtLTrzgnngI2o=",
+        "lastModified": 1758387173,
+        "narHash": "sha256-E5Ru709RoQEFl+Q0MHRXTIvbY0l6LSR1UHqwTulSeog=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "ebd0bfc11fc2b5cff37401e9b3703881ad5fabbd",
+        "rev": "7be9c1b136ef7083e60eb060be0a66dcb254e3ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                    |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`5eb53f60`](https://github.com/nix-darwin/nix-darwin/commit/5eb53f6003acd69b30d4d06997eea711540ed0b6) | `` Add test for system.defaults.NSGlobalDomain.AppleIconAppearanceTheme `` |
| [`3c7396a0`](https://github.com/nix-darwin/nix-darwin/commit/3c7396a09cf0248c586eb0a10cf5df657e86eab6) | `` Add system.defaults.NSGlobalDomain.AppleIconAppearanceTheme ``          |