### PR TITLE
chore(flake/home-manager): `c1a47eae` -> `ef5c1426`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758853693,
-        "narHash": "sha256-Gzrt0dOF9oQvQLTi3bke9HKY7Fv8ZGrjAvgEN58KKgU=",
+        "lastModified": 1758872299,
+        "narHash": "sha256-ptCEC1Q3yr/PuDmuDRJjIB80E3WUVc2sbhq1+qDrnLQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1a47eae05fb93788d3e3a7f1e63d7fc34d60c63",
+        "rev": "ef5c1426bfb558f13cf0e585e1b2830ded87a970",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`ef5c1426`](https://github.com/nix-community/home-manager/commit/ef5c1426bfb558f13cf0e585e1b2830ded87a970) | `` maintainers: update all-maintainers.nix ``            |
| [`f3235d91`](https://github.com/nix-community/home-manager/commit/f3235d91abedc9bcfdcbf1d7807b5bce94258884) | `` mods: get ipsavitsky from Nixpkgs maintainers list `` |