### PR TITLE
chore(flake/nh): `8bf32348` -> `f3920fd9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757846222,
-        "narHash": "sha256-papocgox6HOM+BJrWmWZuRnuDXi625diuC3sajCXd9A=",
+        "lastModified": 1759134674,
+        "narHash": "sha256-7NaMOQpxRFjjUGOLZmoAwb/5dDQQTFn3NuzfZHJZzJ8=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "8bf323483166797a204579a43ed8810113eb128c",
+        "rev": "f3920fd9354902815db2b51c7b3c698f65b62e95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                       |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`40fe8435`](https://github.com/nix-community/nh/commit/40fe8435fe4d3ed7b8acd69254909e5f80263b08) | `` nixos: apply clippy hints ``               |
| [`71cd07ad`](https://github.com/nix-community/nh/commit/71cd07adeeb1540fa74e82f150ed6bc2937d2ada) | `` nixos: simplify configuration switching `` |