### PR TITLE
chore(flake/home-manager): `5a21f481` -> `5890176f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759261733,
-        "narHash": "sha256-G104PUPKBgJmcu4NWs0LUaPpSOTD4jiq4mamLWu3Oc0=",
+        "lastModified": 1759331616,
+        "narHash": "sha256-LVpodobJvJM5rmfh2sFBHPNX0PYpNbbHzx/gprlKGGg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5a21f4819ee1be645f46d6b255d49f4271ef6723",
+        "rev": "5890176f856dcaf55f3ab56b25d4138657531cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`5890176f`](https://github.com/nix-community/home-manager/commit/5890176f856dcaf55f3ab56b25d4138657531cbd) | `` ci: backport use ubuntu latest ``        |
| [`9d5b443c`](https://github.com/nix-community/home-manager/commit/9d5b443cc88fee03542a2af659ef960ecba40d96) | `` flake.lock: Update ``                    |
| [`6b1b122c`](https://github.com/nix-community/home-manager/commit/6b1b122c1bb58b9beb68a42ae3d2aabc0e4e77d2) | `` tests: fix zsh-session-variables test `` |