### PR TITLE
chore(flake/home-manager): `c75fd8e3` -> `a97df40c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759043321,
-        "narHash": "sha256-Efi3THvsIS6Qd97s52/PSSHWybDlSbtUZXP8l3AR9Ps=",
+        "lastModified": 1759088654,
+        "narHash": "sha256-31Xc5bIeqqOJA0Kuk9s7TAMakuyggGHBluP3LqedQiE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c75fd8e300b79502b8eecdacd8a426b12fadb460",
+        "rev": "a97df40c1966cc46b5f6817ac8d8e240da03de96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`a97df40c`](https://github.com/nix-community/home-manager/commit/a97df40c1966cc46b5f6817ac8d8e240da03de96) | `` zsh: envVarsStr fix indentation ``                |
| [`2b03dc82`](https://github.com/nix-community/home-manager/commit/2b03dc82bb1c47af32d90edc8ebeb887c93d9b7e) | `` lib/zsh: revert escapeShellArg in toZshValue ``   |
| [`64a809b1`](https://github.com/nix-community/home-manager/commit/64a809b198904668c043d662043d17e14498cd54) | `` lib/zsh: exportAll add support for indentation `` |