### PR TITLE
chore(flake/lovesegfault-vim-config): `18b3dfc8` -> `0a69cab7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758672602,
-        "narHash": "sha256-LAt0XHxdaJJbovnW2htUoCfAugBjFBF8IJHSJTgVxD4=",
+        "lastModified": 1758758948,
+        "narHash": "sha256-72Isy7qyBnmF4yLOUttci/sT8ZIgQxZWCmyoPUdWWnE=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "18b3dfc815f5776819a229e9ab522e6fe53b357b",
+        "rev": "0a69cab78dae6c5f1ccfcd72377a02eccb51f41d",
         "type": "github"
       },
       "original": {
@@ -609,11 +609,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1758665797,
-        "narHash": "sha256-RIN05AhWIFCXL2OOXGoFdF/k8Q6OBhi/WcRtsYuTF5Q=",
+        "lastModified": 1758718199,
+        "narHash": "sha256-xbkAs3NM9K2sPEhz0MB9kDfDPBXNkkEDueKpPkZzzSc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0c15f88f1fc01c8799c5ce2a432fadc47f20e307",
+        "rev": "fd835f3dd13872841ef394e97be71276f75957b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`0a69cab7`](https://github.com/lovesegfault/vim-config/commit/0a69cab78dae6c5f1ccfcd72377a02eccb51f41d) | `` chore(flake/nixvim): 0c15f88f -> fd835f3d ``      |
| [`722f4192`](https://github.com/lovesegfault/vim-config/commit/722f4192b891d5af61d47ce9a174b759c808c823) | `` chore(flake/treefmt-nix): 128222dc -> 5eda4ee8 `` |