### PR TITLE
chore(flake/home-manager): `6ee84731` -> `619ae569`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759094885,
-        "narHash": "sha256-axmfkJn19E9yhAgfHcnYX0VM71XCyCMWu/5tUVOpM3U=",
+        "lastModified": 1759106866,
+        "narHash": "sha256-GjLvAl7qxGxKtop6ghasxjQ1biTT7pA+WU45byzMl/4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6ee8473173af7a0181a788e8a3d4fa164f4cc72c",
+        "rev": "619ae569293b6427d23cce4854eb4f3c33af3eec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`619ae569`](https://github.com/nix-community/home-manager/commit/619ae569293b6427d23cce4854eb4f3c33af3eec) | `` news: add intelli-shell entry ``          |
| [`580ff74a`](https://github.com/nix-community/home-manager/commit/580ff74a7132af3228f7dd778a07083b3c338aeb) | `` intelli-shell: add module ``              |
| [`50375df1`](https://github.com/nix-community/home-manager/commit/50375df1f734f955a6b532bcc900c2588cddd3ab) | `` git-worktree-switcher: use cfg.package `` |