### PR TITLE
chore(flake/home-manager): `817ace49` -> `5f06ceaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759550472,
-        "narHash": "sha256-JLM3D6RbnGmXR8x+3WNac9neklAxA1JtZHZscwukFYw=",
+        "lastModified": 1759573136,
+        "narHash": "sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "817ace497b72b38da0c08728a683b7febaccf9cf",
+        "rev": "5f06ceafc6c9b773a776b9195c3f47bbe1defa43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`5f06ceaf`](https://github.com/nix-community/home-manager/commit/5f06ceafc6c9b773a776b9195c3f47bbe1defa43) | `` vscode: also test unknown package if IFD is enabled `` |
| [`03f83f51`](https://github.com/nix-community/home-manager/commit/03f83f513de3f32a4539875d64e8511fbcfdaeb4) | `` vscode: get paths from product.json ``                 |