### PR TITLE
chore(flake/lovesegfault-vim-config): `472fc5e6` -> `54d46a65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759536564,
-        "narHash": "sha256-JVg+tfeUmF9hDwHPULOAET90Fz8//dWfvEygSFOnjIs=",
+        "lastModified": 1759622833,
+        "narHash": "sha256-n1zT/wCITfIp8Yh2DHyvDD41f9LAxxPAXG+g05vAkWU=",
         "owner": "lovesegfault",
         "repo": "vim-config",
-        "rev": "472fc5e68941d83c14a96c7ae8370997c4bf1712",
+        "rev": "54d46a653727472f6329a326828b6fef6cd5e621",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1759527752,
-        "narHash": "sha256-+sncyvy1dkwRBeq7vw/YpsKqB18UuaKuW2lKRRv6/EI=",
+        "lastModified": 1759618379,
+        "narHash": "sha256-4j73b+t3B5sN1JAcwAT9XD4P38o3qvBqCkfXPvnAY3o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "42d87fd4d8f51ea8c591b0b72af76b0aba991f54",
+        "rev": "2f8fbcdfd02b16e7392f5cfa3600aa77cd559d37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                         |
| -------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`54d46a65`](https://github.com/lovesegfault/vim-config/commit/54d46a653727472f6329a326828b6fef6cd5e621) | `` chore(flake/nixvim): 42d87fd4 -> 2f8fbcdf `` |