### PR TITLE
chore(flake/home-manager): `5890176f` -> `004753ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759331616,
-        "narHash": "sha256-LVpodobJvJM5rmfh2sFBHPNX0PYpNbbHzx/gprlKGGg=",
+        "lastModified": 1759337100,
+        "narHash": "sha256-CcT3QvZ74NGfM+lSOILcCEeU+SnqXRvl1XCRHenZ0Us=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5890176f856dcaf55f3ab56b25d4138657531cbd",
+        "rev": "004753ae6b04c4b18aa07192c1106800aaacf6c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`004753ae`](https://github.com/nix-community/home-manager/commit/004753ae6b04c4b18aa07192c1106800aaacf6c3) | `` home-manager: add backup overwrite option ``                         |
| [`7500458e`](https://github.com/nix-community/home-manager/commit/7500458e853e17bb1a03f0142d24069ba02ad0f5) | `` files: improve collision error message formatting for readability `` |
| [`a42e05d9`](https://github.com/nix-community/home-manager/commit/a42e05d9b13069eb1d122f565a312c011b09cafe) | `` Revert "fish: support theme plugins" ``                              |