### PR TITLE
chore(flake/stylix): `fe74ba4a` -> `126e6c76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -716,11 +716,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1759131326,
-        "narHash": "sha256-fFhUx2C0Wtz0YkndtnlpSesrqj4lP3d5BUnMprpXtTk=",
+        "lastModified": 1759305203,
+        "narHash": "sha256-Mj3VQcpE5CVqfhi0Yp2B5qn5EcUwiPD4nCngxUiBHMg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fe74ba4ade9f3bb1496fbff27cc7a0ca873e40c4",
+        "rev": "126e6c7625620e949d86578046fe97f418478c42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`126e6c76`](https://github.com/nix-community/stylix/commit/126e6c7625620e949d86578046fe97f418478c42) | `` obsidian: init (#1918) `` |