### PR TITLE
chore(flake/home-manager): `142acd7a` -> `2e260431`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758719930,
-        "narHash": "sha256-DgHe1026Ob49CPegPMiWj1HNtlMTGQzfSZQQVlHC950=",
+        "lastModified": 1758748290,
+        "narHash": "sha256-/U2axzLmPgJb/0J+vQ4XmS++72VZWxJnDblwqTyGmEk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "142acd7a7d9eb7f0bb647f053b4ddfd01fdfbf1d",
+        "rev": "2e260431fca7a782e0d0591985f2040944b43541",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------- |
| [`2e260431`](https://github.com/nix-community/home-manager/commit/2e260431fca7a782e0d0591985f2040944b43541) | `` news: add aiac entry `` |
| [`68a92b03`](https://github.com/nix-community/home-manager/commit/68a92b0301ac0a2d5ac2c60aadce6bc8460591b5) | `` aiac: add module ``     |