### PR TITLE
chore(flake/lovesegfault-vim-config): `b050aa00` -> `3267c9c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758845313,
-        "narHash": "sha256-3mBZx8GKoJTWXLYbwPTg046KOnPu3OHXJOnTFzpZqvc=",
+        "lastModified": 1758845522,
+        "narHash": "sha256-gE3XUEAczYWI9UzeKwTf4tA2M9EmhoNrfaJREn0d5og=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "b050aa006aa3db17ff72c5e68ee4d0258248d6ba",
+        "rev": "3267c9c68ab483111789e4f2d2905d34b7a4dc92",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`3267c9c6`](https://github.com/lovesegfault/vim-config/commit/3267c9c68ab483111789e4f2d2905d34b7a4dc92) | `` chore(flake/nixpkgs): 554be649 -> e643668f `` |