### PR TITLE
chore(flake/home-manager): `26ace005` -> `c75fd8e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758997081,
-        "narHash": "sha256-c4SbPEbR9yP5erODj4niMO7N+2ONEoGnWnt5hauAHRg=",
+        "lastModified": 1759043321,
+        "narHash": "sha256-Efi3THvsIS6Qd97s52/PSSHWybDlSbtUZXP8l3AR9Ps=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "26ace005b720b7628fdf2d4923e7feecdd1631c4",
+        "rev": "c75fd8e300b79502b8eecdacd8a426b12fadb460",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`c75fd8e3`](https://github.com/nix-community/home-manager/commit/c75fd8e300b79502b8eecdacd8a426b12fadb460) | `` gurk-rs: remove references to deprecated 'data_path' option `` |
| [`1dbb3fd2`](https://github.com/nix-community/home-manager/commit/1dbb3fd2f79c804859e6b65fd42f164f7527ff39) | `` radio-active: add module to create config files ``             |