### PR TITLE
chore(flake/home-manager): `bd92e8ee` -> `edafd6da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759519282,
-        "narHash": "sha256-Wj76KLk49eRS086h6Fh0si95P6qqpzO7Gno9/nI336E=",
+        "lastModified": 1759536080,
+        "narHash": "sha256-0aXlKPxm2M+F5oywX2TTbY0e6h+tQ+6OYyx7UZn3A4A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bd92e8ee4a6031ca3dd836c91dc41c13fca1e533",
+        "rev": "edafd6da1936426708f1be0b1a4288007f16639a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`edafd6da`](https://github.com/nix-community/home-manager/commit/edafd6da1936426708f1be0b1a4288007f16639a) | `` news: add aliae's configLocation option entry `` |
| [`2126d13d`](https://github.com/nix-community/home-manager/commit/2126d13d7f0049b2731e586f8e611eb8f775bcd3) | `` aliae: add configLocation option ``              |