### PR TITLE
chore(flake/home-manager): `6238bbc0` -> `497e2bfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758899649,
-        "narHash": "sha256-Z6IxPlvIS83lKbTIliP2xFj4hJ699/eM7Ubte4iytgQ=",
+        "lastModified": 1758916421,
+        "narHash": "sha256-i4vGfcRJpLIWjWzXPzsyhP4cCPJu1bzoY0eMGxRK5SI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6238bbc0ae04951b64a3ad1b69d3e03b8b329e51",
+        "rev": "497e2bfa8a45bebe9788e2aa13e766e6a96677cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`497e2bfa`](https://github.com/nix-community/home-manager/commit/497e2bfa8a45bebe9788e2aa13e766e6a96677cd) | `` news: add aichat agents option entry `` |
| [`e3e15e76`](https://github.com/nix-community/home-manager/commit/e3e15e765d164454db72ca30290c2d3a4917daf9) | `` aichat: add agents option ``            |
| [`35329d44`](https://github.com/nix-community/home-manager/commit/35329d44f3e3578fb33fc7e410c5b26a05fb1e53) | `` news: add aider-chat entry ``           |
| [`9947d3c0`](https://github.com/nix-community/home-manager/commit/9947d3c003e414e29b13e76884b21a482563f5fb) | `` aider-chat: add module ``               |
| [`fb2ae64b`](https://github.com/nix-community/home-manager/commit/fb2ae64bed1ee4997a8e350bc18f4bc5bffa670c) | `` news: add airlift entry ``              |
| [`8a135785`](https://github.com/nix-community/home-manager/commit/8a1357854d21246059d79258b0752834f965ee25) | `` airlift: add module ``                  |