### PR TITLE
chore(flake/stylix): `503d9896` -> `09022804`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1759595578,
-        "narHash": "sha256-cYPdsYgZFyvpMbRg9Nbtt3JtcdjE80gXfe/65T1ELco=",
+        "lastModified": 1759690047,
+        "narHash": "sha256-Vlpa0d1xOgPO9waHwxJNi6LcD2PYqB3EjwLRtSxXlHc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "503d989626aa41174b3a51f18528547da1afe572",
+        "rev": "09022804b2bcd217f3a41a644d26b23d30375d12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                       |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`09022804`](https://github.com/nix-community/stylix/commit/09022804b2bcd217f3a41a644d26b23d30375d12) | `` hyprpanel: more granularly split configElements (#1931) `` |