### PR TITLE
chore(flake/nh): `f3920fd9` -> `f625021e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759134674,
-        "narHash": "sha256-7NaMOQpxRFjjUGOLZmoAwb/5dDQQTFn3NuzfZHJZzJ8=",
+        "lastModified": 1759315083,
+        "narHash": "sha256-vYR2THbt0fHOVyQfAhs8MdB848dNq+llWHZpJF53OBY=",
         "owner": "nix-community",
         "repo": "nh",
-        "rev": "f3920fd9354902815db2b51c7b3c698f65b62e95",
+        "rev": "f625021ec708f002070382f1594cdf0ed8b69a3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                      |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b0a7b1c1`](https://github.com/nix-community/nh/commit/b0a7b1c16ff8aa4c75d77bc61e8b56f9beaf6948) | `` nixos: add `--install-bootloader` for explicit bootloader installation `` |