### PR TITLE
chore(flake/home-manager): `6c5025e2` -> `1a09eb84`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -369,11 +369,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759852939,
-        "narHash": "sha256-WOdYcLE/bVdNM9mfXZir1BdpdVknDloWqax2AT5hvtM=",
+        "lastModified": 1759853171,
+        "narHash": "sha256-uqbhyXtqMbYIiMqVqUhNdSuh9AEEkiasoK3mIPIVRhk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c5025e2bb117eb16c0aa55097ce69935f72e14c",
+        "rev": "1a09eb84fa9e33748432a5253102d01251f72d6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------- |
| [`1a09eb84`](https://github.com/nix-community/home-manager/commit/1a09eb84fa9e33748432a5253102d01251f72d6d) | `` news: add amoco entry `` |
| [`c6f8669f`](https://github.com/nix-community/home-manager/commit/c6f8669f09a7d70abb0435614febbe03bb596a16) | `` amoco: add module ``     |