### PR TITLE
chore(flake/home-manager): `de536983` -> `9a2dc0ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758545873,
-        "narHash": "sha256-0VP5cVd6DyibHNPC/IJ5Ut+KuNYUeKmr5ltzf+IcpjA=",
+        "lastModified": 1758593331,
+        "narHash": "sha256-p+904PfmINyekyA/LieX3IYGsiFtExC00v5gSYfJtpM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "de5369834ff1f75246c46be89ef993392e961c26",
+        "rev": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`9a2dc0ef`](https://github.com/nix-community/home-manager/commit/9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142) | `` zellij: Add extraConfig ``                         |
| [`f59891d5`](https://github.com/nix-community/home-manager/commit/f59891d511d692ac0ed0bb366b39f778d5b594ed) | `` xdg-mime-apps: no spaces in default app entries `` |