### PR TITLE
chore(flake/stylix): `526c8828` -> `484819a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -716,11 +716,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1758716250,
-        "narHash": "sha256-PvOo4vSk7WAOhSifgL+rzExihquU9DOIOQPrUVuFHpE=",
+        "lastModified": 1758757969,
+        "narHash": "sha256-2zC4aHoDsR12Jyd6WvSxmQbAKT4V93frnHHDjA8o3r8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "526c882800837cce7676f3e11bb3e13e975c6032",
+        "rev": "484819a16fdc1c76cdd62d8e94018db44e5e1a8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`484819a1`](https://github.com/nix-community/stylix/commit/484819a16fdc1c76cdd62d8e94018db44e5e1a8b) | `` stylix/testbed/default: simplify attribute set declaration (#1906) `` |
| [`1284c189`](https://github.com/nix-community/stylix/commit/1284c1891b72c8670164eefe602300fe2d87f0cb) | `` lazygit: use consistent border colors (#1907) ``                      |