### PR TITLE
chore(flake/home-manager): `edafd6da` -> `817ace49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759536080,
-        "narHash": "sha256-0aXlKPxm2M+F5oywX2TTbY0e6h+tQ+6OYyx7UZn3A4A=",
+        "lastModified": 1759550472,
+        "narHash": "sha256-JLM3D6RbnGmXR8x+3WNac9neklAxA1JtZHZscwukFYw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edafd6da1936426708f1be0b1a4288007f16639a",
+        "rev": "817ace497b72b38da0c08728a683b7febaccf9cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`817ace49`](https://github.com/nix-community/home-manager/commit/817ace497b72b38da0c08728a683b7febaccf9cf) | `` lorri: make notifications service auto-start if enabled ``   |
| [`66e9a024`](https://github.com/nix-community/home-manager/commit/66e9a024b901034a311cab145e1d6935f66f30bb) | `` hyprshell: fixed tests to use correct name for style file `` |
| [`bdf78c2d`](https://github.com/nix-community/home-manager/commit/bdf78c2d2c285683b02abca8071f11a1667b212a) | `` hyprshell: fixed path for style file ``                      |
| [`edfbe06e`](https://github.com/nix-community/home-manager/commit/edfbe06e1a67d0fb3e3c04c2651eecab39e96928) | `` treewide: remove aidalgol ``                                 |