### PR TITLE
chore(flake/stylix): `126e6c76` -> `3f70c585`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1759305203,
-        "narHash": "sha256-Mj3VQcpE5CVqfhi0Yp2B5qn5EcUwiPD4nCngxUiBHMg=",
+        "lastModified": 1759404594,
+        "narHash": "sha256-k9hd15rLqG7x3OCUPrcQtpleDlOyQjy16ZEseruypNQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "126e6c7625620e949d86578046fe97f418478c42",
+        "rev": "3f70c5855572004f9c630ed4a92aa186755361be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`3f70c585`](https://github.com/nix-community/stylix/commit/3f70c5855572004f9c630ed4a92aa186755361be) | `` hyprpanel: init (#1916) ``                                       |
| [`ecd07bea`](https://github.com/nix-community/stylix/commit/ecd07beac127bb6a73b2c8d6883b6dd1386ea21c) | `` ci: bump korthout/backport-action from 3.3.0 to 3.4.1 (#1923) `` |