### PR TITLE
chore(flake/darwin): `25381509` -> `c48e963a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -118,11 +118,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758447883,
-        "narHash": "sha256-yGA6MV0E4JSEXqLTb4ZZkmdJZcoQ8HUzihRRX12Bvpg=",
+        "lastModified": 1758805352,
+        "narHash": "sha256-BHdc43Lkayd+72W/NXRKHzX5AZ+28F3xaUs3a88/Uew=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "25381509d5c91bbf3c30e23abc6d8476d2143cd1",
+        "rev": "c48e963a5558eb1c3827d59d21c5193622a1477c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                            |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`49eedd3d`](https://github.com/nix-darwin/nix-darwin/commit/49eedd3d2a48922e113f35f8765aa23cc8b4eee2) | `` telegraf: set HOME to avoid crash at startup `` |