### PR TITLE
chore(flake/nix-index-database): `dba023c4` -> `ec7a78cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -534,11 +534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759030228,
-        "narHash": "sha256-NQAhKcIuL9hmHu6rL45XbgP0HePwZYNjH6BRqN6CmsA=",
+        "lastModified": 1759032422,
+        "narHash": "sha256-WZf+FhebP2/1pK2np5xj/NuDjD6fXK2BHnq/tPUN18o=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "dba023c457b6a7c826cd63397f5c6d6ff4d8b828",
+        "rev": "ec7a78cb0e098832d8acac091a4df393259c4839",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ec7a78cb`](https://github.com/nix-community/nix-index-database/commit/ec7a78cb0e098832d8acac091a4df393259c4839) | `` update generated.nix to release 2025-09-28-033035 `` |