### PR TITLE
chore(flake/home-manager): `a97df40c` -> `6ee84731`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759088654,
-        "narHash": "sha256-31Xc5bIeqqOJA0Kuk9s7TAMakuyggGHBluP3LqedQiE=",
+        "lastModified": 1759094885,
+        "narHash": "sha256-axmfkJn19E9yhAgfHcnYX0VM71XCyCMWu/5tUVOpM3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a97df40c1966cc46b5f6817ac8d8e240da03de96",
+        "rev": "6ee8473173af7a0181a788e8a3d4fa164f4cc72c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`6ee84731`](https://github.com/nix-community/home-manager/commit/6ee8473173af7a0181a788e8a3d4fa164f4cc72c) | `` tests: improve debugging for failed test runs `` |
| [`e9114f96`](https://github.com/nix-community/home-manager/commit/e9114f96efc6e40ecf60e3db130c0a0ca88d1800) | `` tests: rename test-all-* tests ``                |