### PR TITLE
chore(flake/home-manager): `06e268d6` -> `5b45dcf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759691947,
-        "narHash": "sha256-+A9wFkB266FZH8Lz/TQfgWf5sOWmYPQZ6p3K8NgpuxU=",
+        "lastModified": 1759702766,
+        "narHash": "sha256-011pCUbIq/fhCiZ20AzqJYNjLzQ1oYkzYEgzcUYVTBg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "06e268d66bbf6d606b349a4f0be3af66ab3ea2be",
+        "rev": "5b45dcf4790bb94fec7e550d2915fc2540a3cdd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5b45dcf4`](https://github.com/nix-community/home-manager/commit/5b45dcf4790bb94fec7e550d2915fc2540a3cdd6) | `` tests/hyprshot: add tests ``                        |
| [`9f2912e3`](https://github.com/nix-community/home-manager/commit/9f2912e3a6c4665bebe3d61ba967ddc65ecd18d4) | `` hyprshot: add platform assertion ``                 |
| [`3c3076b1`](https://github.com/nix-community/home-manager/commit/3c3076b1c1b941715302d731a4a978bca88fa16f) | `` tests/discoss: add tests ``                         |
| [`6e8ab005`](https://github.com/nix-community/home-manager/commit/6e8ab005bc65649428cba369f2730f01955b3d6a) | `` tests/darwinscrublist: add discocss and discord ``  |
| [`f72f6609`](https://github.com/nix-community/home-manager/commit/f72f660976628775d8a5bb5ea6a3ba7ad2000cdb) | `` discocss: only generate css when provided ``        |
| [`aa10fe09`](https://github.com/nix-community/home-manager/commit/aa10fe094b444e173d5d51ee8bf5f07e7e72e473) | `` discocss: fix discordPackage override ``            |
| [`994d854a`](https://github.com/nix-community/home-manager/commit/994d854a4a90df8d8f661b19d05eb1cb6a951419) | `` tests/grep: add tests ``                            |
| [`c2e3f1ca`](https://github.com/nix-community/home-manager/commit/c2e3f1cacd0c6b2609552cb6eb1801afe1e6cc3c) | `` tests/gcc: add tests ``                             |
| [`78fda50b`](https://github.com/nix-community/home-manager/commit/78fda50bd6e1f26ae914ae77d66e6d2381b64507) | `` gcc: fix sessionVariables mkIf evaluation error ``  |
| [`51870a37`](https://github.com/nix-community/home-manager/commit/51870a37a354a37dc3bd32f3a5a7c9054249492d) | `` grep: fix sessionVariables mkIf evaluation error `` |