### PR TITLE
fix(nixos/keynes): import zroot via partlabels

### DIFF
--- a/configurations/nixos/keynes/default.nix
+++ b/configurations/nixos/keynes/default.nix
@@ -31,7 +31,13 @@ in
     # hegel's proven kernel+zfs combo; overrides the profile's mkDefault
     # linuxPackages_latest (ZFS lags mainline).
     kernelPackages = pkgs.linuxPackages_6_18;
-    zfs.package = pkgs.zfs_2_4;
+    zfs = {
+      package = pkgs.zfs_2_4;
+      # Import via partlabels so zpool status shows disko's disk-ebsN-zfs
+      # names instead of whichever of the ~4 by-id aliases udev's readdir
+      # order serves up first (mixed nvme-uuid/_1-suffixed serials).
+      devNodes = "/dev/disk/by-partlabel";
+    };
     kernelParams = [
       # EC2 serial console (aws ec2 get-console-output)
       "console=tty1"


### PR DESCRIPTION
Follow-up to #6811. The initrd imports zroot with `-d /dev/disk/by-id`, where every NVMe device has ~4 udev aliases, so each vdev records whichever alias readdir serves first — leaving `zpool status` with a nondeterministic mix of `nvme-uuid.…` and `_1`-suffixed serial names. Importing via `/dev/disk/by-partlabel` records disko's stable `disk-ebsN-zfs` names (and `zfs-<guid>` for cache partitions). Already deployed; display names normalize at the next reboot.