### PR TITLE
chore(flake/home-manager): `6ce2e180` -> `142acd7a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758692005,
-        "narHash": "sha256-bNRMXWSLM4K9cF1YaHYjLol60KIAWW4GzAoJDp5tA0w=",
+        "lastModified": 1758719930,
+        "narHash": "sha256-DgHe1026Ob49CPegPMiWj1HNtlMTGQzfSZQQVlHC950=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ce2e18007ff022db41d9cc042f8838e8c51ed66",
+        "rev": "142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`142acd7a`](https://github.com/nix-community/home-manager/commit/142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d) | `` bash: source session variable file directly `` |
| [`d398f95f`](https://github.com/nix-community/home-manager/commit/d398f95f1e9108f18c7dbe45423c71ccf52497c4) | `` nixgl: use original package name ``            |
| [`f678263e`](https://github.com/nix-community/home-manager/commit/f678263ecf5b347ed98d2a187d37d052c4f71b0c) | `` mpvpaper: fix typos ``                         |