### PR TITLE
chore(flake/home-manager): `11cc3d55` -> `26ace005`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758985165,
-        "narHash": "sha256-bzthrGCHUDzUHH9F3eNl5LG5rfg4ig9x3TGjjUE23qA=",
+        "lastModified": 1758997081,
+        "narHash": "sha256-c4SbPEbR9yP5erODj4niMO7N+2ONEoGnWnt5hauAHRg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "11cc3d55ded3346a8195000ddeadde782a611e56",
+        "rev": "26ace005b720b7628fdf2d4923e7feecdd1631c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`26ace005`](https://github.com/nix-community/home-manager/commit/26ace005b720b7628fdf2d4923e7feecdd1631c4) | `` tests/zsh: add comprehensive smart formatting test ``                                 |
| [`3aaf3401`](https://github.com/nix-community/home-manager/commit/3aaf340173d3151dd131f679b3bf419da5cd456b) | `` zsh: optimize setOptions with array-based loops ``                                    |
| [`04f672b5`](https://github.com/nix-community/home-manager/commit/04f672b5db5ed5b2fa56aff523089cd29049cb4d) | `` zsh/history: optimize history options with array-based loops ``                       |
| [`c26a2ac2`](https://github.com/nix-community/home-manager/commit/c26a2ac2e430f0a54495eca33b5df342cbcd736e) | `` zsh/plugins: optimize plugin loading with array-based loops ``                        |
| [`bd81c11e`](https://github.com/nix-community/home-manager/commit/bd81c11eb3f854befe8f165cf23b0047fd621eab) | `` tests/darwinScrublist: add zsh-history-substring-search ``                            |
| [`5176d93c`](https://github.com/nix-community/home-manager/commit/5176d93c0a0e5c25a08f298c7f1c4268d4726e5e) | `` lib/zsh: fix shell escaping and integrate formatShellArrayContent ``                  |
| [`a8dbb4e3`](https://github.com/nix-community/home-manager/commit/a8dbb4e325e9fce15f96de8e77bdbb7c9af6e51d) | `` lib/shell: add formatShellArrayContent function for intelligent width optimization `` |