### PR TITLE
chore(flake/home-manager): `004753ae` -> `bd92e8ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759337100,
-        "narHash": "sha256-CcT3QvZ74NGfM+lSOILcCEeU+SnqXRvl1XCRHenZ0Us=",
+        "lastModified": 1759519282,
+        "narHash": "sha256-Wj76KLk49eRS086h6Fh0si95P6qqpzO7Gno9/nI336E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "004753ae6b04c4b18aa07192c1106800aaacf6c3",
+        "rev": "bd92e8ee4a6031ca3dd836c91dc41c13fca1e533",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`bd92e8ee`](https://github.com/nix-community/home-manager/commit/bd92e8ee4a6031ca3dd836c91dc41c13fca1e533) | `` asciinema: Add module to configure package `` |
| [`dd2b0f74`](https://github.com/nix-community/home-manager/commit/dd2b0f74920541d5dc3a5f4e1a12a19e77f5eacc) | `` news: add alistral entry ``                   |
| [`6bbfe2d6`](https://github.com/nix-community/home-manager/commit/6bbfe2d6973fb16137d3ef5e322b4591c22948b1) | `` alistral: add module ``                       |