### PR TITLE
chore(flake/home-manager): `9a2dc0ef` -> `131f4e22`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758593331,
-        "narHash": "sha256-p+904PfmINyekyA/LieX3IYGsiFtExC00v5gSYfJtpM=",
+        "lastModified": 1758653055,
+        "narHash": "sha256-v2Pue/Xa9cDbKcrsOmhD8fiYR4No65z+ReAUBBvvE7g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9a2dc0efbc569ce9352a6ffb8e8ec8dbc098e142",
+        "rev": "131f4e22c30c114378dcf6191cb75c97eba673d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`131f4e22`](https://github.com/nix-community/home-manager/commit/131f4e22c30c114378dcf6191cb75c97eba673d0) | `` anki: rename `sync.passwordFile`, improve documentation `` |
| [`f5852ea3`](https://github.com/nix-community/home-manager/commit/f5852ea36c05f48d01d6e378d45449c962ba6fb4) | `` anki: fix `ankiAddons.passfail2` example ``                |
| [`293d1059`](https://github.com/nix-community/home-manager/commit/293d105993e07fb92deb68a150ca801e3e459c85) | `` anki: strip usernameFile and passwordFile contents ``      |
| [`5468c92a`](https://github.com/nix-community/home-manager/commit/5468c92a2350ca76e15ee6617a083c0e6ce7ade7) | `` news: add ahoviewer entry ``                               |
| [`366b60b8`](https://github.com/nix-community/home-manager/commit/366b60b8a06d237dbadd9a573ab21532dec70031) | `` ahoviewer: add module ``                                   |