### PR TITLE
chore(flake/home-manager): `5b45dcf4` -> `6f4021da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759702766,
-        "narHash": "sha256-011pCUbIq/fhCiZ20AzqJYNjLzQ1oYkzYEgzcUYVTBg=",
+        "lastModified": 1759711004,
+        "narHash": "sha256-B39NxeKCnK3DJlmJKIts6njcXcVVASLUChDNmRl4dxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b45dcf4790bb94fec7e550d2915fc2540a3cdd6",
+        "rev": "6f4021da5d2bb5ea7cb782ff413ecb7062066820",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`6f4021da`](https://github.com/nix-community/home-manager/commit/6f4021da5d2bb5ea7cb782ff413ecb7062066820) | `` deprecations: move just module deprecation to new module `` |
| [`3f07ce05`](https://github.com/nix-community/home-manager/commit/3f07ce05c3b6d59602bc380e42320483081fa38f) | `` deprecations: add deprecations/removal module ``            |