### PR TITLE
chore(flake/nixpkgs): `e9f00bd8` -> `7df7ff7d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -544,11 +544,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "lastModified": 1759381078,
+        "narHash": "sha256-gTrEEp5gEspIcCOx9PD8kMaF1iEmfBcTbO0Jag2QhQs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "rev": "7df7ff7d8e00218376575f0acdcc5d66741351ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`ca9334a3`](https://github.com/NixOS/nixpkgs/commit/ca9334a3f1e2a54818d7ce97b5630886698b32a4) | `` llvmPackages_latest: llvmPackages_20 -> llvmPackages_21 ``                             |
| [`3da9c6b0`](https://github.com/NixOS/nixpkgs/commit/3da9c6b037c88d3006766010b19486ac79bdbbd7) | `` ocamlPackages.ocp-indent: 1.8.2 -> 1.9.0 ``                                            |
| [`174cd482`](https://github.com/NixOS/nixpkgs/commit/174cd482e2410833cda7ee398f30931a04cd7f99) | `` devenv: 1.9 -> 1.9.1 ``                                                                |
| [`ac302292`](https://github.com/NixOS/nixpkgs/commit/ac30229280db62fcc9143139d071d4a5f726b38e) | `` driversi686Linux.mesa: 25.2.3 -> 25.2.4 ``                                             |
| [`14b42392`](https://github.com/NixOS/nixpkgs/commit/14b42392542fc7ef01341423d73c600b0bd31970) | `` deco: cleanup ``                                                                       |
| [`4c068743`](https://github.com/NixOS/nixpkgs/commit/4c068743a798096674e81c4b10147c3ce2750526) | `` deco: unstable-2019-04-03 -> unstable-2025-07-07 ``                                    |
| [`b1646aaa`](https://github.com/NixOS/nixpkgs/commit/b1646aaa7cce7d56d92afbd3070cf4db944c1b1c) | `` scsh: fix looking correct scheme version ``                                            |
| [`98845a3d`](https://github.com/NixOS/nixpkgs/commit/98845a3d79898b5ef72290ea160fb7360225470b) | `` jujutsu: 0.33.0 -> 0.34.0 ``                                                           |
| [`b08d5c06`](https://github.com/NixOS/nixpkgs/commit/b08d5c06f99eac5b9a54e55da6528556de257800) | `` mozillavpn: 2.31.0 -> 2.31.1 ``                                                        |
| [`c92b4231`](https://github.com/NixOS/nixpkgs/commit/c92b42314d879a0f7c44522e0bff6c5d89c2fcf1) | `` clifm: 1.26 -> 1.26.3 ``                                                               |
| [`8c34dffa`](https://github.com/NixOS/nixpkgs/commit/8c34dffa76790d69da8bccfe2035fed67b06228c) | `` wesnoth: add maintainer iedame ``                                                      |
| [`3bdfcf7a`](https://github.com/NixOS/nixpkgs/commit/3bdfcf7a101231c4952d851f4a25e98f3adb2a59) | `` wesnoth: move to pkgs/by-name ``                                                       |
| [`1114ce49`](https://github.com/NixOS/nixpkgs/commit/1114ce4956ad1954e0a7d7e496301223b17d79ef) | `` ossia-score: 3.7.0 -> 3.7.1 ``                                                         |
| [`043b1baf`](https://github.com/NixOS/nixpkgs/commit/043b1baf6094f20a45248ac81019bc6fed041df5) | `` argocd: 3.1.6 -> 3.1.8 ``                                                              |
| [`c9e171db`](https://github.com/NixOS/nixpkgs/commit/c9e171db36af96fc239a6bc3b9ab47a3fd908510) | `` scip-go: 0.1.25 -> 0.1.26 ``                                                           |
| [`20e131d7`](https://github.com/NixOS/nixpkgs/commit/20e131d7ad6c7378f93fed9c31ce3e4b5aa42a3f) | `` diffoscope: 303 -> 304 ``                                                              |
| [`1fbf1f1b`](https://github.com/NixOS/nixpkgs/commit/1fbf1f1b93b6c2834f0b2486fe0eb91d88ba1996) | `` polarity: latest-unstable-2025-09-17 -> latest-unstable-2025-09-25 ``                  |
| [`8080f4f3`](https://github.com/NixOS/nixpkgs/commit/8080f4f3370375ca50f525ef85109da7286d41c8) | `` pkarr: 2.0.0 -> 4.0.0 ``                                                               |
| [`f6496fe0`](https://github.com/NixOS/nixpkgs/commit/f6496fe0146299a4867703da0f7e901779dc32cc) | `` python3Packages.trimesh: 4.8.2 -> 4.8.3 ``                                             |
| [`9cd057b6`](https://github.com/NixOS/nixpkgs/commit/9cd057b6ab614312f051326f730b24c213c06635) | `` vimPlugins.project-nvim: 2025-09-26 -> 2025-10-01 ``                                   |
| [`b03018ad`](https://github.com/NixOS/nixpkgs/commit/b03018ad4a6a894aa07b61ab16c17442afc07937) | `` _1password-gui-beta: 8.11.12-26.BETA -> 8.11.14-19.BETA ``                             |
| [`33349db0`](https://github.com/NixOS/nixpkgs/commit/33349db0ee642a94e9933bb4612474f29bc5abc1) | `` python3Packages.textual: 6.2.0 -> 6.2.1 ``                                             |
| [`e10ac458`](https://github.com/NixOS/nixpkgs/commit/e10ac4585476c6f27234cfa0fbcb62d0e993078f) | `` dotenvx: 1.50.1 -> 1.51.0 ``                                                           |
| [`124ca62f`](https://github.com/NixOS/nixpkgs/commit/124ca62f3faa77ccbeb503615176dacc4463a2c7) | `` python3Packages.fastmcp: skip failing test ``                                          |
| [`220b54af`](https://github.com/NixOS/nixpkgs/commit/220b54afedb8c0241bb48a010a03550358451e7b) | `` olympus-unwrapped: 25.09.09.02 -> 25.09.30.01 ``                                       |
| [`d394ed87`](https://github.com/NixOS/nixpkgs/commit/d394ed871017f99b0edd1f1e9ba54f5a7e9bb28d) | `` chromium,chromedriver: 140.0.7339.207 -> 141.0.7390.54 ``                              |
| [`658df016`](https://github.com/NixOS/nixpkgs/commit/658df016886973832d928b9e3a78227025ba595d) | `` chromium: remove redundant `run_mksnapshot_default` build target ``                    |
| [`713691f9`](https://github.com/NixOS/nixpkgs/commit/713691f9ea04cbe760e589c99531244fbc393749) | `` chromium: remove no longer needed version conditionals ``                              |
| [`2bf6e7a4`](https://github.com/NixOS/nixpkgs/commit/2bf6e7a43ed2c0e2955a72eab8aaa043d5e07edb) | `` dq: 20250201 -> 20251001 ``                                                            |
| [`4b4987c5`](https://github.com/NixOS/nixpkgs/commit/4b4987c5c29d0c26ca629208ee4ddd95f6206b89) | `` nixos/tools: remove deprecated accessors for pkgs.nixos-option and pkgs.nixos-enter `` |
| [`9ee55f63`](https://github.com/NixOS/nixpkgs/commit/9ee55f63c5ccaf52e56a6fb6a53209d3d655037c) | `` bngblaster: 0.9.24 -> 0.9.25 ``                                                        |
| [`49997e1c`](https://github.com/NixOS/nixpkgs/commit/49997e1c8e6afe1c41b145d3ce553f8ccf085422) | `` {nodePackages,vimPlugins}.coc-rls: drop ``                                             |
| [`f046bacd`](https://github.com/NixOS/nixpkgs/commit/f046bacde32c2e9217adafd33dd8d9d35f4565d6) | `` cni-plugin-flannel: 1.7.1-flannel2 -> 1.8.0-flannel1 ``                                |
| [`a9a57621`](https://github.com/NixOS/nixpkgs/commit/a9a5762117788b7d55d1412cbe4f19c0f95738ee) | `` ddns-go: 6.12.4 -> 6.12.5 ``                                                           |
| [`207deec2`](https://github.com/NixOS/nixpkgs/commit/207deec2a820b364ce0a815d772bd51b7332d60b) | `` dablin: 1.16.0 -> 1.16.1 ``                                                            |
| [`b60109ab`](https://github.com/NixOS/nixpkgs/commit/b60109ab98a704fcca87119adae3613527bb0340) | `` python3Packages.langsmith: 0.4.29 -> 0.4.31 ``                                         |
| [`9a693ae7`](https://github.com/NixOS/nixpkgs/commit/9a693ae7fe44c3b7ae1f8bde19b69ba50e937b29) | `` nodePackages.coc-docker: migrate to pkgs/by-name ``                                    |
| [`7e310754`](https://github.com/NixOS/nixpkgs/commit/7e310754cedad9054669ab8fa9d8ab6c58e2eee7) | `` openspeedrun: init at 0.3.3 ``                                                         |
| [`36dddbb1`](https://github.com/NixOS/nixpkgs/commit/36dddbb1cd9b2092c9af9e7c2ece35b311b5916b) | `` ocamlPackages.hxd: 0.3.4 -> 0.3.5 ``                                                   |
| [`cd508737`](https://github.com/NixOS/nixpkgs/commit/cd508737e1d129b36cabf92e027c6860e9cdf4cb) | `` ocamlPackages.alcotest: 1.9.0 -> 1.9.1 ``                                              |
| [`2158ccb6`](https://github.com/NixOS/nixpkgs/commit/2158ccb683a31516707fa2ffda3b98c7b98ddeb6) | `` zfs: fix version specific command rename ``                                            |
| [`640ee975`](https://github.com/NixOS/nixpkgs/commit/640ee975568941846000aa4e31597b13ff057a15) | `` python3Packages.django-import-export: 4.3.9 -> 4.3.10 ``                               |
| [`07818993`](https://github.com/NixOS/nixpkgs/commit/0781899332b61a7145a21303352963b953fdf3a6) | `` python3Packages.cynthion: 0.2.3 -> 0.2.4 ``                                            |
| [`7a27cd59`](https://github.com/NixOS/nixpkgs/commit/7a27cd59ec192b88743b5648fd064260e3c0cabc) | `` di-tui: 1.11.2 -> 1.11.3 ``                                                            |
| [`be0b65c1`](https://github.com/NixOS/nixpkgs/commit/be0b65c1a09a881e79060ea3d792bcc337e51e2a) | `` terraform-providers.nomad: 2.5.0 -> 2.5.1 ``                                           |
| [`1a02b8ef`](https://github.com/NixOS/nixpkgs/commit/1a02b8ef1c0ddc88584c2df02954aa1e20a9c59e) | `` python3Packages.fastmcp: 2.11.3 -> 2.12.4 ``                                           |
| [`eedcc51c`](https://github.com/NixOS/nixpkgs/commit/eedcc51c7d46e057ae82f2ceb3cee3b57e93f44f) | `` mackerel-agent: 0.85.1 -> 0.85.2 ``                                                    |
| [`7b3c6cf1`](https://github.com/NixOS/nixpkgs/commit/7b3c6cf18ddeda6ee1d5823068a7cfc37d0f620e) | `` qwen-code: 0.0.13 -> 0.0.14 ``                                                         |
| [`090ba28a`](https://github.com/NixOS/nixpkgs/commit/090ba28a9e96509ba0d3a0aaa7633059d360ff55) | `` libretro-shaders-slang: 0-unstable-2025-09-14 -> 0-unstable-2025-09-26 ``              |
| [`91c1aa5b`](https://github.com/NixOS/nixpkgs/commit/91c1aa5bc75337801278e743da81f5100d1d640d) | `` libretro.snes9x: 0-unstable-2025-09-18 -> 0-unstable-2025-09-24 ``                     |
| [`8f73592c`](https://github.com/NixOS/nixpkgs/commit/8f73592c7a1fc3c31634ea174ec95dc0d21152f3) | `` gale: 1.9.7 -> 1.10.0 ``                                                               |
| [`7cc7c1ec`](https://github.com/NixOS/nixpkgs/commit/7cc7c1ec3b24f6fbc5f498603ab0f4bae17ea299) | `` python3Packages.databricks-sdk: 0.65.0 -> 0.67.0 ``                                    |
| [`d2b703d2`](https://github.com/NixOS/nixpkgs/commit/d2b703d206d953b633aad3456ce93b6ad5b5dcf6) | `` zsh-forgit: 25.09.0 -> 25.10.0 ``                                                      |
| [`02a889f1`](https://github.com/NixOS/nixpkgs/commit/02a889f18aefb0b922f4a7ee2854e96e62760e47) | `` whisperx: 3.4.2 -> 3.4.3 ``                                                            |
| [`40550690`](https://github.com/NixOS/nixpkgs/commit/40550690893b07f5d2a7c68506ebc07a9700c502) | `` immich: 1.143.1 -> 1.144.1 ``                                                          |
| [`06d40e88`](https://github.com/NixOS/nixpkgs/commit/06d40e889f6b16d014965d3c803f846975df99ac) | `` vscode: 1.104.1 -> 1.104.2 ``                                                          |
| [`2c373672`](https://github.com/NixOS/nixpkgs/commit/2c373672a05b3a153f825760ff2a96471f702f62) | `` osv-scanner: 2.2.2 -> 2.2.3 ``                                                         |
| [`5a026899`](https://github.com/NixOS/nixpkgs/commit/5a026899267f05161ddaa865302ad43850f38f35) | `` media-downloader: 5.4.2 -> 5.4.3 ``                                                    |
| [`b953f292`](https://github.com/NixOS/nixpkgs/commit/b953f2928714b69dca70e4987874c22f6a65ee3a) | `` vscode-extensions.prisma.prisma: 6.16.2 -> 6.16.3 ``                                   |
| [`edbe92d2`](https://github.com/NixOS/nixpkgs/commit/edbe92d26dc7c414e9524e0bad49acb17b1c4903) | `` terraform-providers.google-beta: 7.3.0 -> 7.5.0 ``                                     |
| [`29c1e9e8`](https://github.com/NixOS/nixpkgs/commit/29c1e9e8b18198c2d7a4cb6db92758f7b08e66b8) | `` python3Packages.blake3: 1.0.6 -> 1.0.7 ``                                              |
| [`cabaf208`](https://github.com/NixOS/nixpkgs/commit/cabaf20875e382d33d053911d78f47829bb5f76a) | `` kitty: 0.43.0->0.43.1 ``                                                               |
| [`32ff85be`](https://github.com/NixOS/nixpkgs/commit/32ff85be3038f9e7bffa367b7f23d9903fcd83e0) | `` python3Packages.cantools: 40.7.0 -> 40.7.1 ``                                          |
| [`63fa10f9`](https://github.com/NixOS/nixpkgs/commit/63fa10f9913f31366fa465906653a6b1b98ba3a3) | `` python313Packages.pyicloud: 1.0.0 -> 2.1.0 ``                                          |
| [`fada6dd6`](https://github.com/NixOS/nixpkgs/commit/fada6dd622e0557c72db6d327a4033475e0801c4) | `` python313Packages.boto3-stubs: 1.40.41 -> 1.40.42 ``                                   |
| [`5e1d78d4`](https://github.com/NixOS/nixpkgs/commit/5e1d78d405f1fec6326692a178631730bbe6da54) | `` python312Packages.mypy-boto3-transfer: 1.40.0 -> 1.40.42 ``                            |
| [`abad91e1`](https://github.com/NixOS/nixpkgs/commit/abad91e1258e6b54320481d2f7f4a71ac8d714c8) | `` python312Packages.mypy-boto3-rds: 1.40.29 -> 1.40.42 ``                                |
| [`8e30132c`](https://github.com/NixOS/nixpkgs/commit/8e30132c76b58d068f5f8415c9a69e83762af8d1) | `` python312Packages.mypy-boto3-quicksight: 1.40.29 -> 1.40.42 ``                         |
| [`3ffde587`](https://github.com/NixOS/nixpkgs/commit/3ffde58703ce3b6be0f5551cd73a62634544fecf) | `` python312Packages.mypy-boto3-mediatailor: 1.40.0 -> 1.40.42 ``                         |
| [`48a5ecaf`](https://github.com/NixOS/nixpkgs/commit/48a5ecafc72b6d9457d4fec2b3e8e7e5854583d1) | `` python312Packages.mypy-boto3-fsx: 1.40.10 -> 1.40.42 ``                                |
| [`85459050`](https://github.com/NixOS/nixpkgs/commit/854590500870858dfeb48e174be1818cf8c15cdf) | `` python312Packages.mypy-boto3-ecs: 1.40.29 -> 1.40.42 ``                                |
| [`c44cac25`](https://github.com/NixOS/nixpkgs/commit/c44cac2592731ae29bbd6341ca4c6babd86c25e5) | `` python312Packages.mypy-boto3-ds: 1.40.19 -> 1.40.42 ``                                 |
| [`933e19ff`](https://github.com/NixOS/nixpkgs/commit/933e19ff26765226016a416ca14eccf62de921f9) | `` python312Packages.mypy-boto3-datasync: 1.40.0 -> 1.40.42 ``                            |
| [`c4c9aee2`](https://github.com/NixOS/nixpkgs/commit/c4c9aee2f3c3ec9d5ec3030621fdf84414a4066f) | `` python312Packages.mypy-boto3-customer-profiles: 1.40.0 -> 1.40.42 ``                   |
| [`d8e39aed`](https://github.com/NixOS/nixpkgs/commit/d8e39aedc597125c5086846f9bd130f516936256) | `` python312Packages.mypy-boto3-connectcases: 1.40.0 -> 1.40.42 ``                        |
| [`89a12692`](https://github.com/NixOS/nixpkgs/commit/89a126923bfcaa47e9940a34b3f818da2e546c4d) | `` python312Packages.mypy-boto3-chime-sdk-voice: 1.40.19 -> 1.40.42 ``                    |
| [`7ac45f45`](https://github.com/NixOS/nixpkgs/commit/7ac45f4553eda4555e676cfedf269a4ccc5ea88d) | `` stalwart-mail: 0.13.2 -> 0.13.4 ``                                                     |
| [`a7d28426`](https://github.com/NixOS/nixpkgs/commit/a7d284263a5a29a8967179a12061e3ecb5614f3f) | `` nixos/tests/renovate: fixes for recent forgejo updates ``                              |
| [`33cf67d6`](https://github.com/NixOS/nixpkgs/commit/33cf67d6263f5c7ea4c64b3d1f52eba5af4dd3e4) | `` python3Packages.pyinstaller-hooks-contrib: 2025.8 -> 2025.9 ``                         |
| [`89bd3105`](https://github.com/NixOS/nixpkgs/commit/89bd31053cd789c520e6964b2a30ced65264eea7) | `` zfs_unstable: 2.4.0-rc1 -> 2.4.0-rc2 ``                                                |
| [`a2fcc129`](https://github.com/NixOS/nixpkgs/commit/a2fcc129c2960ae21fd17810b39469b8714113a1) | `` avbroot: 3.22.0 -> 3.23.0 ``                                                           |
| [`5dcf5e89`](https://github.com/NixOS/nixpkgs/commit/5dcf5e899d7a00cc8caa24f2096eaace027a65b8) | `` fishPlugins.forgit: 25.09.0 -> 25.10.0 ``                                              |
| [`843fa0fa`](https://github.com/NixOS/nixpkgs/commit/843fa0fa28579ec26a79450a7edf96e3ba303e16) | `` nixos/pantheon: add elementary-maps ``                                                 |
| [`126480b1`](https://github.com/NixOS/nixpkgs/commit/126480b1b080fa9f8667594820b9dd63a8238ffd) | `` pantheon.elementary-maps: init at 8.1.0 ``                                             |
| [`e5bf465a`](https://github.com/NixOS/nixpkgs/commit/e5bf465aca1c29df4fc8d08c83ae7c0ad3ea2f9b) | `` pantheon.granite7: 7.6.0 -> 7.7.0 ``                                                   |
| [`e63a0fe6`](https://github.com/NixOS/nixpkgs/commit/e63a0fe653cff64c35d37c2448904db45382353a) | `` geographiclib: 2.5.2 -> 2.6 ``                                                         |
| [`902d290b`](https://github.com/NixOS/nixpkgs/commit/902d290b7d6ae02a4d71c42fa24c991a15734f80) | `` polymake: 4.14 -> 4.15 ``                                                              |
| [`02ccf010`](https://github.com/NixOS/nixpkgs/commit/02ccf010c7c235ad7b276a1afefb9ddb2cff09f6) | `` librewolf-unwrapped: 143.0-1 -> 143.0.3-1 ``                                           |
| [`7c7bfaa8`](https://github.com/NixOS/nixpkgs/commit/7c7bfaa83b7dcd62de46168cb6ecde172837f19b) | `` renovate: 41.81.0 -> 41.132.4 ``                                                       |
| [`a7ad617b`](https://github.com/NixOS/nixpkgs/commit/a7ad617b8e30fa8e22ed18492b9b7302358185f5) | `` mtail: 3.2.16 -> 3.2.18 ``                                                             |
| [`d026e4d7`](https://github.com/NixOS/nixpkgs/commit/d026e4d7fb7942798536eae6f31abf10490e3b60) | `` snakefmt: 0.11.0 -> 0.11.2 ``                                                          |
| [`26aa426e`](https://github.com/NixOS/nixpkgs/commit/26aa426e2ae01801b62e8288129d5ab8c0dd6638) | `` ni: 26.0.1 -> 26.1.0 ``                                                                |
| [`2e4222fa`](https://github.com/NixOS/nixpkgs/commit/2e4222fa7c535f269698c770c09f03b94149e346) | `` tlrc: 1.11.1 -> 1.12.0 ``                                                              |
| [`6cd3cca0`](https://github.com/NixOS/nixpkgs/commit/6cd3cca0934074f65c4241010433e00caccdb221) | `` checkov: 3.2.471 -> 3.2.473 ``                                                         |
| [`a0fa6df0`](https://github.com/NixOS/nixpkgs/commit/a0fa6df0a25f5ab607675ca160b07df158b51c3b) | `` bluemap: 5.11 -> 5.12 ``                                                               |
| [`9197cc53`](https://github.com/NixOS/nixpkgs/commit/9197cc5350cdfabc9e94e981e7a8104d3a78a01a) | `` cargo-shuttle: 0.57.1 -> 0.57.3 ``                                                     |
| [`b1fa6752`](https://github.com/NixOS/nixpkgs/commit/b1fa67523dca94d7cb0c956d885edba99b5f1103) | `` python3Packages.docling-mcp: 1.2.0 -> 1.3.1 ``                                         |
| [`d465f694`](https://github.com/NixOS/nixpkgs/commit/d465f694b299312f89f0256ceba7ba1e6e352608) | `` python3Packages.llama-stack-client: 0.2.22 -> 0.2.23 ``                                |