### PR TITLE
chore(flake/home-manager): `2e260431` -> `23245405`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758748290,
-        "narHash": "sha256-/U2axzLmPgJb/0J+vQ4XmS++72VZWxJnDblwqTyGmEk=",
+        "lastModified": 1758786164,
+        "narHash": "sha256-o1WyZI2T7yPywiY06Swt8AZH/ewKU1nLqDw8fw1fwPc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2e260431fca7a782e0d0591985f2040944b43541",
+        "rev": "232454052008027c8e925979d13a951e92729781",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`23245405`](https://github.com/nix-community/home-manager/commit/232454052008027c8e925979d13a951e92729781) | `` syncthing: assert tray service content in test `` |
| [`ade85015`](https://github.com/nix-community/home-manager/commit/ade850153b41793e785e730f812b09302e9fd3b4) | `` syncthing: remove deprecated code ``              |
| [`74a78aac`](https://github.com/nix-community/home-manager/commit/74a78aacb7fe6b5d8fac79f9314abddbdaf07f09) | `` maintainers: update all-maintainers.nix ``        |
| [`e2ecfbf6`](https://github.com/nix-community/home-manager/commit/e2ecfbf6d034617f85b38fa9043d0539da2d5c03) | `` tahoe-lafs: update default package ``             |