### PR TITLE
chore(flake/stylix): `3f70c585` -> `503d9896`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1759404594,
-        "narHash": "sha256-k9hd15rLqG7x3OCUPrcQtpleDlOyQjy16ZEseruypNQ=",
+        "lastModified": 1759595578,
+        "narHash": "sha256-cYPdsYgZFyvpMbRg9Nbtt3JtcdjE80gXfe/65T1ELco=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3f70c5855572004f9c630ed4a92aa186755361be",
+        "rev": "503d989626aa41174b3a51f18528547da1afe572",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`503d9896`](https://github.com/nix-community/stylix/commit/503d989626aa41174b3a51f18528547da1afe572) | `` flake: add default modules (#1905) ``               |
| [`2de90e0a`](https://github.com/nix-community/stylix/commit/2de90e0ab11481652bb02716209a7e66d911daec) | `` waybar: improve tooltip label contrast (#1919) ``   |
| [`22d291b0`](https://github.com/nix-community/stylix/commit/22d291b0a5f7570807337b4d9bff8a5d17536d30) | `` ci: check: use correct x86_64-darwin runner ``      |
| [`cbb9010d`](https://github.com/nix-community/stylix/commit/cbb9010d16a265c4b67495fa60d7067b87fc7389) | `` ci: check: bump x86_64-darwin runner to macos-15 `` |