### PR TITLE
chore(flake/home-manager): `676c0159` -> `6ce2e180`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758676806,
-        "narHash": "sha256-XhSTUBFOtuumxAUVxTVD5k7nE/FgK11YUxAgzNQcmLU=",
+        "lastModified": 1758692005,
+        "narHash": "sha256-bNRMXWSLM4K9cF1YaHYjLol60KIAWW4GzAoJDp5tA0w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "676c0159ed51d10489a249ecdc61e115c2a90d03",
+        "rev": "6ce2e18007ff022db41d9cc042f8838e8c51ed66",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`6ce2e180`](https://github.com/nix-community/home-manager/commit/6ce2e18007ff022db41d9cc042f8838e8c51ed66) | `` nix-your-shell: Allow using `nom` for `nix` commands ``  |
| [`cb68b5cd`](https://github.com/nix-community/home-manager/commit/cb68b5cd6a90325c05a9aa0cb27d8c1c98bc14ae) | `` syncthing: handle per-folder `encryptionPasswordFile` `` |
| [`ef376249`](https://github.com/nix-community/home-manager/commit/ef3762499bb1ecd542e236b5b073c3c9399f8782) | `` flake.lock: Update (#7864) ``                            |