### PR TITLE
fix(actions): don't fail-fast the flake-check matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -224,6 +224,7 @@ jobs:
     - name: nix flake show
       run: nix flake show 'git+file:.'
     strategy:
+      fail-fast: false
       matrix:
         systems:
         - os: ubuntu-24.04

--- a/modules/flake-parts/actions.nix
+++ b/modules/flake-parts/actions.nix
@@ -165,7 +165,10 @@ in
           flake-check = {
             name = "flake check (\${{ matrix.systems.platform }})";
             environment = "ci";
-            strategy.matrix.systems = checkPlatforms;
+            strategy = {
+              fail-fast = false;
+              matrix.systems = checkPlatforms;
+            };
             runs-on = "\${{ matrix.systems.os }}";
             steps = setupSteps ++ [
               {


### PR DESCRIPTION
## Summary
- Add `fail-fast: false` to the `flake-check` matrix in the actions-nix workflow definition, matching what `build`, `build-linux-builder`, and `build-darwin-host` already do.
- During #6815, the x86_64-linux flake check failed an eval assertion and GitHub's default fail-fast cancelled the still-running aarch64-darwin flake check, hiding its result. All platforms now run to completion so a single-platform failure can't mask the others.
- Includes the regenerated `.github/workflows/ci.yaml` (via `nix run .#render-workflows`).

## Test plan
- [ ] CI on this PR runs the flake-check matrix on all three platforms
- [ ] Rendered `ci.yaml` diff is exactly the one-line `fail-fast: false` addition