### PR TITLE
chore(flake/home-manager): `5f06ceaf` -> `06e268d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759573136,
-        "narHash": "sha256-ILSPD0Dm8p0w0fCVzOx98ZH8yFDrR75GmwmH3fS2VnE=",
+        "lastModified": 1759691947,
+        "narHash": "sha256-+A9wFkB266FZH8Lz/TQfgWf5sOWmYPQZ6p3K8NgpuxU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f06ceafc6c9b773a776b9195c3f47bbe1defa43",
+        "rev": "06e268d66bbf6d606b349a4f0be3af66ab3ea2be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`06e268d6`](https://github.com/nix-community/home-manager/commit/06e268d66bbf6d606b349a4f0be3af66ab3ea2be) | `` services/barrier: drop module `` |
| [`b52ece2b`](https://github.com/nix-community/home-manager/commit/b52ece2bb670e888fa39ea7ef7cce523839a9452) | `` flake.lock: Update ``            |
| [`9070d7d3`](https://github.com/nix-community/home-manager/commit/9070d7d32b3d4317e95b6b92f98fee850c1f116d) | `` news: add am2rlauncher entry ``  |
| [`87570dbc`](https://github.com/nix-community/home-manager/commit/87570dbc43fafb99081a24353a26763acdad6f76) | `` am2rlauncher: add module ``      |
| [`8b624044`](https://github.com/nix-community/home-manager/commit/8b62404497528386642f4368dc552a8f79d9febe) | `` news: add amber entry ``         |
| [`2b64e332`](https://github.com/nix-community/home-manager/commit/2b64e332a047ec8d3695946bfded39bc3f3583bb) | `` amber: add module ``             |