### PR TITLE
chore(flake/home-manager): `619ae569` -> `12fa8548`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759106866,
-        "narHash": "sha256-GjLvAl7qxGxKtop6ghasxjQ1biTT7pA+WU45byzMl/4=",
+        "lastModified": 1759172751,
+        "narHash": "sha256-E8W8sRXfrvkFW26GuuiWq6QfReU7m5+cngwHuRo/3jc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "619ae569293b6427d23cce4854eb4f3c33af3eec",
+        "rev": "12fa8548feefa9a10266ba65152fd1a787cdde8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`12fa8548`](https://github.com/nix-community/home-manager/commit/12fa8548feefa9a10266ba65152fd1a787cdde8f) | `` maintainers: update all-maintainers.nix `` |